### PR TITLE
Fix missing assertions in ServerTest

### DIFF
--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -31,7 +31,7 @@ class ServerTest extends TestCase
         $responseAssertion = null;
 
         $server = new Server($io);
-        $server->on('request', function (Request $request, Response $response) use (&$i, &$requestAssertion, &$responseAssertion) {
+        $server->on('request', function ($request, $response) use (&$i, &$requestAssertion, &$responseAssertion) {
             $i++;
             $requestAssertion = $request;
             $responseAssertion = $response;


### PR DESCRIPTION
The assertion of PHPUnit in anonymous functions don't have an effect and will always be marked as OK by PHPUnit.

The `assert*(*)` methods must be placed inside the test method.
