### PR TITLE
Use new Guzzle PSR7 parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "guzzle/parser": "~3.0",
-        "react/socket": "0.4.*",
-        "react/stream": "0.4.*",
-        "evenement/evenement": "~2.0"
+        "guzzlehttp/psr7": "^1.0",
+        "react/socket": "^0.4",
+        "react/stream": "^0.4",
+        "evenement/evenement": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
fixes #24 
fixes #20 

This is not exposing the PSR-7 interfaces yet, just using the new Guzzle parser which will remove the annoying composer error. This has no BC API breaks. 