### PR TITLE
ServerInterface is unneeded

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -7,7 +7,7 @@ use React\Socket\ServerInterface as SocketServerInterface;
 use React\Socket\ConnectionInterface;
 
 /** @event request */
-class Server extends EventEmitter implements ServerInterface
+class Server extends EventEmitter
 {
     private $io;
 

--- a/src/ServerInterface.php
+++ b/src/ServerInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace React\Http;
-
-use Evenement\EventEmitterInterface;
-
-interface ServerInterface extends EventEmitterInterface
-{
-}


### PR DESCRIPTION
The `ServerInterface` is not needed, because the Server already extends `EventEmitter`.