### PR TITLE
Fix minimum phpunit version and allow v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^4.8.10||^5.0"
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -34,7 +34,9 @@ class ResponseTest extends TestCase
         $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -73,7 +75,9 @@ class ResponseTest extends TestCase
         $expected .= "CONTENT-LENGTH: 0\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -91,7 +95,9 @@ class ResponseTest extends TestCase
         $expected .= "X-POWERED-BY: demo\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')
@@ -108,7 +114,9 @@ class ResponseTest extends TestCase
         $expected .= "Content-Length: 0\r\n";
         $expected .= "\r\n";
 
-        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
         $conn
             ->expects($this->once())
             ->method('write')


### PR DESCRIPTION
Follow-up of #111 and https://github.com/reactphp/http/pull/114

phpunit ^5.0 is required since as of 4.8.20 php 7.0 is not supported (see https://github.com/sebastianbergmann/phpunit/blob/4.8.32/ChangeLog-4.8.md)

Welcome to version hell :/