### PR TITLE
[WIP]  Parser: urlencoded

### DIFF
--- a/src/StreamingBodyParser/FormUrlencodedParser.php
+++ b/src/StreamingBodyParser/FormUrlencodedParser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace React\Http\StreamingBodyParser;
+
+use Evenement\EventEmitterTrait;
+use React\Http\Request;
+
+class FormUrlencodedParser implements ParserInterface
+{
+    use EventEmitterTrait;
+
+    /**
+     * @param Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $headers = $request->getHeaders();
+        $headers = array_change_key_case($headers, CASE_LOWER);
+
+        ContentLengthBufferedSink::createPromise(
+            $request,
+            $headers['content-length']
+        )->then([$this, 'finish']);
+    }
+
+    /**
+     * @param string $buffer
+     */
+    public function finish($buffer)
+    {
+        parse_str(trim($buffer), $result);
+        foreach ($result as $key => $value) {
+            $this->emit('post', [$key, $value]);
+        }
+        $this->emit('end');
+    }
+}

--- a/tests/StreamingBodyParser/FormUrlencodedParserTest.php
+++ b/tests/StreamingBodyParser/FormUrlencodedParserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\Tests\Http\StreamingBodyParser;
+
+use React\Http\StreamingBodyParser\FormUrlencodedParser;
+use React\Http\Request;
+use React\Tests\Http\TestCase;
+
+class FormUrlencodedParserTest extends TestCase
+{
+    public function testParse()
+    {
+        $post = [];
+        $request = new Request('POST', 'http://example.com/', [], '1.1', [
+            'Content-Length' => 79,
+        ]);
+        $parser = new FormUrlencodedParser($request);
+        $parser->on('post', function ($key, $value) use (&$post) {
+            $post[] = [$key, $value];
+        });
+        $request->emit('data', ['user=single&user2=second&us']);
+        $request->emit('data', ['ers%5B%5D=first+in+array&users%5B%5D=second+in+array']);
+        $this->assertEquals(
+            [
+                ['user', 'single'],
+                ['user2', 'second'],
+                ['users', ['first in array', 'second in array']],
+            ],
+            $post
+        );
+    }
+}


### PR DESCRIPTION
Adds a urlencoded parser and updates the parser factory (#69) to utilize that parser when applicable.

Depends on #69 and #70
- [X] Form urlencoded parser
- [ ] Cancelable parser
- [ ] Readme Documentation
- [ ] Class/Method Documentation
- [ ] Merge master in when #69 is in
- [ ] Ensure tests are up to date and passing
- [ ] Squash on merge
