### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "keywords": ["http"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/psr7": "^1.0",
+        "php": ">=5.3.0",
+        "ringcentral/psr7": "^1.0",
         "react/socket": "^0.4",
         "react/stream": "^0.4",
-        "evenement/evenement": "^2.0"
+        "evenement/evenement": "^2.0 || ^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -4,7 +4,7 @@ namespace React\Http;
 
 use Evenement\EventEmitter;
 use Exception;
-use GuzzleHttp\Psr7 as g7;
+use RingCentral\Psr7 as g7;
 
 /**
  * @event headers
@@ -37,7 +37,7 @@ class RequestHeaderParser extends EventEmitter
             try {
                 $this->parseAndEmitRequest();
             } catch (Exception $exception) {
-                $this->emit('error', [$exception]);
+                $this->emit('error', array($exception));
             }
             $this->removeAllListeners();
         }
@@ -55,7 +55,7 @@ class RequestHeaderParser extends EventEmitter
 
         $psrRequest = g7\parse_request($headers);
 
-        $parsedQuery = [];
+        $parsedQuery = array();
         $queryString = $psrRequest->getUri()->getQuery();
         if ($queryString) {
             parse_str($queryString, $parsedQuery);

--- a/src/Response.php
+++ b/src/Response.php
@@ -17,18 +17,18 @@ class Response extends EventEmitter implements WritableStreamInterface
     public function __construct(ConnectionInterface $conn)
     {
         $this->conn = $conn;
-
-        $this->conn->on('end', function () {
-            $this->close();
+        $that = $this;
+        $this->conn->on('end', function () use ($that) {
+            $that->close();
         });
 
-        $this->conn->on('error', function ($error) {
-            $this->emit('error', array($error, $this));
-            $this->close();
+        $this->conn->on('error', function ($error) use ($that) {
+            $that->emit('error', array($error, $that));
+            $that->close();
         });
 
-        $this->conn->on('drain', function () {
-            $this->emit('drain');
+        $this->conn->on('drain', function () use ($that) {
+            $that->emit('drain');
         });
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -121,7 +121,7 @@ class ServerTest extends TestCase
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
         $data .= str_repeat('A', 4097 - strlen($data)) . "\r\n\r\n";
-        $this->connection->emit('data', [$data]);
+        $this->connection->emit('data', array($data));
 
         $this->assertInstanceOf('OverflowException', $error);
         $this->connection->expects($this->never())->method('write');


### PR DESCRIPTION
Because _why not_… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting _significant amount_ of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually _require_ any new language features or some external lib, then I'm all for dropping support again.
