### PR TITLE
Support http connection keep-alive

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -26,9 +26,8 @@ class RequestHeaderParser extends EventEmitter
 
         if (false !== strpos($this->buffer, "\r\n\r\n")) {
             list($request, $bodyBuffer) = $this->parseRequest($this->buffer);
-
+            $this->buffer = '';
             $this->emit('headers', array($request, $bodyBuffer));
-            $this->removeAllListeners();
         }
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -107,7 +107,7 @@ class Response extends EventEmitter implements WritableStreamInterface
         return $flushed;
     }
 
-    public function end($data = null)
+    public function end($data = null, $keepAlive = false)
     {
         if (null !== $data) {
             $this->write($data);
@@ -119,7 +119,10 @@ class Response extends EventEmitter implements WritableStreamInterface
 
         $this->emit('end');
         $this->removeAllListeners();
-        $this->conn->end();
+
+        if (!$keepAlive) {
+          $this->conn->end();
+        }
     }
 
     public function close()

--- a/src/Response.php
+++ b/src/Response.php
@@ -121,7 +121,7 @@ class Response extends EventEmitter implements WritableStreamInterface
         $this->removeAllListeners();
 
         if (!$keepAlive) {
-          $this->conn->end();
+            $this->conn->end();
         }
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -117,7 +117,7 @@ class Response extends EventEmitter implements WritableStreamInterface
             $this->conn->write("0\r\n\r\n");
         }
 
-        $this->emit('end');
+        $this->emit('end', array($keepAlive));
         $this->removeAllListeners();
 
         if (!$keepAlive) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -57,8 +57,8 @@ class Server extends EventEmitter implements ServerInterface
         }
 
         $response->on('end', function () use ($conn, $parser) {
-          $conn->removeAllListeners(); // stop data being sent to this Request instance
-          $conn->on('data', array($parser, 'feed')); // resume sending data to RequestHeaderParser
+            $conn->removeAllListeners(); // stop data being sent to this Request instance
+            $conn->on('data', array($parser, 'feed')); // resume sending data to RequestHeaderParser
         });
 
         $this->emit('request', array($request, $response));


### PR DESCRIPTION
Supporting HTTP 1.1 Connection: Keep-Alive is essentially a matter of just not closing the connection after sending a response, and ensuring processing resumes when further data arrives over the connection.

With this modification, a 'keepAlive' parameter is added to the Response end function. The caller can choose to keep the connection open by specifying keepAlive = true. Previous behaviour of closing the connection is retained if the parameter is not specified.

Testing performance with small HTTP POST messages sent using a test program (using php curl) to a test server:
- Closing connection each time: 350 requests per second.
- Persistent connection: 3125 requests per second.
