### PR TITLE
Handle keepalive

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -6,54 +6,88 @@ use Evenement\EventEmitter;
 use React\Socket\ServerInterface as SocketServerInterface;
 use React\Socket\ConnectionInterface;
 
+
+class ConnProxy {
+    public $id;
+    public $count;
+    public $conn;
+    public function __construct($id, ConnectionInterface $conn)
+    {
+        $this->id = $id;
+        $this->conn = $conn;
+        $this->count = 0;
+    }
+}
+
 /** @event request */
 class Server extends EventEmitter implements ServerInterface
 {
-    private $io;
-
+    const KEEPALIVE_MAX_REQUEST = 25;
+    private $connectionsCount = 0;
     public function __construct(SocketServerInterface $io)
     {
-        $this->io = $io;
-
-        $this->io->on('connection', function (ConnectionInterface $conn) {
-            // TODO: http 1.1 keep-alive
-            // TODO: chunked transfer encoding (also for outgoing data)
-            // TODO: multipart parsing
-
-            $parser = new RequestHeaderParser();
-            $parser->on('headers', function (Request $request, $bodyBuffer) use ($conn, $parser) {
-                // attach remote ip to the request as metadata
-                $request->remoteAddress = $conn->getRemoteAddress();
-
-                $this->handleRequest($conn, $request, $bodyBuffer);
-
-                $conn->removeListener('data', array($parser, 'feed'));
-                $conn->on('end', function () use ($request) {
-                    $request->emit('end');
-                });
-                $conn->on('data', function ($data) use ($request) {
-                    $request->emit('data', array($data));
-                });
-                $request->on('pause', function () use ($conn) {
-                    $conn->emit('pause');
-                });
-                $request->on('resume', function () use ($conn) {
-                    $conn->emit('resume');
-                });
-            });
-
-            $conn->on('data', array($parser, 'feed'));
+        $io->on('connection', function (ConnectionInterface $conn) {
+            $this->connectionsCount += 1;
+            $this->handleConnection(new ConnProxy($this->connectionsCount, $conn));
         });
     }
 
-    public function handleRequest(ConnectionInterface $conn, Request $request, $bodyBuffer)
+    public function handleConnection(ConnProxy $connProxy) {
+        $conn = $connProxy->conn;
+        // TODO: chunked transfer encoding (also for outgoing data)
+        // TODO: multipart parsing
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', function (Request $request, $bodyBuffer) use ($conn, $parser, $connProxy) {
+            // attach remote ip to the request as metadata
+            $request->remoteAddress = $conn->getRemoteAddress();
+
+            $conn->removeListener('data', array($parser, 'feed'));
+            $conn->on('end', function () use ($request) {
+                $request->emit('end');
+            });
+            $conn->on('data', function ($data) use ($request) {
+                $request->emit('data', array($data));
+            });
+            $request->on('pause', function () use ($conn) {
+                $conn->emit('pause');
+            });
+            $request->on('resume', function () use ($conn) {
+                $conn->emit('resume');
+            });
+
+            $this->handleRequest($connProxy, $request, $bodyBuffer);
+        });
+
+        $conn->on('data', array($parser, 'feed'));
+    }
+
+    public function handleRequest(ConnProxy $connProxy, Request $request, $bodyBuffer)
     {
+        $conn = $connProxy->conn;
         $response = new Response($conn);
+
+        //Keepalive max requests
+        $connProxy->count += 1;
+        if ($connProxy->count >= self::KEEPALIVE_MAX_REQUEST) {
+            $response->closeConnection = true;
+        }
+
+        $headers = $request->getHeaders();
+        if (empty($headers['Connection']) || $headers['Connection'] == 'close') {
+            $response->closeConnection = true;
+        }
+
         $response->on('close', array($request, 'close'));
+
+        //Handle keepalive
+        $response->on('end', function() use ($conn, $response, $connProxy) {
+            if (! $response->closeConnection) {
+                $this->handleConnection($connProxy);
+            }
+        });
 
         if (!$this->listeners('request')) {
             $response->end();
-
             return;
         }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -12,6 +12,7 @@ class ResponseTest extends TestCase
         $expected .= "HTTP/1.1 200 OK\r\n";
         $expected .= "X-Powered-By: React/alpha\r\n";
         $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');
@@ -30,6 +31,7 @@ class ResponseTest extends TestCase
         $expected .= "HTTP/1.1 200 OK\r\n";
         $expected .= "X-Powered-By: React/alpha\r\n";
         $expected .= "Content-Length: 22\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');
@@ -132,6 +134,7 @@ class ResponseTest extends TestCase
         $expected .= "X-Powered-By: React/alpha\r\n";
         $expected .= "FooBar: BazQux\r\n";
         $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');
@@ -151,6 +154,7 @@ class ResponseTest extends TestCase
         $expected .= "HTTP/1.1 700 \r\n";
         $expected .= "X-Powered-By: React/alpha\r\n";
         $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');
@@ -172,6 +176,7 @@ class ResponseTest extends TestCase
         $expected .= "Set-Cookie: foo=bar\r\n";
         $expected .= "Set-Cookie: bar=baz\r\n";
         $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');
@@ -191,6 +196,7 @@ class ResponseTest extends TestCase
         $expected .= "HTTP/1.1 200 OK\r\n";
         $expected .= "X-Powered-By: React/alpha\r\n";
         $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "Connection: keep-alive\r\n";
         $expected .= "\r\n";
 
         $conn = $this->getMock('React\Socket\ConnectionInterface');


### PR DESCRIPTION
Hi,
I see a previous keepalive pull request opened for some time now.
Here is another one I made.
I find it clearer than the previous one because the connection is maintained/closed according to request header and a max number of reuse of the connection.

I've done some tests with apache benchark on a virtual machine and I'm getting an average of 1.6x requests/s with keepalive.

By the way testing with PHP 7.0.8 shows that the connexion shouldn't be reused too many times. I set it as a constant in the code to 25. Increasing this number shows a drop in speed, I havent managed to understand why...


Closes #39