### PR TITLE
Send HTTP status code 400 for invalid requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ $http->on('request', function (Request $request, Response $response) {
 
 See also [`Request`](#request) and [`Response`](#response) for more details.
 
+If a client sends an invalid request message, it will emit an `error` event,
+send an HTTP error response to the client and close the connection:
+
+```php
+$http->on('error', function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+});
+```
+
 ### Request
 
 The `Request` class is responsible for streaming the incoming request body

--- a/src/Server.php
+++ b/src/Server.php
@@ -28,6 +28,15 @@ use React\Socket\ConnectionInterface;
  *
  * See also [`Request`](#request) and [`Response`](#response) for more details.
  *
+ * If a client sends an invalid request message, it will emit an `error` event,
+ * send an HTTP error response to the client and close the connection:
+ *
+ * ```php
+ * $http->on('error', function (Exception $e) {
+ *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
+ * });
+ * ```
+ *
  * @see Request
  * @see Response
  */


### PR DESCRIPTION
Currently, sending an invalid request will result in the connection simply being dropped.

This simple PR changes this to respond with an `HTTP/1.1 400 Bad request` message.

> Recipients of an invalid request-line SHOULD respond with […] a 400 (Bad Request) error […]

https://tools.ietf.org/html/rfc7230#section-3.1.1

This is also the base for some more (upcoming) error handling issues.
Builds on top of #123.