### PR TITLE
The Server should always have a `request` listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ $http->on('request', function (Request $request, Response $response) {
 
 See also [`Request`](#request) and [`Response`](#response) for more details.
 
+> Note that you SHOULD always listen for the `request` event.
+Failing to do so will result in the server parsing the incoming request,
+but never sending a response back to the client.
+
 The `Server` supports both HTTP/1.1 and HTTP/1.0 request messages.
 If a client sends an invalid request message or uses an invalid HTTP protocol
 version, it will emit an `error` event, send an HTTP error response to the

--- a/src/Server.php
+++ b/src/Server.php
@@ -28,6 +28,10 @@ use React\Socket\ConnectionInterface;
  *
  * See also [`Request`](#request) and [`Response`](#response) for more details.
  *
+ * > Note that you SHOULD always listen for the `request` event.
+ *   Failing to do so will result in the server parsing the incoming request,
+ *   but never sending a response back to the client.
+ *
  * The `Server` supports both HTTP/1.1 and HTTP/1.0 request messages.
  * If a client sends an invalid request message or uses an invalid HTTP protocol
  * version, it will emit an `error` event, send an HTTP error response to the
@@ -117,12 +121,6 @@ class Server extends EventEmitter
 
         $response = new Response($conn, $request->getProtocolVersion());
         $response->on('close', array($request, 'close'));
-
-        if (!$this->listeners('request')) {
-            $response->end();
-
-            return;
-        }
 
         // attach remote ip to the request as metadata
         $request->remoteAddress = trim(

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -308,6 +308,28 @@ class ServerTest extends TestCase
         $this->assertContains("\r\n\r\nError 505: HTTP Version Not Supported", $buffer);
     }
 
+    public function testServerWithNoRequestListenerDoesNotSendAnythingToConnection()
+    {
+        $server = new Server($this->socket);
+
+        $this->connection
+            ->expects($this->never())
+            ->method('write');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('end');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('close');
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
     public function testParserErrorEmitted()
     {
         $error = null;


### PR DESCRIPTION
Having an HTTP server with no `request` listener does not really make any sense at all.

Currently, the `end()` call actually results in an invalid HTTP response stream, because it sends a closing chunk (chunked transfer encoding) without actually sending any HTTP response headers.

This simple PR changes it so that this case will simply not be handled at all, so that the client never receives any response data at all. This is actually in line with how our Socket component works if there's no `connection` listener.

Note that the invalid response stream will that is sent by `end()` will be addressed in a separate ticket, I'll link to this here once it's ready.