### PR TITLE
Increase the message parser speed with pecl

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -46,7 +46,6 @@ class RequestHeaderParser extends EventEmitter
             }
         }
 
-        self::$parser = new MessageParser();
         $parsed = self::$parser->parseRequest($headers."\r\n\r\n");
 
         $parsedQuery = array();

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -3,6 +3,7 @@
 namespace React\Http;
 
 use Evenement\EventEmitter;
+use Guzzle\Parser\Message\PeclHttpMessageParser;
 use Guzzle\Parser\Message\MessageParser;
 
 /**
@@ -13,6 +14,7 @@ class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
     private $maxSize = 4096;
+    private static $parser;
 
     public function feed($data)
     {
@@ -36,8 +38,16 @@ class RequestHeaderParser extends EventEmitter
     {
         list($headers, $bodyBuffer) = explode("\r\n\r\n", $data, 2);
 
-        $parser = new MessageParser();
-        $parsed = $parser->parseRequest($headers."\r\n\r\n");
+        if (!self::$parser) {
+            if ( function_exists('http_parse_message') ) {
+                self::$parser = new PeclHttpMessageParser();
+            } else {
+                self::$parser = new MessageParser();
+            }
+        }
+
+        self::$parser = new MessageParser();
+        $parsed = self::$parser->parseRequest($headers."\r\n\r\n");
 
         $parsedQuery = array();
         if ($parsed['request_url']['query']) {


### PR DESCRIPTION
Hi,

This pull-request is an optimization of the message parser : 
- using the pecl version of parser if available
- avoid creating a new parser at each run because, after reviewing the code of guzzle message parser, no 1 time $this is used (so no memory leaks possible)

I've made some benchmarks, I have 10% of increase at req/sec on a HelloWorld benchmark.
