### PR TITLE
Forward pause/resume from request to connection

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -26,6 +26,10 @@ class Server extends EventEmitter implements ServerInterface
                 // attach remote ip to the request as metadata
                 $request->remoteAddress = $conn->getRemoteAddress();
 
+                // forward pause/resume calls to underlying connection
+                $request->on('pause', array($conn, 'pause'));
+                $request->on('resume', array($conn, 'resume'));
+
                 $that->handleRequest($conn, $request, $bodyBuffer);
 
                 $conn->removeListener('data', array($parser, 'feed'));
@@ -34,12 +38,6 @@ class Server extends EventEmitter implements ServerInterface
                 });
                 $conn->on('data', function ($data) use ($request) {
                     $request->emit('data', array($data));
-                });
-                $request->on('pause', function () use ($conn) {
-                    $conn->emit('pause');
-                });
-                $request->on('resume', function () use ($conn) {
-                    $conn->emit('resume');
                 });
             });
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -79,6 +79,34 @@ class ServerTest extends TestCase
         $this->assertInstanceOf('React\Http\Response', $responseAssertion);
     }
 
+    public function testRequestPauseWillbeForwardedToConnection()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request) {
+            $request->pause();
+        });
+
+        $this->connection->expects($this->once())->method('pause');
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
+    public function testRequestResumeWillbeForwardedToConnection()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request) {
+            $request->resume();
+        });
+
+        $this->connection->expects($this->once())->method('resume');
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
     public function testResponseContainsPoweredByHeader()
     {
         $server = new Server($this->socket);


### PR DESCRIPTION
I consider this a new feature, as stream back-pressure now works as expected.

Fixes / closes #84
Supersedes / closes #85