### PR TITLE
Remove all listeners after emitting error in RequestHeaderParser

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -29,7 +29,7 @@ class RequestHeaderParser extends EventEmitter
             try {
                 $this->parseAndEmitRequest();
             } catch (Exception $exception) {
-                $this->emit('error', [$exception, $this]);
+                $this->emit('error', [$exception]);
             }
 
             $this->removeAllListeners();

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -19,7 +19,7 @@ class RequestHeaderParser extends EventEmitter
     {
         if (strlen($this->buffer) + strlen($data) > $this->maxSize) {
             $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded."), $this));
-
+            $this->removeAllListeners();
             return;
         }
 

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -29,7 +29,7 @@ class RequestHeaderParser extends EventEmitter
             try {
                 $this->parseAndEmitRequest();
             } catch (Exception $exception) {
-                $this->emit('error', [$exception]);
+                $this->emit('error', [$exception, $this]);
             }
 
             $this->removeAllListeners();

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -124,13 +124,11 @@ class RequestHeaderParserTest extends TestCase
     public function testGuzzleRequestParseException()
     {
         $error = null;
-        $passedParser = null;
 
         $parser = new RequestHeaderParser();
         $parser->on('headers', $this->expectCallableNever());
-        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
+        $parser->on('error', function ($message) use (&$error) {
             $error = $message;
-            $passedParser = $parser;
         });
 
         $this->assertSame(1, count($parser->listeners('headers')));
@@ -140,7 +138,6 @@ class RequestHeaderParserTest extends TestCase
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid message', $error->getMessage());
-        $this->assertSame($parser, $passedParser);
         $this->assertSame(0, count($parser->listeners('headers')));
         $this->assertSame(0, count($parser->listeners('error')));
     }

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -99,24 +99,27 @@ class RequestHeaderParserTest extends TestCase
     public function testHeaderOverflowShouldEmitError()
     {
         $error = null;
-
         $parser = new RequestHeaderParser();
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
         });
 
+        $this->assertSame(1, count($parser->listeners('headers')));
+        $this->assertSame(1, count($parser->listeners('error')));
+
         $data = str_repeat('A', 4097);
         $parser->feed($data);
 
         $this->assertInstanceOf('OverflowException', $error);
         $this->assertSame('Maximum header size of 4096 exceeded.', $error->getMessage());
+        $this->assertSame(0, count($parser->listeners('headers')));
+        $this->assertSame(0, count($parser->listeners('error')));
     }
 
     public function testGuzzleRequestParseException()
     {
         $error = null;
-
         $parser = new RequestHeaderParser();
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -99,10 +99,13 @@ class RequestHeaderParserTest extends TestCase
     public function testHeaderOverflowShouldEmitError()
     {
         $error = null;
+        $passedParser = null;
+
         $parser = new RequestHeaderParser();
         $parser->on('headers', $this->expectCallableNever());
-        $parser->on('error', function ($message) use (&$error) {
+        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
             $error = $message;
+            $passedParser = $parser;
         });
 
         $this->assertSame(1, count($parser->listeners('headers')));
@@ -113,6 +116,7 @@ class RequestHeaderParserTest extends TestCase
 
         $this->assertInstanceOf('OverflowException', $error);
         $this->assertSame('Maximum header size of 4096 exceeded.', $error->getMessage());
+        $this->assertSame($parser, $passedParser);
         $this->assertSame(0, count($parser->listeners('headers')));
         $this->assertSame(0, count($parser->listeners('error')));
     }
@@ -120,10 +124,13 @@ class RequestHeaderParserTest extends TestCase
     public function testGuzzleRequestParseException()
     {
         $error = null;
+        $passedParser = null;
+
         $parser = new RequestHeaderParser();
         $parser->on('headers', $this->expectCallableNever());
-        $parser->on('error', function ($message) use (&$error) {
+        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
             $error = $message;
+            $passedParser = $parser;
         });
 
         $this->assertSame(1, count($parser->listeners('headers')));
@@ -133,6 +140,7 @@ class RequestHeaderParserTest extends TestCase
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid message', $error->getMessage());
+        $this->assertSame($parser, $passedParser);
         $this->assertSame(0, count($parser->listeners('headers')));
         $this->assertSame(0, count($parser->listeners('error')));
     }


### PR DESCRIPTION
Follow up on @clue's comment here: https://github.com/reactphp/http/pull/65#discussion_r78152932
