### PR TITLE
Interpret content-type header for 'application/x-www-form-urlencoded' correctly

### DIFF
--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -133,7 +133,7 @@ class RequestParser extends EventEmitter
                 return;
             }
 
-            elseif (strpos(strtolower($headers['Content-Type']), 'application/x-www-form-urlencoded') == 0) {
+            elseif (strpos(strtolower($headers['Content-Type']), 'application/x-www-form-urlencoded') === 0) {
                 parse_str(urldecode($content), $result);
                 $this->request->setPost($result);
 

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -133,7 +133,7 @@ class RequestParser extends EventEmitter
                 return;
             }
 
-            if (strtolower($headers['Content-Type']) == 'application/x-www-form-urlencoded') {
+            elseif (strpos(strtolower($headers['Content-Type']), 'application/x-www-form-urlencoded') == 0) {
                 parse_str(urldecode($content), $result);
                 $this->request->setPost($result);
 

--- a/tests/RequestParserTest.php
+++ b/tests/RequestParserTest.php
@@ -252,7 +252,7 @@ class RequestParserTest extends TestCase
         $data .= "Host: localhost:8080\r\n";
         $data .= "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:32.0) Gecko/20100101 Firefox/32.0\r\n";
         $data .= "Connection: close\r\n";
-        $data .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $data .= "Content-Type: application/x-www-form-urlencoded; charset=utf-8\r\n";
         $data .= "Content-Length: 79\r\n";
         $data .= "\r\n";
         $data .= "user=single&user2=second&users%5B%5D=first+in+array&users%5B%5D=second+in+array\r\n";

--- a/tests/RequestParserTest.php
+++ b/tests/RequestParserTest.php
@@ -143,7 +143,10 @@ class RequestParserTest extends TestCase
         $this->assertEquals(2, count($request->getFiles()['files']));
     }
 
-    public function testShouldReceivePostInBody()
+    /**
+     * @dataProvider shouldReceivePostInBodyDataProvider
+     */
+    public function testShouldReceivePostInBody($postData)
     {
         $request = null;
         $body = null;
@@ -154,7 +157,7 @@ class RequestParserTest extends TestCase
                 $body = $parsedBodyBuffer;
             });
 
-        $parser->feed($this->createPostWithContent());
+        $parser->feed($postData);
 
         $this->assertInstanceOf('React\Http\Request', $request);
         $this->assertSame('', $body);
@@ -162,6 +165,14 @@ class RequestParserTest extends TestCase
             $request->getPost(),
             ['user' => 'single', 'user2' => 'second', 'users' => ['first in array', 'second in array']]
         );
+    }
+
+    public function shouldReceivePostInBodyDataProvider()
+    {
+        return [
+            [$this->createPostWithContent()],
+            [$this->createPostWithContentUtf8Charset()]
+        ];
     }
 
     public function testHeaderOverflowShouldEmitError()
@@ -247,6 +258,20 @@ class RequestParserTest extends TestCase
     }
 
     private function createPostWithContent()
+    {
+        $data  = "POST /foo?bar=baz HTTP/1.1\r\n";
+        $data .= "Host: localhost:8080\r\n";
+        $data .= "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:32.0) Gecko/20100101 Firefox/32.0\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $data .= "Content-Length: 79\r\n";
+        $data .= "\r\n";
+        $data .= "user=single&user2=second&users%5B%5D=first+in+array&users%5B%5D=second+in+array\r\n";
+
+        return $data;
+    }
+
+    private function createPostWithContentUtf8Charset()
     {
         $data  = "POST /foo?bar=baz HTTP/1.1\r\n";
         $data .= "Host: localhost:8080\r\n";


### PR DESCRIPTION
Sometimes the `Content-Type` header can have additional information, such as `charset`.  Also, there should only be one Content-Type header in a HTTP Request.

This PR fixes interpretation of the `application/x-www-form-urlencoded` by comparing only the beginning of the `Content-Type` header value instead of testing for equality.  So, now both of these headers will now be interpreted correctly:

Worked before:

```
Content-Type: application/x-www-form-urlencoded
```

Works now:

```
Content-Type: application/x-www-form-urlencoded; charset=utf-8
```
