### PR TITLE
Change Request methods to be in line with PSR-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,34 @@ It implements the `ReadableStreamInterface`.
 
 See the above usage example and the class outline for details.
 
+#### getMethod()
+
+The `getMethod(): string` method can be used to
+return the request method.
+
+#### getPath()
+
+The `getPath(): string` method can be used to
+return the request path.
+
+#### getQueryParams()
+
+The `getQueryParams(): array` method can be used to
+return an array with all query parameters ($_GET).
+
+#### getProtocolVersion()
+
+The `getProtocolVersion(): string` method can be used to
+return the HTTP protocol version (such as "1.0" or "1.1").
+
 #### getHeaders()
 
 The `getHeaders(): array` method can be used to
 return an array with ALL headers.
 
 The keys represent the header name in the exact case in which they were
-originally specified. The values will be a string if there's only a single
-value for the respective header name or an array of strings if this header
-has multiple values.
-
-> Note that this differs from the PSR-7 implementation of this method,
-which always returns an array for each header name, even if it only has a
-single value.
+originally specified. The values will be an array of strings for each
+value for the respective header name.
 
 #### getHeader()
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -28,22 +28,42 @@ class Request extends EventEmitter implements ReadableStreamInterface
         $this->headers = $headers;
     }
 
+    /**
+     * Returns the request method
+     *
+     * @return string
+     */
     public function getMethod()
     {
         return $this->method;
     }
 
+    /**
+     * Returns the request path
+     *
+     * @return string
+     */
     public function getPath()
     {
         return $this->path;
     }
 
-    public function getQuery()
+    /**
+     * Returns an array with all query parameters ($_GET)
+     *
+     * @return array
+     */
+    public function getQueryParams()
     {
         return $this->query;
     }
 
-    public function getHttpVersion()
+    /**
+     * Returns the HTTP protocol version (such as "1.0" or "1.1")
+     *
+     * @return string
+     */
+    public function getProtocolVersion()
     {
         return $this->httpVersion;
     }
@@ -52,13 +72,8 @@ class Request extends EventEmitter implements ReadableStreamInterface
      * Returns an array with ALL headers
      *
      * The keys represent the header name in the exact case in which they were
-     * originally specified. The values will be a string if there's only a single
-     * value for the respective header name or an array of strings if this header
-     * has multiple values.
-     *
-     * Note that this differs from the PSR-7 implementation of this method,
-     * which always returns an array for each header name, even if it only has a
-     * single value.
+     * originally specified. The values will be an array of strings for each
+     * value for the respective header name.
      *
      * @return array
      */

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -61,20 +61,12 @@ class RequestHeaderParser extends EventEmitter
             parse_str($queryString, $parsedQuery);
         }
 
-        $headers = array_map(function($val) {
-            if (1 === count($val)) {
-                $val = $val[0];
-            }
-
-            return $val;
-        }, $psrRequest->getHeaders());
-
         $request = new Request(
             $psrRequest->getMethod(),
             $psrRequest->getUri()->getPath(),
             $parsedQuery,
             $psrRequest->getProtocolVersion(),
-            $headers
+            $psrRequest->getHeaders()
         );
 
         return array($request, $bodyBuffer);

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -48,9 +48,9 @@ class RequestHeaderParserTest extends TestCase
         $this->assertInstanceOf('React\Http\Request', $request);
         $this->assertSame('GET', $request->getMethod());
         $this->assertSame('/', $request->getPath());
-        $this->assertSame(array(), $request->getQuery());
-        $this->assertSame('1.1', $request->getHttpVersion());
-        $this->assertSame(array('Host' => 'example.com:80', 'Connection' => 'close'), $request->getHeaders());
+        $this->assertSame(array(), $request->getQueryParams());
+        $this->assertSame('1.1', $request->getProtocolVersion());
+        $this->assertSame(array('Host' => array('example.com:80'), 'Connection' => array('close')), $request->getHeaders());
 
         $this->assertSame('RANDOM DATA', $bodyBuffer);
     }
@@ -86,12 +86,12 @@ class RequestHeaderParserTest extends TestCase
         $this->assertInstanceOf('React\Http\Request', $request);
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('/foo', $request->getPath());
-        $this->assertSame(array('bar' => 'baz'), $request->getQuery());
-        $this->assertSame('1.1', $request->getHttpVersion());
+        $this->assertSame(array('bar' => 'baz'), $request->getQueryParams());
+        $this->assertSame('1.1', $request->getProtocolVersion());
         $headers = array(
-            'Host' => 'example.com:80',
-            'User-Agent' => 'react/alpha',
-            'Connection' => 'close',
+            'Host' => array('example.com:80'),
+            'User-Agent' => array('react/alpha'),
+            'Connection' => array('close'),
         );
         $this->assertSame($headers, $request->getHeaders());
     }
@@ -139,9 +139,9 @@ class RequestHeaderParserTest extends TestCase
         $parser->feed($data);
 
         $headers = array(
-            'Host' => 'example.com:80',
-            'User-Agent' => 'react/alpha',
-            'Connection' => 'close',
+            'Host' => array('example.com:80'),
+            'User-Agent' => array('react/alpha'),
+            'Connection' => array('close'),
         );
         $this->assertSame($headers, $request->getHeaders());
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -18,7 +18,7 @@ class RequestTest extends TestCase
     /** @test */
     public function expectsContinueShouldBeTrueIfContinueExpected()
     {
-        $headers = array('Expect' => '100-continue');
+        $headers = array('Expect' => array('100-continue'));
         $request = new Request('GET', '/', array(), '1.1', $headers);
 
         $this->assertTrue($request->expectsContinue());
@@ -27,7 +27,7 @@ class RequestTest extends TestCase
     /** @test */
     public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
     {
-        $headers = array('EXPECT' => '100-CONTINUE');
+        $headers = array('EXPECT' => array('100-CONTINUE'));
         $request = new Request('GET', '/', array(), '1.1', $headers);
 
         $this->assertTrue($request->expectsContinue());
@@ -36,7 +36,7 @@ class RequestTest extends TestCase
     /** @test */
     public function expectsContinueShouldBeFalseForHttp10()
     {
-        $headers = array('Expect' => '100-continue');
+        $headers = array('Expect' => array('100-continue'));
         $request = new Request('GET', '/', array(), '1.0', $headers);
 
         $this->assertFalse($request->expectsContinue());
@@ -55,10 +55,10 @@ class RequestTest extends TestCase
     public function testHeaderIsCaseInsensitive()
     {
         $request = new Request('GET', '/', array(), '1.1', array(
-            'TEST' => 'Yes',
+            'TEST' => array('Yes'),
         ));
 
-        $this->assertEquals(array('TEST' => 'Yes'), $request->getHeaders());
+        $this->assertEquals(array('TEST' => array('Yes')), $request->getHeaders());
         $this->assertTrue($request->hasHeader('Test'));
         $this->assertEquals(array('Yes'), $request->getHeader('Test'));
         $this->assertEquals('Yes', $request->getHeaderLine('Test'));


### PR DESCRIPTION
Change Request methods to be in line with PSR-7

* Rename `getQuery()` to `getQueryParams()`
* Rename `getHttpVersion()` to `getProtocolVersion()`
* Change `getHeaders()` to always return an array of string values
  for each header

Note that this does NOT implement the PSR-7 interfaces yet, it's merely a step towards removing differences between our interfaces and PSR-7.

Refs #28
Refs #103