### PR TITLE
Decode chunked transfer encoding for incoming requests

### DIFF
--- a/src/ChunkedDecoder.php
+++ b/src/ChunkedDecoder.php
@@ -7,6 +7,7 @@ use React\Stream\WritableStreamInterface;
 use React\Stream\Util;
 use Exception;
 
+/** @internal */
 class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 {
     const CRLF = "\r\n";

--- a/src/ChunkedDecoder.php
+++ b/src/ChunkedDecoder.php
@@ -1,0 +1,196 @@
+<?php
+namespace React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+use Exception;
+
+class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
+{
+    const CRLF = "\r\n";
+
+    private $closed = false;
+    private $input;
+    private $buffer = '';
+    private $chunkSize = 0;
+    private $actualChunksize = 0;
+    private $chunkHeaderComplete = false;
+
+    public function __construct(ReadableStreamInterface $input)
+    {
+        $this->input = $input;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+
+    public function isReadable()
+    {
+        return ! $this->closed && $this->input->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->input->pause();
+    }
+
+    public function resume()
+    {
+        $this->input->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        $this->input->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    /**
+     * Extracts the hexadecimal header and removes it from the given data string
+     *
+     * @param string $data - complete or incomplete chunked string
+     * @return string
+     */
+    private function handleChunkHeader($data)
+    {
+        $hexValue = strtok($this->buffer . $data, static::CRLF);
+        if ($this->isLineComplete($this->buffer . $data, $hexValue, strlen($hexValue))) {
+
+            if (dechex(hexdec($hexValue)) != $hexValue) {
+                $this->emit('error', array(new \Exception('Unable to identify ' . $hexValue . 'as hexadecimal number')));
+                $this->close();
+                return;
+            }
+
+            $this->chunkSize = hexdec($hexValue);
+            $this->chunkHeaderComplete = true;
+
+            $data = substr($this->buffer . $data, strlen($hexValue) + 2);
+            $this->buffer = '';
+            // Chunk header is complete
+            return $data;
+        }
+
+        $this->buffer .= $data;
+        $data = '';
+        // Chunk header isn't complete, buffer
+        return $data;
+    }
+
+    /**
+     * Extracts the chunk data and removes it from the income data string
+     *
+     * @param unknown $data - string without the hexadecimal header
+     * @return string
+     */
+    private function handleChunkData($data)
+    {
+        $chunk = substr($this->buffer . $data, 0, $this->chunkSize);
+        $this->actualChunksize = strlen($chunk);
+
+        if ($this->chunkSize == $this->actualChunksize) {
+            $data = $this->sendChunk($data, $chunk);
+        } elseif ($this->actualChunksize < $this->chunkSize) {
+            $this->buffer .= $data;
+            $data = '';
+        }
+
+        return $data;
+    }
+
+    /**
+     * Sends the chunk or ends the stream
+     *
+     * @param string $data - incomed data stream the chunk will be removed from this string
+     * @param string $chunk - chunk which will be emitted
+     * @return string - rest data string
+     */
+    private function sendChunk($data, $chunk)
+    {
+        if ($this->chunkSize == 0 && $this->isLineComplete($this->buffer . $data, $chunk, $this->chunkSize)) {
+            $this->emit('end', array());
+            return;
+        }
+
+        if (!$this->isLineComplete($this->buffer . $data, $chunk, $this->chunkSize)) {
+            $this->emit('error', array(new \Exception('Chunk doesn\'t end with new line delimiter')));
+            $this->close();
+            return;
+        }
+
+        $data = substr($this->buffer . $data, $this->chunkSize + 2);
+        $this->emit('data', array($chunk));
+
+        $this->buffer = '';
+        $this->chunkSize = 0;
+        $this->chunkHeaderComplete = false;
+
+        return $data;
+    }
+
+    /**
+     * Checks if the given chunk is ending with a "\r\n" at the start of the data string
+     *
+     * @param string $data - complete data string
+     * @param string $chunk - string which should end with "\r\n"
+     * @param unknown $length - possible length of the data chunk
+     * @return boolean
+     */
+    private function isLineComplete($data, $chunk, $length)
+    {
+        if (substr($data, 0, $length + 2) == $chunk . static::CRLF) {
+            return true;
+        }
+        return false;
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (! $this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        while (strlen($data) != 0) {
+            if (! $this->chunkHeaderComplete) {
+                $data = $this->handleChunkHeader($data);
+            }
+            // Not 'else', chunkHeaderComplete can change in 'handleChunkHeader'
+            if ($this->chunkHeaderComplete) {
+                $data = $this->handleChunkData($data);
+            }
+        }
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -57,10 +57,13 @@ class Server extends EventEmitter implements ServerInterface
             return;
         }
 
-        $header = $request->getHeaders();
         $stream = $conn;
-        if (!empty($header['Transfer-Encoding']) && $header['Transfer-Encoding'] === 'chunked') {
-            $stream = new ChunkedDecoder($conn);
+        if ($request->hasHeader('Transfer-Encoding')) {
+            $transferEncodingHeader = $request->getHeader('Transfer-Encoding');
+            // 'chunked' must always be the final value of 'Transfer-Encoding' according to: https://tools.ietf.org/html/rfc7230#section-3.3.1
+            if (strtolower(end($transferEncodingHeader)) === 'chunked') {
+                $stream = new ChunkedDecoder($conn);
+            }
         }
 
         $stream->on('data', function ($data) use ($request) {

--- a/tests/ChunkedDecoderTest.php
+++ b/tests/ChunkedDecoderTest.php
@@ -16,50 +16,74 @@ class ChunkedDecoderTest extends TestCase
     public function testSimpleChunk()
     {
         $this->parser->on('data', $this->expectCallableOnceWith('hello'));
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
         $this->input->emit('data', array("5\r\nhello\r\n"));
     }
 
     public function testTwoChunks()
     {
-    	$this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
-    	$this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
     }
 
     public function testEnd()
     {
-    	$this->parser->on('end', $this->expectCallableOnce(array()));
-    	$this->input->emit('data', array("0\r\n\r\n"));
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("0\r\n\r\n"));
     }
 
     public function testParameterWithEnd()
     {
-    	$this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
-    	$this->parser->on('end', $this->expectCallableOnce(array()));
-    	$this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $this->parser->on('end', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
     }
 
     public function testInvalidChunk()
     {
-    	$this->parser->on('data', $this->expectCallableNever());
-    	$this->parser->on('error', $this->expectCallableOnce(array()));
-    	$this->input->emit('data', array("bla\r\n"));
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("bla\r\n"));
     }
 
     public function testNeverEnd()
     {
-    	$this->parser->on('end', $this->expectCallableNever());
-    	$this->input->emit('data', array("0\r\n"));
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
+
+        $this->input->emit('data', array("0\r\n"));
     }
 
     public function testWrongChunkHex()
     {
-    	$this->parser->on('error', $this->expectCallableOnce(array()));
-    	$this->input->emit('data', array("2\r\na\r\n5\r\nhello\r\n"));
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
+
+        $this->input->emit('data', array("2\r\na\r\n5\r\nhello\r\n"));
     }
 
     public function testSplittedChunk()
     {
-        $this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
         $this->input->emit('data', array("4\r\n"));
         $this->input->emit('data', array("welt\r\n"));
@@ -67,66 +91,86 @@ class ChunkedDecoderTest extends TestCase
 
     public function testSplittedHeader()
     {
-    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());#
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("4"));
-    	$this->input->emit('data', array("\r\nwelt\r\n"));
+
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\nwelt\r\n"));
     }
 
     public function testSplittedBoth()
     {
-    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("4"));
-    	$this->input->emit('data', array("\r\n"));
-    	$this->input->emit('data', array("welt\r\n"));
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("welt\r\n"));
     }
 
     public function testCompletlySplitted()
     {
-    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+        $this->parser->on('data', $this->expectCallableOnceWith('welt'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("4"));
-    	$this->input->emit('data', array("\r\n"));
-    	$this->input->emit('data', array("we"));
-    	$this->input->emit('data', array("lt\r\n"));
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("we"));
+        $this->input->emit('data', array("lt\r\n"));
     }
 
     public function testMixed()
     {
-    	$this->parser->on('data',  $this->expectCallableConsecutive(2, array('welt', 'hello')));
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('welt', 'hello')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("4"));
-    	$this->input->emit('data', array("\r\n"));
-    	$this->input->emit('data', array("we"));
-    	$this->input->emit('data', array("lt\r\n"));
-    	$this->input->emit('data', array("5\r\nhello\r\n"));
+        $this->input->emit('data', array("4"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("we"));
+        $this->input->emit('data', array("lt\r\n"));
+        $this->input->emit('data', array("5\r\nhello\r\n"));
     }
 
     public function testBigger()
     {
-    	$this->parser->on('data',  $this->expectCallableConsecutive(2, array('abcdeabcdeabcdea', 'hello')));
+        $this->parser->on('data', $this->expectCallableConsecutive(2, array('abcdeabcdeabcdea', 'hello')));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("1"));
-    	$this->input->emit('data', array("0"));
-    	$this->input->emit('data', array("\r\n"));
-    	$this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
-    	$this->input->emit('data', array("5\r\nhello\r\n"));
+        $this->input->emit('data', array("1"));
+        $this->input->emit('data', array("0"));
+        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
+        $this->input->emit('data', array("5\r\nhello\r\n"));
     }
 
     public function testOneUnfinished()
     {
-    	$this->parser->on('data', $this->expectCallableOnceWith('bla'));
+        $this->parser->on('data', $this->expectCallableOnceWith('bla'));
+        $this->parser->on('close', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('error', $this->expectCallableNever());
 
-    	$this->input->emit('data', array("3\r\n"));
-    	$this->input->emit('data', array("bla\r\n"));
-    	$this->input->emit('data', array("5\r\nhello"));
+        $this->input->emit('data', array("3\r\n"));
+        $this->input->emit('data', array("bla\r\n"));
+        $this->input->emit('data', array("5\r\nhello"));
     }
 
     public function testHandleError()
     {
         $this->parser->on('error', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('end', $this->expectCallableNever());
 
         $this->input->emit('error', array(new \RuntimeException()));
 
@@ -163,10 +207,10 @@ class ChunkedDecoderTest extends TestCase
 
     public function testHandleClose()
     {
-    	$this->parser->on('close', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
 
-    	$this->input->close();
-    	$this->input->emit('end', array());
+        $this->input->close();
+        $this->input->emit('end', array());
 
     	$this->assertFalse($this->parser->isReadable());
     }

--- a/tests/ChunkedDecoderTest.php
+++ b/tests/ChunkedDecoderTest.php
@@ -183,18 +183,4 @@ class ChunkedDecoderTest extends TestCase
 
         $this->assertFalse($input->isReadable());
     }
-
-    private function expectCallableConsecutive($numberOfCalls, array $with)
-    {
-        $mock = $this->createCallableMock();
-
-        for ($i = 0; $i < $numberOfCalls; $i++) {
-            $mock
-                ->expects($this->at($i))
-                ->method('__invoke')
-                ->with($this->equalTo($with[$i]));
-        }
-
-        return $mock;
-    }
 }

--- a/tests/ChunkedDecoderTest.php
+++ b/tests/ChunkedDecoderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace React\Tests\Http;
+
+use React\Stream\ReadableStream;
+use React\Http\ChunkedDecoder;
+
+class ChunkedDecoderTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+        $this->parser = new ChunkedDecoder($this->input);
+    }
+
+    public function testSimpleChunk()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('hello'));
+        $this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testTwoChunks()
+    {
+    	$this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+    	$this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
+    }
+
+    public function testEnd()
+    {
+    	$this->parser->on('end', $this->expectCallableOnce(array()));
+    	$this->input->emit('data', array("0\r\n\r\n"));
+    }
+
+    public function testParameterWithEnd()
+    {
+    	$this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+    	$this->parser->on('end', $this->expectCallableOnce(array()));
+    	$this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
+    }
+
+    public function testInvalidChunk()
+    {
+    	$this->parser->on('data', $this->expectCallableNever());
+    	$this->parser->on('error', $this->expectCallableOnce(array()));
+    	$this->input->emit('data', array("bla\r\n"));
+    }
+
+    public function testNeverEnd()
+    {
+    	$this->parser->on('end', $this->expectCallableNever());
+    	$this->input->emit('data', array("0\r\n"));
+    }
+
+    public function testWrongChunkHex()
+    {
+    	$this->parser->on('error', $this->expectCallableOnce(array()));
+    	$this->input->emit('data', array("2\r\na\r\n5\r\nhello\r\n"));
+    }
+
+    public function testSplittedChunk()
+    {
+        $this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+
+        $this->input->emit('data', array("4\r\n"));
+        $this->input->emit('data', array("welt\r\n"));
+    }
+
+    public function testSplittedHeader()
+    {
+    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+
+    	$this->input->emit('data', array("4"));
+    	$this->input->emit('data', array("\r\nwelt\r\n"));
+    }
+
+    public function testSplittedBoth()
+    {
+    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+
+    	$this->input->emit('data', array("4"));
+    	$this->input->emit('data', array("\r\n"));
+    	$this->input->emit('data', array("welt\r\n"));
+    }
+
+    public function testCompletlySplitted()
+    {
+    	$this->parser->on('data',  $this->expectCallableOnceWith('welt'));
+
+    	$this->input->emit('data', array("4"));
+    	$this->input->emit('data', array("\r\n"));
+    	$this->input->emit('data', array("we"));
+    	$this->input->emit('data', array("lt\r\n"));
+    }
+
+    public function testMixed()
+    {
+    	$this->parser->on('data',  $this->expectCallableConsecutive(2, array('welt', 'hello')));
+
+    	$this->input->emit('data', array("4"));
+    	$this->input->emit('data', array("\r\n"));
+    	$this->input->emit('data', array("we"));
+    	$this->input->emit('data', array("lt\r\n"));
+    	$this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testBigger()
+    {
+    	$this->parser->on('data',  $this->expectCallableConsecutive(2, array('abcdeabcdeabcdea', 'hello')));
+
+    	$this->input->emit('data', array("1"));
+    	$this->input->emit('data', array("0"));
+    	$this->input->emit('data', array("\r\n"));
+    	$this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
+    	$this->input->emit('data', array("5\r\nhello\r\n"));
+    }
+
+    public function testOneUnfinished()
+    {
+    	$this->parser->on('data', $this->expectCallableOnceWith('bla'));
+
+    	$this->input->emit('data', array("3\r\n"));
+    	$this->input->emit('data', array("bla\r\n"));
+    	$this->input->emit('data', array("5\r\nhello"));
+    }
+
+    public function testHandleError()
+    {
+        $this->parser->on('error', $this->expectCallableOnce());
+        $this->parser->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($this->parser->isReadable());
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedDecoder($input);
+        $parser->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $input->expects($this->once())->method('pause');
+
+        $parser = new ChunkedDecoder($input);
+        $parser->pause();
+        $parser->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $dest = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $ret = $this->parser->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+    	$this->parser->on('close', $this->expectCallableOnce());
+
+    	$this->input->close();
+    	$this->input->emit('end', array());
+
+    	$this->assertFalse($this->parser->isReadable());
+    }
+
+    public function testOutputStreamCanCloseInputStream()
+    {
+        $input = new ReadableStream();
+        $input->on('close', $this->expectCallableOnce());
+
+        $stream = new ChunkedDecoder($input);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $stream->close();
+
+        $this->assertFalse($input->isReadable());
+    }
+
+    private function expectCallableConsecutive($numberOfCalls, array $with)
+    {
+        $mock = $this->createCallableMock();
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $mock
+                ->expects($this->at($i))
+                ->method('__invoke')
+                ->with($this->equalTo($with[$i]));
+        }
+
+        return $mock;
+    }
+}

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -159,11 +159,12 @@ class ServerTest extends TestCase
     {
         $server = new Server($this->socket);
 
-        $buffer = '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableNever();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -176,19 +177,18 @@ class ServerTest extends TestCase
         $data .= "hello";
 
         $this->connection->emit('data', array($data));
-
-        $this->assertEquals('hello', $buffer);
     }
 
     public function testChunkedEncodedRequestWillBeParsedForRequestEvent()
     {
         $server = new Server($this->socket);
 
-        $buffer =  '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -202,19 +202,18 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
-
-        $this->assertEquals('hello', $buffer);
     }
 
     public function testChunkedEncodedRequestAdditionalDataWontBeEmitted()
     {
         $server = new Server($this->socket);
 
-        $buffer =  '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -229,18 +228,18 @@ class ServerTest extends TestCase
         $data .= "2\r\nhi\r\n";
 
         $this->connection->emit('data', array($data));
-        $this->assertEquals('hello', $buffer);
     }
 
     public function testEmptyChunkedEncodedRequest()
     {
         $server = new Server($this->socket);
 
-        $buffer =  '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableNever();
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -253,18 +252,80 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
-        $this->assertEquals('', $buffer);
     }
 
+    public function testOneChunkWillBeEmittedDelayed()
+    {
+        $server = new Server($this->socket);
+
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Transfer-Encoding: chunked\r\n";
+        $data .= "\r\n";
+        $data .= "5\r\nhel";
+
+        $this->connection->emit('data', array($data));
+
+        $data = "lo\r\n";
+        $data .= "0\r\n\r\n";
+
+        $this->connection->emit('data', array($data));
+    }
+
+    public function testEmitTwoChunksDelayed()
+    {
+        $server = new Server($this->socket);
+
+        $dataEvent = $this->expectCallableConsecutive(2, array('hello', 'world'));
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Transfer-Encoding: chunked\r\n";
+        $data .= "\r\n";
+        $data .= "5\r\nhello\r\n";
+
+        $this->connection->emit('data', array($data));
+
+        $data = "5\r\nworld\r\n";
+        $data .= "0\r\n\r\n";
+
+        $this->connection->emit('data', array($data));
+    }
+
+    /**
+     * All transfer-coding names are case-insensitive according to:
+     * https://tools.ietf.org/html/rfc7230#section-4
+     */
     public function testChunkedIsUpperCase()
     {
         $server = new Server($this->socket);
 
-        $buffer =  '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -278,18 +339,22 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
-        $this->assertEquals('hello', $buffer);
     }
 
+    /**
+     * All transfer-coding names are case-insensitive according to:
+     * https://tools.ietf.org/html/rfc7230#section-4
+     */
     public function testChunkedIsMixedUpperAndLowerCase()
     {
         $server = new Server($this->socket);
 
-        $buffer =  '';
-        $server->on('request', function (Request $request, Response $response) use (&$buffer) {
-            $request->on('data', function ($data) use (&$buffer) {
-                $buffer .= $data;
-            });
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -303,7 +368,6 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
-        $this->assertEquals('hello', $buffer);
     }
 
     private function createGetRequest()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,6 +45,20 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $mock;
     }
 
+    protected function expectCallableConsecutive($numberOfCalls, array $with)
+    {
+        $mock = $this->createCallableMock();
+
+        for ($i = 0; $i < $numberOfCalls; $i++) {
+            $mock
+                ->expects($this->at($i))
+                ->method('__invoke')
+                ->with($this->equalTo($with[$i]));
+        }
+
+        return $mock;
+    }
+
     protected function createCallableMock()
     {
         return $this

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,6 +34,17 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->equalTo($value));
+
+        return $mock;
+    }
+
     protected function createCallableMock()
     {
         return $this


### PR DESCRIPTION
This ensures that only decoded body data will be emitted via the request object.

Resolves / closes #96