### PR TITLE
Replace PHPUnit's getMock() for forward compatibility

### DIFF
--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -14,7 +14,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -32,7 +34,9 @@ class ResponseTest extends TestCase
         $expected .= "Content-Length: 22\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -44,7 +48,9 @@ class ResponseTest extends TestCase
 
     public function testResponseBodyShouldBeChunkedCorrectly()
     {
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->at(4))
             ->method('write')
@@ -75,7 +81,9 @@ class ResponseTest extends TestCase
     {
         $ended = false;
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $response = new Response($conn);
 
         $response->on('end', function () use (&$ended) {
@@ -89,7 +97,9 @@ class ResponseTest extends TestCase
     /** @test */
     public function writeContinueShouldSendContinueLineBeforeRealHeaders()
     {
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->at(3))
             ->method('write')
@@ -107,7 +117,9 @@ class ResponseTest extends TestCase
     /** @test */
     public function shouldForwardEndDrainAndErrorEvents()
     {
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->at(0))
             ->method('on')
@@ -134,7 +146,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -153,7 +167,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -174,7 +190,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -193,7 +211,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function createCallableMock()
     {
-        return $this->getMock('React\Tests\Http\CallableStub');
+        return $this
+            ->getMockBuilder('React\Tests\Http\CallableStub')
+            ->getMock();
     }
 }


### PR DESCRIPTION
per comment in https://github.com/reactphp/event-loop/pull/68#issuecomment-271815329
with respect of replacing usage of getMock to avoid deprecation warnings with newer versions
of phpunit