### PR TITLE
Replace `request` listener with callback function

### DIFF
--- a/examples/01-hello-world.php
+++ b/examples/01-hello-world.php
@@ -10,8 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket);
-$server->on('request', function (Request $request, Response $response) {
+$server = new \React\Http\Server($socket, function (Request $request, Response $response) {
     $response->writeHead(200, array('Content-Type' => 'text/plain'));
     $response->end("Hello world!\n");
 });

--- a/examples/02-hello-world-https.php
+++ b/examples/02-hello-world-https.php
@@ -14,8 +14,7 @@ $socket = new SecureServer($socket, $loop, array(
     'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
 ));
 
-$server = new \React\Http\Server($socket);
-$server->on('request', function (Request $reques, Response $response) {
+$server = new \React\Http\Server($socket, function (Request $request, Response $response) {
     $response->writeHead(200, array('Content-Type' => 'text/plain'));
     $response->end("Hello world!\n");
 });

--- a/examples/03-handling-body-data.php
+++ b/examples/03-handling-body-data.php
@@ -10,8 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket);
-$server->on('request', function (Request $request, Response $response) {
+$server = new \React\Http\Server($socket, function (Request $request, Response $response) {
     $contentLength = 0;
     $request->on('data', function ($data) use (&$contentLength) {
         $contentLength += strlen($data);


### PR DESCRIPTION
A callback function is more useful and helps to understand better how the server works.
The `request` event isn't useful, because there is no real scenario where you need different listeners on this event.

Btw.: this would make it easier to implement PSR-7 too ;)