### PR TITLE
Emit error when guzzle throws an InvalidArgumentException on parse_request

### DIFF
--- a/src/RequestParser.php
+++ b/src/RequestParser.php
@@ -36,7 +36,13 @@ class RequestParser extends EventEmitter
                 return;
             }
 
-            $this->request = $this->parseHeaders($headers . "\r\n\r\n");
+            try {
+                $this->request = $this->parseHeaders($headers . "\r\n\r\n");
+            } catch (\InvalidArgumentException $e) {
+                $this->emit('error', [$e]);
+                return;
+            }
+            
 
             if($this->request->expectsContinue()) {
                 $this->emit('expects_continue');

--- a/tests/RequestParserTest.php
+++ b/tests/RequestParserTest.php
@@ -20,6 +20,24 @@ class RequestParserTest extends TestCase
 
         $parser->feed("\r\n");
     }
+    
+    public function testEmptyHeaderShouldEmitError()
+    {
+        $parser = new RequestParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', $this->expectCallableOnce());
+
+        $parser->feed("\r\n\r\n");
+    }
+
+    public function testInvalidHeaderShouldEmitError()
+    {
+        $parser = new RequestParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', $this->expectCallableOnce());
+
+        $parser->feed("GET\r\nhello: there\r\n\r\n");
+    }
 
     public function testFeedInOneGo()
     {


### PR DESCRIPTION
This PR catches the InvalidArgumentException that is thrown by `parse_request` when there is an invalid header and emits the exception via event emitter.