### PR TITLE
Fix headers to be handled case insensitive and ignore 100-continue for HTTP/1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ See the above usage example and the class outline for details.
 
 ### Request
 
+The `Request` class is responsible for streaming the incoming request body
+and contains meta data which was parsed from the request headers.
+
+It implements the `ReadableStreamInterface`.
+
 See the above usage example and the class outline for details.
 
 #### getHeaders()
@@ -79,9 +84,109 @@ Returns a comma-separated list of all values for this header name or an empty st
 The `hasHeader(string $name): bool` method can be used to
 check if a header exists by the given case-insensitive name.
 
+#### expectsContinue()
+
+The `expectsContinue(): bool` method can be used to
+check if the request headers contain the `Expect: 100-continue` header.
+
+This header MAY be included when an HTTP/1.1 client wants to send a bigger
+request body.
+See [`writeContinue()`](#writecontinue) for more details.
+
 ### Response
 
+The `Response` class is responsible for streaming the outgoing response body.
+
+It implements the `WritableStreamInterface`.
+
 See the above usage example and the class outline for details.
+
+#### writeContinue()
+
+The `writeContinue(): void` method can be used to
+send an intermediary `HTTP/1.1 100 continue` response.
+
+This is a feature that is implemented by *many* HTTP/1.1 clients.
+When clients want to send a bigger request body, they MAY send only the request
+headers with an additional `Expect: 100-continue` header and wait before
+sending the actual (large) message body.
+
+The server side MAY use this header to verify if the request message is
+acceptable by checking the request headers (such as `Content-Length` or HTTP
+authentication) and then ask the client to continue with sending the message body.
+Otherwise, the server can send a normal HTTP response message and save the
+client from transfering the whole body at all.
+
+This method is mostly useful in combination with the
+[`expectsContinue()`](#expectscontinue) method like this:
+
+```php
+$http->on('request', function (Request $request, Response $response) {
+    if ($request->expectsContinue()) {
+        $response->writeContinue();
+    }
+
+    $response->writeHead(200, array('Content-Type' => 'text/plain'));
+    $response->end("Hello World!\n");
+});
+```
+
+Note that calling this method is strictly optional.
+If you do not use it, then the client MUST continue sending the request body
+after waiting some time.
+
+This method MUST NOT be invoked after calling `writeHead()`.
+Calling this method after sending the headers will result in an `Exception`.
+
+#### writeHead()
+
+The `writeHead(int $status = 200, array $headers = array(): void` method can be used to
+write the given HTTP message header.
+
+This method MUST be invoked once before calling `write()` or `end()` to send
+the actual HTTP message body:
+
+```php
+$response->writeHead(200, array(
+    'Content-Type' => 'text/plain'
+));
+$response->end('Hello World!');
+```
+
+Calling this method more than once will result in an `Exception`.
+
+Unless you specify a `Content-Length` header yourself, the response message
+will automatically use chunked transfer encoding and send the respective header
+(`Transfer-Encoding: chunked`) automatically. If you know the length of your
+body, you MAY specify it like this instead:
+
+```php
+$data = 'Hello World!';
+
+$response->writeHead(200, array(
+    'Content-Type' => 'text/plain',
+    'Content-Length' => strlen($data)
+));
+$response->end($data);
+```
+
+Note that it will automatically assume a `X-Powered-By: react/alpha` header
+unless your specify a custom `X-Powered-By` header yourself:
+
+```php
+$response->writeHead(200, array(
+    'X-Powered-By' => 'PHP 3'
+));
+```
+
+If you do not want to send this header at all, you can use an empty array as
+value like this:
+
+```php
+$response->writeHead(200, array(
+    'X-Powered-By' => array()
+));
+```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ This header MAY be included when an HTTP/1.1 client wants to send a bigger
 request body.
 See [`writeContinue()`](#writecontinue) for more details.
 
+This will always be `false` for HTTP/1.0 requests, regardless of what
+any header values say.
+
 ### Response
 
 The `Response` class is responsible for streaming the outgoing response body.

--- a/src/Request.php
+++ b/src/Request.php
@@ -111,6 +111,16 @@ class Request extends EventEmitter implements ReadableStreamInterface
         return !!$this->getHeader($name);
     }
 
+    /**
+     * Checks if the request headers contain the `Expect: 100-continue` header.
+     *
+     * This header MAY be included when an HTTP/1.1 client wants to send a bigger
+     * request body.
+     * See [`writeContinue()`] for more details.
+     *
+     * @return bool
+     * @see Response::writeContinue()
+     */
     public function expectsContinue()
     {
         return '100-continue' === $this->getHeaderLine('Expect');

--- a/src/Request.php
+++ b/src/Request.php
@@ -118,12 +118,15 @@ class Request extends EventEmitter implements ReadableStreamInterface
      * request body.
      * See [`writeContinue()`] for more details.
      *
+     * This will always be `false` for HTTP/1.0 requests, regardless of what
+     * any header values say.
+     *
      * @return bool
      * @see Response::writeContinue()
      */
     public function expectsContinue()
     {
-        return '100-continue' === strtolower($this->getHeaderLine('Expect'));
+        return $this->httpVersion !== '1.0' && '100-continue' === strtolower($this->getHeaderLine('Expect'));
     }
 
     public function isReadable()

--- a/src/Request.php
+++ b/src/Request.php
@@ -113,7 +113,7 @@ class Request extends EventEmitter implements ReadableStreamInterface
 
     public function expectsContinue()
     {
-        return isset($this->headers['Expect']) && '100-continue' === $this->headers['Expect'];
+        return '100-continue' === $this->getHeaderLine('Expect');
     }
 
     public function isReadable()

--- a/src/Request.php
+++ b/src/Request.php
@@ -123,7 +123,7 @@ class Request extends EventEmitter implements ReadableStreamInterface
      */
     public function expectsContinue()
     {
-        return '100-continue' === $this->getHeaderLine('Expect');
+        return '100-continue' === strtolower($this->getHeaderLine('Expect'));
     }
 
     public function isReadable()

--- a/src/Response.php
+++ b/src/Response.php
@@ -37,6 +37,45 @@ class Response extends EventEmitter implements WritableStreamInterface
         return $this->writable;
     }
 
+    /**
+     * Sends an intermediary `HTTP/1.1 100 continue` response.
+     *
+     * This is a feature that is implemented by *many* HTTP/1.1 clients.
+     * When clients want to send a bigger request body, they MAY send only the request
+     * headers with an additional `Expect: 100-continue` header and wait before
+     * sending the actual (large) message body.
+     *
+     * The server side MAY use this header to verify if the request message is
+     * acceptable by checking the request headers (such as `Content-Length` or HTTP
+     * authentication) and then ask the client to continue with sending the message body.
+     * Otherwise, the server can send a normal HTTP response message and save the
+     * client from transfering the whole body at all.
+     *
+     * This method is mostly useful in combination with the
+     * [`expectsContinue()`] method like this:
+     *
+     * ```php
+     * $http->on('request', function (Request $request, Response $response) {
+     *     if ($request->expectsContinue()) {
+     *         $response->writeContinue();
+     *     }
+     *
+     *     $response->writeHead(200, array('Content-Type' => 'text/plain'));
+     *     $response->end("Hello World!\n");
+     * });
+     * ```
+     *
+     * Note that calling this method is strictly optional.
+     * If you do not use it, then the client MUST continue sending the request body
+     * after waiting some time.
+     *
+     * This method MUST NOT be invoked after calling `writeHead()`.
+     * Calling this method after sending the headers will result in an `Exception`.
+     *
+     * @return void
+     * @throws \Exception
+     * @see Request::expectsContinue()
+     */
     public function writeContinue()
     {
         if ($this->headWritten) {
@@ -46,6 +85,58 @@ class Response extends EventEmitter implements WritableStreamInterface
         $this->conn->write("HTTP/1.1 100 Continue\r\n\r\n");
     }
 
+    /**
+     * Writes the given HTTP message header.
+     *
+     * This method MUST be invoked once before calling `write()` or `end()` to send
+     * the actual HTTP message body:
+     *
+     * ```php
+     * $response->writeHead(200, array(
+     *     'Content-Type' => 'text/plain'
+     * ));
+     * $response->end('Hello World!');
+     * ```
+     *
+     * Calling this method more than once will result in an `Exception`.
+     *
+     * Unless you specify a `Content-Length` header yourself, the response message
+     * will automatically use chunked transfer encoding and send the respective header
+     * (`Transfer-Encoding: chunked`) automatically. If you know the length of your
+     * body, you MAY specify it like this instead:
+     *
+     * ```php
+     * $data = 'Hello World!';
+     *
+     * $response->writeHead(200, array(
+     *     'Content-Type' => 'text/plain',
+     *     'Content-Length' => strlen($data)
+     * ));
+     * $response->end($data);
+     * ```
+     *
+     * Note that it will automatically assume a `X-Powered-By: react/alpha` header
+     * unless your specify a custom `X-Powered-By` header yourself:
+     *
+     * ```php
+     * $response->writeHead(200, array(
+     *     'X-Powered-By' => 'PHP 3'
+     * ));
+     * ```
+     *
+     * If you do not want to send this header at all, you can use an empty array as
+     * value like this:
+     *
+     * ```php
+     * $response->writeHead(200, array(
+     *     'X-Powered-By' => array()
+     * ));
+     * ```
+     *
+     * @param int   $status
+     * @param array $headers
+     * @throws \Exception
+     */
     public function writeHead($status = 200, array $headers = array())
     {
         if ($this->headWritten) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -27,7 +27,7 @@ class RequestTest extends TestCase
     /** @test */
     public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
     {
-        $headers = array('EXPECT' => '100-continue');
+        $headers = array('EXPECT' => '100-CONTINUE');
         $request = new Request('GET', '/', array(), '1.1', $headers);
 
         $this->assertTrue($request->expectsContinue());

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -24,6 +24,15 @@ class RequestTest extends TestCase
         $this->assertTrue($request->expectsContinue());
     }
 
+    /** @test */
+    public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
+    {
+        $headers = array('EXPECT' => '100-continue');
+        $request = new Request('GET', '/', array(), '1.1', $headers);
+
+        $this->assertTrue($request->expectsContinue());
+    }
+
     public function testEmptyHeader()
     {
         $request = new Request('GET', '/');

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -33,6 +33,15 @@ class RequestTest extends TestCase
         $this->assertTrue($request->expectsContinue());
     }
 
+    /** @test */
+    public function expectsContinueShouldBeFalseForHttp10()
+    {
+        $headers = array('Expect' => '100-continue');
+        $request = new Request('GET', '/', array(), '1.0', $headers);
+
+        $this->assertFalse($request->expectsContinue());
+    }
+
     public function testEmptyHeader()
     {
         $request = new Request('GET', '/');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -26,6 +26,25 @@ class ResponseTest extends TestCase
         $response->writeHead();
     }
 
+    public function testResponseShouldBeChunkedEvenWithOtherTransferEncoding()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "X-Powered-By: React/alpha\r\n";
+        $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array('transfer-encoding' => 'custom'));
+    }
+
+
     public function testResponseShouldNotBeChunkedWithContentLength()
     {
         $expected = '';
@@ -44,6 +63,59 @@ class ResponseTest extends TestCase
 
         $response = new Response($conn);
         $response->writeHead(200, array('Content-Length' => 22));
+    }
+
+    public function testResponseShouldNotBeChunkedWithContentLengthCaseInsensitive()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "X-Powered-By: React/alpha\r\n";
+        $expected .= "CONTENT-LENGTH: 0\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array('CONTENT-LENGTH' => 0));
+    }
+
+    public function testResponseShouldIncludeCustomByPoweredAsFirstHeaderIfGivenExplicitly()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "Content-Length: 0\r\n";
+        $expected .= "X-POWERED-BY: demo\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array('Content-Length' => 0, 'X-POWERED-BY' => 'demo'));
+    }
+
+    public function testResponseShouldNotIncludePoweredByIfGivenEmptyArray()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "Content-Length: 0\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array('Content-Length' => 0, 'X-Powered-By' => array()));
     }
 
     public function testResponseBodyShouldBeChunkedCorrectly()


### PR DESCRIPTION
This simple PR makes sure we always match header names case insensitive.

Also adds some documentation for the existing methods.

Builds on top of #103 
Fixes / closes #51
Fixes / closes #36
Supersedes / closes #54
Supersedes #53
Supersedes #47