### PR TITLE
Catch Guzzle parse request errors

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -36,7 +36,12 @@ class RequestHeaderParser extends EventEmitter
     {
         list($headers, $bodyBuffer) = explode("\r\n\r\n", $data, 2);
 
-        $psrRequest = g7\parse_request($headers);
+        try {
+            $psrRequest = g7\parse_request($headers);
+        } catch (Exception $exception) {
+            $this->emit('error', [$exception]);
+            return [null, null];
+        }
 
         $parsedQuery = [];
         $queryString = $psrRequest->getUri()->getQuery();

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -27,14 +27,19 @@ class RequestHeaderParser extends EventEmitter
 
         if (false !== strpos($this->buffer, "\r\n\r\n")) {
             try {
-                list($request, $bodyBuffer) = $this->parseRequest($this->buffer);
-                $this->emit('headers', array($request, $bodyBuffer));
+                $this->parseAndEmitRequest();
             } catch (Exception $exception) {
                 $this->emit('error', [$exception]);
             }
 
             $this->removeAllListeners();
         }
+    }
+
+    protected function parseAndEmitRequest()
+    {
+        list($request, $bodyBuffer) = $this->parseRequest($this->buffer);
+        $this->emit('headers', array($request, $bodyBuffer));
     }
 
     public function parseRequest($data)

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -3,6 +3,7 @@
 namespace React\Http;
 
 use Evenement\EventEmitter;
+use Exception;
 use GuzzleHttp\Psr7 as g7;
 
 /**

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -123,10 +123,15 @@ class RequestHeaderParserTest extends TestCase
             $error = $message;
         });
 
+        $this->assertSame(1, count($parser->listeners('headers')));
+        $this->assertSame(1, count($parser->listeners('error')));
+
         $parser->feed("\r\n\r\n");
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid message', $error->getMessage());
+        $this->assertSame(0, count($parser->listeners('headers')));
+        $this->assertSame(0, count($parser->listeners('error')));
     }
 
     private function createGetRequest()

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -113,6 +113,22 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Maximum header size of 4096 exceeded.', $error->getMessage());
     }
 
+    public function testGuzzleRequestParseException()
+    {
+        $error = null;
+
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $parser->feed("\r\n\r\n");
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertSame('Invalid message', $error->getMessage());
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
As discovered during @clue's talk at Typo3 days https://www.youtube.com/watch?v=q2pVVDZtuJs Guzzle's request parser can throw an exception but we don't catch it. This PR adds catching that exception and emitting it as an error.