### PR TITLE
Test lowest version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,18 @@ php:
   - 7
   - hhvm
 
+matrix:
+  include:
+    - php: 5.3
+      env:
+        - DEPENDENCIES=lowest
+    - php: 7.0
+      env:
+        - DEPENDENCIES=lowest
+
 install:
   - composer install --no-interaction
+  - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest -n; fi
   
 script:
   - ./vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
Follow-up of #101 and #111. 

See https://travis-ci.org/andig/http/builds/200662157 for sample output. It already shows that ringcentral:1.0 is broken. https://travis-ci.org/andig/http/jobs/200662167 shows some additional errors that should be investigated once ringcentral/psr7 is upgraded to 1.2.

**Note**: this *doubles* the build matrix