### PR TITLE
Explicitly list dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "require": {
         "php": ">=5.4.0",
         "guzzle/parser": "~3.0",
-        "react/socket": "0.4.*"
+        "react/socket": "0.4.*",
+        "react/stream": "0.4.*",
+        "evenement/evenement": "~2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The code has an explicit dependency on React's `stream` component and `evenement`, hence we should explicitly define both as a dependency.

Currently, they're (implicitly) installed as part of a dependency of the `socket` component. IMHO this is an implementation detail that we should not rely on.

The resulting dependency graph looks like this:
![graph-composer](https://cloud.githubusercontent.com/assets/776829/3223580/a0eb5a2e-f024-11e3-843e-dae91aa9bd77.png)
