### PR TITLE
Support json content in RequestParsers class

### DIFF
--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -140,6 +140,12 @@ class RequestParser extends EventEmitter
 
                 return;
             }
+
+            if (strtolower($headers['Content-Type']) == 'application/json') {
+                $result = json_decode($content);
+                $this->request->setBody($result);
+                return;
+            }
         }
 
 


### PR DESCRIPTION
This PR to Support new HTTP content-type "application/json".
Currently body property in request object will contains a JSON object decoded from incoming JSON string. 
