### PR TITLE
Added payload to the request build. This fixes #30.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -15,17 +15,19 @@ class Request extends EventEmitter implements ReadableStreamInterface
     private $query;
     private $httpVersion;
     private $headers;
+    private $payload;
 
     // metadata, implicitly added externally
     public $remoteAddress;
 
-    public function __construct($method, $path, $query = array(), $httpVersion = '1.1', $headers = array())
+    public function __construct($method, $path, $query = array(), $httpVersion = '1.1', $headers = array(), $payload = null)
     {
         $this->method = $method;
         $this->path = $path;
         $this->query = $query;
         $this->httpVersion = $httpVersion;
         $this->headers = $headers;
+        $this->payload = $payload;
     }
 
     public function getMethod()
@@ -51,6 +53,11 @@ class Request extends EventEmitter implements ReadableStreamInterface
     public function getHeaders()
     {
         return $this->headers;
+    }
+
+    public function getPayload()
+    {
+        return $this->payload;
     }
 
     public function expectsContinue()

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -56,7 +56,8 @@ class RequestHeaderParser extends EventEmitter
             $psrRequest->getUri()->getPath(),
             $parsedQuery,
             $psrRequest->getProtocolVersion(),
-            $headers
+            $headers,
+            $psrRequest->getBody()
         );
 
         return array($request, $bodyBuffer);


### PR DESCRIPTION
As of right now, if one passes a payload on a request to react/http, such as the following:

    curl -X POST http://<myurl>/ --data "{\"key\": \"value\"}" -H "Content-Type: application/json"

The payload is unreachable within the server. It won't be parsed as a querystring on `RequestHeaderParser::parseRequest` and will thus be discarded.

This can't happen, and I believe this PR fixes the issue.

It adds a new parameter to the Request constructor ($payload), at the end, with a default value (`null`), as a way to not break backwards compatibility with classes that may omit this parameter. It also adds a `getPayload()` method to the request.