### PR TITLE
Add new HeaderBag (modeled after Symfony) to support case-insensitive header matching.

### DIFF
--- a/src/HeaderBag.php
+++ b/src/HeaderBag.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace React\Http;
+
+
+class HeaderBag extends \ArrayObject
+{
+    /** Map Header keys in a case-insensitive manner.
+     * This is a map from an upper case version of a header name
+     * to it's original name (so we can preserve case for posterity).
+     *
+     * @var array
+     */
+    protected $headermap = [];
+    
+    
+    public function __construct($input = [], $flags = 0, $iterator_class = "ArrayIterator")
+    {
+        foreach ($input as $key => $val) {
+            $this->headermap[strtoupper($key)] = $key;
+        }
+        
+        parent::__construct($input, $flags, $iterator_class);
+    }
+    
+    public function offsetGet($index)
+    {
+        if (!isset($this->headermap[strtoupper($index)])) {
+            return false;
+        }
+        return parent::offsetGet($this->headermap[strtoupper($index)]);
+    }
+    
+    public function offsetExists($index)
+    {
+        return isset($this->headermap[strtoupper($index)]);
+    }
+    
+    public function offsetSet($index, $value)
+    {
+        $this->headermap[strtoupper($index)] = $index;
+        return parent::offsetSet($index, $value);
+    }
+    
+    public function toArray()
+    {
+        $ret = [];
+        
+        
+        foreach ($this->headermap as $header)
+        {
+            $ret[$header] = $this->offsetGet($header);
+        }
+        
+        return $ret;
+    }
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -28,7 +28,7 @@ class Request extends EventEmitter implements ReadableStreamInterface
         $this->url = $url;
         $this->query = $query;
         $this->httpVersion = $httpVersion;
-        $this->headers = $headers;
+        $this->headers = new HeaderBag($headers);
         $this->body = $body;
     }
 

--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -64,13 +64,13 @@ class RequestParser extends EventEmitter
 
         // if there is no content length, there should
         // be no content so we can say it's done
-        if (!array_key_exists('Content-Length', $headers)) {
+        if (!isset($headers['Content-Length'])) {
             return true;
         }
 
         // if the content is present and has the
         // right length, we're good to go
-        if (array_key_exists('Content-Length', $headers) && strlen($this->buffer) >= $headers['Content-Length']) {
+        if (isset($headers['Content-Length']) && strlen($this->buffer) >= $headers['Content-Length']) {
 
             // store the expected content length
             $this->length = $this->request->getHeaders()['Content-Length'];
@@ -124,7 +124,7 @@ class RequestParser extends EventEmitter
     {
         $headers = $this->request->getHeaders();
 
-        if (array_key_exists('Content-Type', $headers)) {
+        if (isset($headers['Content-Type'])) {
             if (strpos($headers['Content-Type'], 'multipart/') === 0) {
                 //TODO :: parse the content while it is streaming
                 preg_match("/boundary=\"?(.*)\"?$/", $headers['Content-Type'], $matches);

--- a/src/Server.php
+++ b/src/Server.php
@@ -24,6 +24,14 @@ class Server extends EventEmitter implements ServerInterface
                 // attach remote ip to the request as metadata
                 $request->remoteAddress = $conn->getRemoteAddress();
 
+                $request->on('pause', function () use ($conn) {
+                    $conn->pause();
+                    $conn->emit('pause');
+                });
+                $request->on('resume', function () use ($conn) {
+                    $conn->resume();
+                    $conn->emit('resume');
+                });
                 $this->handleRequest($conn, $request, $bodyBuffer);
 
                 $conn->removeListener('data', array($parser, 'feed'));
@@ -32,12 +40,6 @@ class Server extends EventEmitter implements ServerInterface
                 });
                 $conn->on('data', function ($data) use ($request) {
                     $request->emit('data', array($data));
-                });
-                $request->on('pause', function () use ($conn) {
-                    $conn->emit('pause');
-                });
-                $request->on('resume', function () use ($conn) {
-                    $conn->emit('resume');
                 });
             });
 

--- a/tests/RequestParserTest.php
+++ b/tests/RequestParserTest.php
@@ -94,7 +94,7 @@ class RequestParserTest extends TestCase
             'User-Agent' => 'react/alpha',
             'Connection' => 'close',
         );
-        $this->assertSame($headers, $request->getHeaders());
+        $this->assertSame($headers, $request->getHeaders()->toArray());
     }
 
     public function testShouldReceiveBodyContent()

--- a/tests/RequestParserTest.php
+++ b/tests/RequestParserTest.php
@@ -51,7 +51,7 @@ class RequestParserTest extends TestCase
         $this->assertSame('1.1', $request->getHttpVersion());
         $this->assertSame(
             array('Host' => 'example.com:80', 'Connection' => 'close', 'Content-Length' => '11'),
-            $request->getHeaders()
+            $request->getHeaders()->toArray()
         );
 
         $this->assertSame('RANDOM DATA', $bodyBuffer);


### PR DESCRIPTION
Used a new HeaderBag class to support case-insensitive header name matches. This fixes a bug where ab (Apache Benchmark) simply hangs.
