### PR TITLE
[WIP] Streaming parser bufferedsink

### DIFF
--- a/src/StreamingBodyParser/BodyBufferedSink.php
+++ b/src/StreamingBodyParser/BodyBufferedSink.php
@@ -23,7 +23,7 @@ class BodyBufferedSink
         $parser->on('body', function ($rawBody) use (&$body) {
             $body = $rawBody;
         });
-        $parser->on('end', function () use ($deferred, &$postFields, &$files, &$body) {
+        $parser->on('end', function () use ($deferred, &$body) {
             $deferred->resolve($body);
         });
 

--- a/src/StreamingBodyParser/BodyBufferedSink.php
+++ b/src/StreamingBodyParser/BodyBufferedSink.php
@@ -13,10 +13,6 @@ class BodyBufferedSink
      */
     public static function createPromise(ParserInterface $parser)
     {
-        if ($parser instanceof NoBodyParser) {
-            return Promise\resolve('');
-        }
-
         $deferred = new Promise\Deferred();
         $body = '';
 

--- a/src/StreamingBodyParser/BodyBufferedSink.php
+++ b/src/StreamingBodyParser/BodyBufferedSink.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\Http\StreamingBodyParser;
+
+use React\Http\File;
+use React\Promise;
+
+class BodyBufferedSink
+{
+    /**
+     * @param ParserInterface $parser
+     * @return PromiseInterface
+     */
+    public static function createPromise(ParserInterface $parser)
+    {
+        if ($parser instanceof NoBodyParser) {
+            return Promise\resolve('');
+        }
+
+        $deferred = new Promise\Deferred();
+        $body = '';
+
+        $parser->on('body', function ($rawBody) use (&$body) {
+            $body = $rawBody;
+        });
+        $parser->on('end', function () use ($deferred, &$postFields, &$files, &$body) {
+            $deferred->resolve($body);
+        });
+
+        return $deferred->promise();
+    }
+}

--- a/src/StreamingBodyParser/BodyBufferedSink.php
+++ b/src/StreamingBodyParser/BodyBufferedSink.php
@@ -9,7 +9,7 @@ class BodyBufferedSink
 {
     /**
      * @param ParserInterface $parser
-     * @return PromiseInterface
+     * @return Promise\PromiseInterface
      */
     public static function createPromise(ParserInterface $parser)
     {

--- a/src/StreamingBodyParser/BodyBufferedSink.php
+++ b/src/StreamingBodyParser/BodyBufferedSink.php
@@ -21,7 +21,7 @@ class BodyBufferedSink
         $body = '';
 
         $parser->on('body', function ($rawBody) use (&$body) {
-            $body = $rawBody;
+            $body .= $rawBody;
         });
         $parser->on('end', function () use ($deferred, &$body) {
             $deferred->resolve($body);

--- a/src/StreamingBodyParser/BufferedSink.php
+++ b/src/StreamingBodyParser/BufferedSink.php
@@ -2,89 +2,22 @@
 
 namespace React\Http\StreamingBodyParser;
 
-use React\Http\File;
-use React\Promise\Deferred;
-use React\Promise\PromiseInterface;
-use React\Stream\BufferedSink as StreamBufferedSink;
+use React\Promise;
 
 class BufferedSink
 {
     /**
      * @param ParserInterface $parser
-     * @return PromiseInterface
+     * @return Promise\PromiseInterface
      */
     public static function createPromise(ParserInterface $parser)
     {
-        if ($parser instanceof NoBodyParser) {
-            return \React\Promise\resolve([
-                'post' => [],
-                'files' => [],
-                'body' => '',
-            ]);
-        }
+        $promises = [
+            'body'  => BodyBufferedSink::createPromise($parser),
+            'post'  => PostBufferedSink::createPromise($parser),
+            'files' => FilesBufferedSink::createPromise($parser),
+        ];
 
-        $deferred = new Deferred();
-        $postFields = [];
-        $files = [];
-        $body = '';
-        $parser->on('post', function ($key, $value) use (&$postFields) {
-            self::extractPost($postFields, $key, $value);
-        });
-        $parser->on('file', function ($name, File $file) use (&$files) {
-            StreamBufferedSink::createPromise($file->getStream())->done(function ($buffer) use ($name, $file, &$files) {
-                $files[] = [
-                    'name' => $name,
-                    'file' => $file,
-                    'buffer' => $buffer,
-                ];
-            });
-        });
-        $parser->on('body', function ($rawBody) use (&$body) {
-            $body = $rawBody;
-        });
-        $parser->on('end', function () use ($deferred, &$postFields, &$files, &$body) {
-            $deferred->resolve([
-                'post' => $postFields,
-                'files' => $files,
-                'body' => $body,
-            ]);
-        });
-
-        return $deferred->promise();
-    }
-
-    public static function extractPost(&$postFields, $key, $value)
-    {
-        $chunks = explode('[', $key);
-        if (count($chunks) == 1) {
-            $postFields[$key] = $value;
-            return;
-        }
-
-        $chunkKey = $chunks[0];
-        if (!isset($postFields[$chunkKey])) {
-            $postFields[$chunkKey] = [];
-        }
-
-        $parent = &$postFields;
-        for ($i = 1; $i < count($chunks); $i++) {
-            $previousChunkKey = $chunkKey;
-            if (!isset($parent[$previousChunkKey])) {
-                $parent[$previousChunkKey] = [];
-            }
-            $parent = &$parent[$previousChunkKey];
-            $chunkKey = $chunks[$i];
-
-            if ($chunkKey == ']') {
-                $parent[] = $value;
-                return;
-            }
-
-            $chunkKey = rtrim($chunkKey, ']');
-            if ($i == count($chunks) - 1) {
-                $parent[$chunkKey] = $value;
-                return;
-            }
-        }
+        return Promise\all($promises);
     }
 }

--- a/src/StreamingBodyParser/BufferedSink.php
+++ b/src/StreamingBodyParser/BufferedSink.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace React\Http\StreamingBodyParser;
+
+use React\Http\File;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use React\Stream\BufferedSink as StreamBufferedSink;
+
+class BufferedSink
+{
+    /**
+     * @param ParserInterface $parser
+     * @return PromiseInterface
+     */
+    public static function createPromise(ParserInterface $parser)
+    {
+        if ($parser instanceof NoBodyParser) {
+            return \React\Promise\resolve([
+                'post' => [],
+                'files' => [],
+                'body' => '',
+            ]);
+        }
+
+        $deferred = new Deferred();
+        $postFields = [];
+        $files = [];
+        $body = '';
+        $parser->on('post', function ($key, $value) use (&$postFields) {
+            self::extractPost($postFields, $key, $value);
+        });
+        $parser->on('file', function ($name, File $file) use (&$files) {
+            StreamBufferedSink::createPromise($file->getStream())->then(function ($buffer) use ($name, $file, &$files) {
+                $files[] = [
+                    'name' => $name,
+                    'file' => $file,
+                    'buffer' => $buffer,
+                ];
+            });
+        });
+        $parser->on('body', function ($rawBody) use (&$body) {
+            $body = $rawBody;
+        });
+        $parser->on('end', function () use ($deferred, &$postFields, &$files, &$body) {
+            $deferred->resolve([
+                'post' => $postFields,
+                'files' => $files,
+                'body' => $body,
+            ]);
+        });
+
+        return $deferred->promise();
+    }
+
+    public static function extractPost(&$postFields, $key, $value)
+    {
+        $chunks = explode('[', $key);
+        if (count($chunks) == 1) {
+            $postFields[$key] = $value;
+            return;
+        }
+
+        $chunkKey = $chunks[0];
+        if (!isset($postFields[$chunkKey])) {
+            $postFields[$chunkKey] = [];
+        }
+
+        $parent = &$postFields;
+        for ($i = 1; $i < count($chunks); $i++) {
+            $previousChunkKey = $chunkKey;
+            if (!isset($parent[$previousChunkKey])) {
+                $parent[$previousChunkKey] = [];
+            }
+            $parent = &$parent[$previousChunkKey];
+            $chunkKey = $chunks[$i];
+
+            if ($chunkKey == ']') {
+                $parent[] = $value;
+                return;
+            }
+
+            $chunkKey = rtrim($chunkKey, ']');
+            if ($i == count($chunks) - 1) {
+                $parent[$chunkKey] = $value;
+                return;
+            }
+        }
+    }
+}

--- a/src/StreamingBodyParser/BufferedSink.php
+++ b/src/StreamingBodyParser/BufferedSink.php
@@ -31,7 +31,7 @@ class BufferedSink
             self::extractPost($postFields, $key, $value);
         });
         $parser->on('file', function ($name, File $file) use (&$files) {
-            StreamBufferedSink::createPromise($file->getStream())->then(function ($buffer) use ($name, $file, &$files) {
+            StreamBufferedSink::createPromise($file->getStream())->done(function ($buffer) use ($name, $file, &$files) {
                 $files[] = [
                     'name' => $name,
                     'file' => $file,

--- a/src/StreamingBodyParser/FilesBufferedSink.php
+++ b/src/StreamingBodyParser/FilesBufferedSink.php
@@ -14,10 +14,6 @@ class FilesBufferedSink
      */
     public static function createPromise(ParserInterface $parser)
     {
-        if ($parser instanceof NoBodyParser) {
-            return Promise\resolve([]);
-        }
-
         $deferred = new Promise\Deferred();
         $files = [];
 

--- a/src/StreamingBodyParser/FilesBufferedSink.php
+++ b/src/StreamingBodyParser/FilesBufferedSink.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace React\Http\StreamingBodyParser;
+
+use React\Http\File;
+use React\Promise;
+use React\Stream\BufferedSink as StreamBufferedSink;
+
+class FilesBufferedSink
+{
+    /**
+     * @param ParserInterface $parser
+     * @return Promise\PromiseInterface
+     */
+    public static function createPromise(ParserInterface $parser)
+    {
+        if ($parser instanceof NoBodyParser) {
+            return Promise\resolve([]);
+        }
+
+        $deferred = new Promise\Deferred();
+        $files = [];
+
+        $parser->on('file', function ($name, File $file) use (&$files) {
+            StreamBufferedSink::createPromise($file->getStream())->done(function ($buffer) use ($name, $file, &$files) {
+                $files[] = [
+                    'name' => $name,
+                    'file' => $file,
+                    'buffer' => $buffer,
+                ];
+            });
+        });
+        $parser->on('end', function () use ($deferred, &$files) {
+            $deferred->resolve($files);
+        });
+
+        return $deferred->promise();
+    }
+}

--- a/src/StreamingBodyParser/PostBufferedSink.php
+++ b/src/StreamingBodyParser/PostBufferedSink.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace React\Http\StreamingBodyParser;
+
+use React\Promise;
+
+class PostBufferedSink
+{
+    /**
+     * @param ParserInterface $parser
+     * @return PromiseInterface
+     */
+    public static function createPromise(ParserInterface $parser)
+    {
+        if ($parser instanceof NoBodyParser) {
+            return Promise\resolve([]);
+        }
+
+        $deferred = new Promise\Deferred();
+        $postFields = [];
+
+        $parser->on('post', function ($key, $value) use (&$postFields) {
+            self::extractPost($postFields, $key, $value);
+        });
+        $parser->on('end', function () use ($deferred, &$postFields) {
+            $deferred->resolve($postFields);
+        });
+
+        return $deferred->promise();
+    }
+
+    public static function extractPost(&$postFields, $key, $value)
+    {
+        $chunks = explode('[', $key);
+        if (count($chunks) == 1) {
+            $postFields[$key] = $value;
+            return;
+        }
+
+        $chunkKey = $chunks[0];
+        if (!isset($postFields[$chunkKey])) {
+            $postFields[$chunkKey] = [];
+        }
+
+        $parent = &$postFields;
+        for ($i = 1; $i < count($chunks); $i++) {
+            $previousChunkKey = $chunkKey;
+            if (!isset($parent[$previousChunkKey])) {
+                $parent[$previousChunkKey] = [];
+            }
+            $parent = &$parent[$previousChunkKey];
+            $chunkKey = $chunks[$i];
+
+            if ($chunkKey == ']') {
+                $parent[] = $value;
+                return;
+            }
+
+            $chunkKey = rtrim($chunkKey, ']');
+            if ($i == count($chunks) - 1) {
+                $parent[$chunkKey] = $value;
+                return;
+            }
+        }
+    }
+}

--- a/src/StreamingBodyParser/PostBufferedSink.php
+++ b/src/StreamingBodyParser/PostBufferedSink.php
@@ -12,10 +12,6 @@ class PostBufferedSink
      */
     public static function createPromise(ParserInterface $parser)
     {
-        if ($parser instanceof NoBodyParser) {
-            return Promise\resolve([]);
-        }
-
         $deferred = new Promise\Deferred();
         $postFields = [];
 

--- a/src/StreamingBodyParser/PostBufferedSink.php
+++ b/src/StreamingBodyParser/PostBufferedSink.php
@@ -8,7 +8,7 @@ class PostBufferedSink
 {
     /**
      * @param ParserInterface $parser
-     * @return PromiseInterface
+     * @return Promise\PromiseInterface
      */
     public static function createPromise(ParserInterface $parser)
     {

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -11,14 +11,6 @@ use React\Tests\Http\TestCase;
 
 class BodyBufferedSinkTest extends TestCase
 {
-    public function testDoneParser()
-    {
-        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
-        $deferredStream = BodyBufferedSink::createPromise($parser);
-        $result = Block\await($deferredStream, Factory::create(), 10);
-        $this->assertSame('', $result);
-    }
-
     public function testDeferredStream()
     {
         $parser = new DummyParser(new Request('get', 'http://example.com'));

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -4,7 +4,7 @@ namespace React\Tests\Http\StreamingBodyParser;
 
 use Clue\React\Block;
 use React\EventLoop\Factory;
-use React\Http\StreamingBodyParser\BufferedSink;
+use React\Http\StreamingBodyParser\BodyBufferedSink;
 use React\Http\StreamingBodyParser\NoBodyParser;
 use React\Http\Request;
 use React\Tests\Http\TestCase;
@@ -14,7 +14,7 @@ class BodyBufferedSinkTest extends TestCase
     public function testDoneParser()
     {
         $parser = new NoBodyParser(new Request('get', 'http://example.com'));
-        $deferredStream = BufferedSink::createPromise($parser);
+        $deferredStream = BodyBufferedSink::createPromise($parser);
         $result = Block\await($deferredStream, Factory::create(), 10);
         $this->assertSame('', $result);
     }
@@ -22,7 +22,7 @@ class BodyBufferedSinkTest extends TestCase
     public function testDeferredStream()
     {
         $parser = new DummyParser(new Request('get', 'http://example.com'));
-        $deferredStream = BufferedSink::createPromise($parser);
+        $deferredStream = BodyBufferedSink::createPromise($parser);
 
         $parser->emit('body', ['abc']);
         $parser->emit('end');

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -31,4 +31,18 @@ class BodyBufferedSinkTest extends TestCase
 
         $this->assertSame('abc', $result);
     }
+
+    public function testDeferredStreamMultipleCalls()
+    {
+        $parser = new DummyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BodyBufferedSink::createPromise($parser);
+
+        $parser->emit('body', ['abc']);
+        $parser->emit('body', ['def']);
+        $parser->emit('end');
+
+        $result = Block\await($deferredStream, Factory::create(), 10);
+
+        $this->assertSame('abcdef', $result);
+    }
 }

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -31,6 +31,6 @@ class BodyBufferedSinkTest extends TestCase
 
         $result = Block\await($deferredStream, Factory::create(), 10);
 
-        $this->assertSame('abc', $result['body']);
+        $this->assertSame('abc', $result);
     }
 }

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -4,11 +4,9 @@ namespace React\Tests\Http\StreamingBodyParser;
 
 use Clue\React\Block;
 use React\EventLoop\Factory;
-use React\Http\File;
 use React\Http\StreamingBodyParser\BufferedSink;
 use React\Http\StreamingBodyParser\NoBodyParser;
 use React\Http\Request;
-use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
 class BodyBufferedSinkTest extends TestCase

--- a/tests/StreamingBodyParser/BodyBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BodyBufferedSinkTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace React\Tests\Http\StreamingBodyParser;
+
+use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Http\File;
+use React\Http\StreamingBodyParser\BufferedSink;
+use React\Http\StreamingBodyParser\NoBodyParser;
+use React\Http\Request;
+use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
+
+class BodyBufferedSinkTest extends TestCase
+{
+    public function testDoneParser()
+    {
+        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame('', $result);
+    }
+
+    public function testDeferredStream()
+    {
+        $parser = new DummyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+
+        $parser->emit('body', ['abc']);
+        $parser->emit('end');
+
+        $result = Block\await($deferredStream, Factory::create(), 10);
+
+        $this->assertSame('abc', $result['body']);
+    }
+}

--- a/tests/StreamingBodyParser/BufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BufferedSinkTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace React\Tests\Http\StreamingBodyParser;
+
+use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Http\File;
+use React\Http\StreamingBodyParser\BufferedSink;
+use React\Http\StreamingBodyParser\NoBodyParser;
+use React\Http\Request;
+use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
+
+class DeferredStreamTest extends TestCase
+{
+    public function testDoneParser()
+    {
+        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame([
+            'post' => [],
+            'files' => [],
+            'body' => '',
+        ], $result);
+    }
+
+    public function testDeferredStream()
+    {
+        $parser = new DummyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+        $parser->emit('post', ['foo', 'bar']);
+        $parser->emit('post', ['array[]', 'foo']);
+        $parser->emit('post', ['array[]', 'bar']);
+        $parser->emit('post', ['dem[two]', 'bar']);
+        $parser->emit('post', ['dom[two][]', 'bar']);
+
+        $stream = new ThroughStream();
+        $file = new File('bar.ext', 'text', $stream);
+        $parser->emit('file', ['foo', $file]);
+        $stream->end('foo.bar');
+
+        $parser->emit('body', ['abc']);
+
+        $parser->emit('end');
+
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame([
+            'foo' => 'bar',
+            'array' => [
+                'foo',
+                'bar',
+            ],
+            'dem' => [
+                'two' => 'bar',
+            ],
+            'dom' => [
+                'two' => [
+                    'bar',
+                ],
+            ],
+        ], $result['post']);
+
+        $this->assertSame('foo', $result['files'][0]['name']);
+        $this->assertSame('bar.ext', $result['files'][0]['file']->getFilename());
+        $this->assertSame('text', $result['files'][0]['file']->getContentType());
+        $this->assertSame('foo.bar', $result['files'][0]['buffer']);
+
+        $this->assertSame('abc', $result['body']);
+    }
+
+    public function testExtractPost()
+    {
+        $postFields = [];
+        BufferedSink::extractPost($postFields, 'dem', 'value');
+        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_a');
+        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_b');
+        BufferedSink::extractPost($postFields, 'dam[]', 'value_a');
+        BufferedSink::extractPost($postFields, 'dam[]', 'value_b');
+        BufferedSink::extractPost($postFields, 'dum[sum]', 'value');
+        $this->assertSame([
+            'dem' => 'value',
+            'dom' => [
+                'one' => [
+                    'two' => [
+                        'value_a',
+                        'value_b',
+                    ],
+                ],
+            ],
+            'dam' => [
+                'value_a',
+                'value_b',
+            ],
+            'dum' => [
+                'sum' => 'value',
+            ],
+        ], $postFields);
+    }
+}

--- a/tests/StreamingBodyParser/BufferedSinkTest.php
+++ b/tests/StreamingBodyParser/BufferedSinkTest.php
@@ -11,7 +11,7 @@ use React\Http\Request;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
-class DeferredStreamTest extends TestCase
+class BufferedSinkTest extends TestCase
 {
     public function testDoneParser()
     {

--- a/tests/StreamingBodyParser/FilesBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/FilesBufferedSinkTest.php
@@ -13,14 +13,6 @@ use React\Tests\Http\TestCase;
 
 class FilesBufferedSinkTest extends TestCase
 {
-    public function testDoneParser()
-    {
-        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
-        $deferredStream = FilesBufferedSink::createPromise($parser);
-        $result = Block\await($deferredStream, Factory::create(), 10);
-        $this->assertSame([], $result);
-    }
-
     public function testDeferredStream()
     {
         $parser = new DummyParser(new Request('get', 'http://example.com'));

--- a/tests/StreamingBodyParser/FilesBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/FilesBufferedSinkTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace React\Tests\Http\StreamingBodyParser;
+
+use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Http\File;
+use React\Http\StreamingBodyParser\FilesBufferedSink;
+use React\Http\StreamingBodyParser\NoBodyParser;
+use React\Http\Request;
+use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
+
+class FilesBufferedSinkTest extends TestCase
+{
+    public function testDoneParser()
+    {
+        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
+        $deferredStream = FilesBufferedSink::createPromise($parser);
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame([], $result);
+    }
+
+    public function testDeferredStream()
+    {
+        $parser = new DummyParser(new Request('get', 'http://example.com'));
+        $deferredStream = FilesBufferedSink::createPromise($parser);
+
+        $stream = new ThroughStream();
+        $file = new File('bar.ext', 'text', $stream);
+        $parser->emit('file', ['foo', $file]);
+        $stream->end('foo.bar');
+
+        $parser->emit('end');
+
+        $result = Block\await($deferredStream, Factory::create(), 10);
+
+        $this->assertSame('foo', $result['files'][0]['name']);
+        $this->assertSame('bar.ext', $result['files'][0]['file']->getFilename());
+        $this->assertSame('text', $result['files'][0]['file']->getContentType());
+        $this->assertSame('foo.bar', $result['files'][0]['buffer']);
+    }
+}

--- a/tests/StreamingBodyParser/PostBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/PostBufferedSinkTest.php
@@ -4,17 +4,17 @@ namespace React\Tests\Http\StreamingBodyParser;
 
 use Clue\React\Block;
 use React\EventLoop\Factory;
-use React\Http\StreamingBodyParser\BufferedSink;
+use React\Http\StreamingBodyParser\PostBufferedSink;
 use React\Http\StreamingBodyParser\NoBodyParser;
 use React\Http\Request;
 use React\Tests\Http\TestCase;
 
-class PostBufferedSinkTest extends TestCase
+class PostPostBufferedSinkTest extends TestCase
 {
     public function testDoneParser()
     {
         $parser = new NoBodyParser(new Request('get', 'http://example.com'));
-        $deferredStream = BufferedSink::createPromise($parser);
+        $deferredStream = PostBufferedSink::createPromise($parser);
         $result = Block\await($deferredStream, Factory::create(), 10);
         $this->assertSame([], $result);
     }
@@ -22,7 +22,7 @@ class PostBufferedSinkTest extends TestCase
     public function testDeferredStream()
     {
         $parser = new DummyParser(new Request('get', 'http://example.com'));
-        $deferredStream = BufferedSink::createPromise($parser);
+        $deferredStream = PostBufferedSink::createPromise($parser);
         $parser->emit('post', ['foo', 'bar']);
         $parser->emit('post', ['array[]', 'foo']);
         $parser->emit('post', ['array[]', 'bar']);
@@ -52,12 +52,12 @@ class PostBufferedSinkTest extends TestCase
     public function testExtractPost()
     {
         $postFields = [];
-        BufferedSink::extractPost($postFields, 'dem', 'value');
-        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_a');
-        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_b');
-        BufferedSink::extractPost($postFields, 'dam[]', 'value_a');
-        BufferedSink::extractPost($postFields, 'dam[]', 'value_b');
-        BufferedSink::extractPost($postFields, 'dum[sum]', 'value');
+        PostBufferedSink::extractPost($postFields, 'dem', 'value');
+        PostBufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_a');
+        PostBufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_b');
+        PostBufferedSink::extractPost($postFields, 'dam[]', 'value_a');
+        PostBufferedSink::extractPost($postFields, 'dam[]', 'value_b');
+        PostBufferedSink::extractPost($postFields, 'dum[sum]', 'value');
         $this->assertSame([
             'dem' => 'value',
             'dom' => [

--- a/tests/StreamingBodyParser/PostBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/PostBufferedSinkTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace React\Tests\Http\StreamingBodyParser;
+
+use Clue\React\Block;
+use React\EventLoop\Factory;
+use React\Http\StreamingBodyParser\BufferedSink;
+use React\Http\StreamingBodyParser\NoBodyParser;
+use React\Http\Request;
+use React\Tests\Http\TestCase;
+
+class PostBufferedSinkTest extends TestCase
+{
+    public function testDoneParser()
+    {
+        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame([], $result);
+    }
+
+    public function testDeferredStream()
+    {
+        $parser = new DummyParser(new Request('get', 'http://example.com'));
+        $deferredStream = BufferedSink::createPromise($parser);
+        $parser->emit('post', ['foo', 'bar']);
+        $parser->emit('post', ['array[]', 'foo']);
+        $parser->emit('post', ['array[]', 'bar']);
+        $parser->emit('post', ['dem[two]', 'bar']);
+        $parser->emit('post', ['dom[two][]', 'bar']);
+
+        $parser->emit('end');
+
+        $result = Block\await($deferredStream, Factory::create(), 10);
+        $this->assertSame([
+            'foo' => 'bar',
+            'array' => [
+                'foo',
+                'bar',
+            ],
+            'dem' => [
+                'two' => 'bar',
+            ],
+            'dom' => [
+                'two' => [
+                    'bar',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function testExtractPost()
+    {
+        $postFields = [];
+        BufferedSink::extractPost($postFields, 'dem', 'value');
+        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_a');
+        BufferedSink::extractPost($postFields, 'dom[one][two][]', 'value_b');
+        BufferedSink::extractPost($postFields, 'dam[]', 'value_a');
+        BufferedSink::extractPost($postFields, 'dam[]', 'value_b');
+        BufferedSink::extractPost($postFields, 'dum[sum]', 'value');
+        $this->assertSame([
+            'dem' => 'value',
+            'dom' => [
+                'one' => [
+                    'two' => [
+                        'value_a',
+                        'value_b',
+                    ],
+                ],
+            ],
+            'dam' => [
+                'value_a',
+                'value_b',
+            ],
+            'dum' => [
+                'sum' => 'value',
+            ],
+        ], $postFields);
+    }
+}

--- a/tests/StreamingBodyParser/PostBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/PostBufferedSinkTest.php
@@ -9,7 +9,7 @@ use React\Http\StreamingBodyParser\NoBodyParser;
 use React\Http\Request;
 use React\Tests\Http\TestCase;
 
-class PostPostBufferedSinkTest extends TestCase
+class PostBufferedSinkTest extends TestCase
 {
     public function testDeferredStream()
     {

--- a/tests/StreamingBodyParser/PostBufferedSinkTest.php
+++ b/tests/StreamingBodyParser/PostBufferedSinkTest.php
@@ -11,14 +11,6 @@ use React\Tests\Http\TestCase;
 
 class PostPostBufferedSinkTest extends TestCase
 {
-    public function testDoneParser()
-    {
-        $parser = new NoBodyParser(new Request('get', 'http://example.com'));
-        $deferredStream = PostBufferedSink::createPromise($parser);
-        $result = Block\await($deferredStream, Factory::create(), 10);
-        $this->assertSame([], $result);
-    }
-
     public function testDeferredStream()
     {
         $parser = new DummyParser(new Request('get', 'http://example.com'));


### PR DESCRIPTION
Just like the bufferedsink from stream and #70 but this sink takes a streaming body parser and buffers any post field, body data, or uploaded file. Once the full request it in the promise will resolve.

Depends on #69 and #62 
- [X] BufferedSink for streaming parsers
- [ ] Class/Method Documentation
- [ ] Readme Documentation
- [ ] Split up sink in a file, post, and body sink
- [ ] Merge master in when #69 and #62 are in
- [ ] Ensure tests are up to date and passing
- [ ] Squash on merge
