### PR TITLE
Expect Continue

### DIFF
--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -37,6 +37,10 @@ class RequestParser extends EventEmitter
             }
 
             $this->request = $this->parseHeaders($headers . "\r\n\r\n");
+
+            if($this->request->expectsContinue()) {
+                $this->emit('expects_continue');
+            }
         }
 
         // if there is a request (meaning the headers are parsed) and

--- a/src/Server.php
+++ b/src/Server.php
@@ -42,6 +42,10 @@ class Server extends EventEmitter implements ServerInterface
             });
 
             $conn->on('data', array($parser, 'feed'));
+
+            $parser->on('expects_continue', function() use($conn) {
+                $conn->write("HTTP/1.1 100 Continue\r\n\r\n");
+            });
         });
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -116,6 +116,4 @@ class ServerTest extends TestCase
 
         return $data;
     }
-
-
 }


### PR DESCRIPTION
When `curl` sends a long POST body, it sends `Expect: 100-continue` header.

    Content-Type: application/json
    Content-Length: 4641
    Expect: 100-continue

Without this patch - `curl` will wait for 1 second before sending the body (which is unreasonable delay).

It's easy to test - just `curl -XPOST -d'(a few thousand bytes here)'` and you will see the delay.