### PR TITLE
changed "guzzle/parser" to "guzzle/guzzle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzle/parser": "~3.0",
+        "guzzle/guzzle": "~3.0",
         "react/socket": "0.4.*",
         "react/stream": "0.4.*",
         "evenement/evenement": "~2.0"


### PR DESCRIPTION
as far as 
```
This package is abandoned and no longer maintained. The author suggests using the guzzle/guzzle package instead.
```