### PR TITLE
Request parser interface

### DIFF
--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7 as gPsr;
  * @event headers
  * @event error
  */
-class RequestParser extends EventEmitter
+class RequestParser extends EventEmitter implements RequestParserInterface
 {
     private $buffer = '';
     private $maxSize = 4096;

--- a/src/RequestParserFactory.php
+++ b/src/RequestParserFactory.php
@@ -1,0 +1,12 @@
+<?php namespace React\Http;
+
+class RequestParserFactory implements RequestParserFactoryInterface
+{
+    /**
+     * @return RequestParser
+     */
+    public function create()
+    {
+        return new RequestParser();
+    }
+}

--- a/src/RequestParserFactoryInterface.php
+++ b/src/RequestParserFactoryInterface.php
@@ -1,0 +1,9 @@
+<?php namespace React\Http;
+
+interface RequestParserFactoryInterface
+{
+    /**
+     * @return RequestParserInterface
+     */
+    public function create();
+}

--- a/src/RequestParserInterface.php
+++ b/src/RequestParserInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Http;
+
+use Evenement\EventEmitterInterface;
+
+interface RequestParserInterface extends EventEmitterInterface {
+
+    /**
+     * @param $data
+     * @return null
+     */
+    public function feed($data);
+
+}

--- a/src/RequestParserInterface.php
+++ b/src/RequestParserInterface.php
@@ -4,6 +4,10 @@ namespace React\Http;
 
 use Evenement\EventEmitterInterface;
 
+/**
+ * @event headers
+ * @event error
+ */
 interface RequestParserInterface extends EventEmitterInterface {
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,15 +11,15 @@ class Server extends EventEmitter implements ServerInterface
 {
     private $io;
 
-    public function __construct(SocketServerInterface $io)
+    public function __construct(SocketServerInterface $io, RequestParserInterface $parser = null)
     {
         $this->io = $io;
 
-        $this->io->on('connection', function (ConnectionInterface $conn) {
+        $this->io->on('connection', function (ConnectionInterface $conn) use ($parser) {
             // TODO: http 1.1 keep-alive
             // TODO: chunked transfer encoding (also for outgoing data)
 
-            $parser = new RequestParser();
+            $parser = $parser ?: new RequestParser();
             $parser->on('headers', function (Request $request, $bodyBuffer) use ($conn, $parser) {
                 // attach remote ip to the request as metadata
                 $request->remoteAddress = $conn->getRemoteAddress();

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,15 +11,16 @@ class Server extends EventEmitter implements ServerInterface
 {
     private $io;
 
-    public function __construct(SocketServerInterface $io, RequestParserInterface $parser = null)
+    public function __construct(SocketServerInterface $io, RequestParserFactoryInterface $parserFactory = null)
     {
         $this->io = $io;
 
-        $this->io->on('connection', function (ConnectionInterface $conn) use ($parser) {
+        $this->io->on('connection', function (ConnectionInterface $conn) use ($parserFactory) {
             // TODO: http 1.1 keep-alive
             // TODO: chunked transfer encoding (also for outgoing data)
 
-            $parser = $parser ?: new RequestParser();
+            $parserFactory = $parserFactory ?: new RequestParserFactory();
+            $parser = $parserFactory->create();
             $parser->on('headers', function (Request $request, $bodyBuffer) use ($conn, $parser) {
                 // attach remote ip to the request as metadata
                 $request->remoteAddress = $conn->getRemoteAddress();

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -66,7 +66,7 @@ class ServerTest extends TestCase
         $this->assertContains("\r\nX-Powered-By: React/alpha\r\n", $conn->getData());
     }
 
-    public function testServerUsesProvidedRequestParser()
+    public function testServerUsesProvidedRequestParserFactory()
     {
         $io = new ServerStub();
 
@@ -74,7 +74,11 @@ class ServerTest extends TestCase
         $parser = $this->getMockBuilder('React\Http\RequestParser')->getMock();
         $parser->expects($this->once())->method('on');
 
-        new Server($io, $parser);
+        /** @var \React\Http\RequestParserFactory | \PHPUnit_Framework_MockObject_MockObject $parserFactory */
+        $parserFactory = $this->getMockBuilder('React\Http\RequestParserFactory')->getMock();
+        $parserFactory->expects($this->once())->method('create')->willReturn($parser);
+
+        new Server($io, $parserFactory);
 
         $conn = new ConnectionStub();
         $io->emit('connection', array($conn));

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -66,6 +66,20 @@ class ServerTest extends TestCase
         $this->assertContains("\r\nX-Powered-By: React/alpha\r\n", $conn->getData());
     }
 
+    public function testServerUsesProvidedRequestParser()
+    {
+        $io = new ServerStub();
+
+        /** @var \React\Http\RequestParser|\PHPUnit_Framework_MockObject_MockObject $parser */
+        $parser = $this->getMockBuilder('React\Http\RequestParser')->getMock();
+        $parser->expects($this->once())->method('on');
+
+        new Server($io, $parser);
+
+        $conn = new ConnectionStub();
+        $io->emit('connection', array($conn));
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
This branch creates an interface for the RequestParser and injects it.

Reasoning being, I am working on some alternative parsers using C extensions.  It would be nice to implement something like the event loop's factory and inject the fastest parser possible.

I do not know of a way to enforce that the parser emits `headers` with a `Request` object and body buffer.

I made injection of the parser optional to prevent a BC break.
