### PR TITLE
Support HTTP/1.1 and HTTP/1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ The `Server` is responsible for emitting `Request` and `Response` objects.
 The `Response` will automatically use the same HTTP protocol version as the
 corresponding `Request`.
 
+HTTP/1.1 responses will automatically apply chunked transfer encoding if
+no `Content-Length` header has been set.
+See [`writeHead()`](#writehead) for more details.
+
 See the above usage example and the class outline for details.
 
 #### writeContinue()
@@ -237,7 +241,7 @@ $response->end('Hello World!');
 
 Calling this method more than once will result in an `Exception`.
 
-Unless you specify a `Content-Length` header yourself, the response message
+Unless you specify a `Content-Length` header yourself, HTTP/1.1 responses
 will automatically use chunked transfer encoding and send the respective header
 (`Transfer-Encoding: chunked`) automatically. If you know the length of your
 body, you MAY specify it like this instead:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ $http->on('request', function (Request $request, Response $response) {
 
 See also [`Request`](#request) and [`Response`](#response) for more details.
 
-If a client sends an invalid request message, it will emit an `error` event,
-send an HTTP error response to the client and close the connection:
+The `Server` supports both HTTP/1.1 and HTTP/1.0 request messages.
+If a client sends an invalid request message or uses an invalid HTTP protocol
+version, it will emit an `error` event, send an HTTP error response to the
+client and close the connection:
 
 ```php
 $http->on('error', function (Exception $e) {

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ It implements the `WritableStreamInterface`.
 The constructor is internal, you SHOULD NOT call this yourself.
 The `Server` is responsible for emitting `Request` and `Response` objects.
 
+The `Response` will automatically use the same HTTP protocol version as the
+corresponding `Request`.
+
 See the above usage example and the class outline for details.
 
 #### writeContinue()

--- a/README.md
+++ b/README.md
@@ -217,12 +217,15 @@ $http->on('request', function (Request $request, Response $response) {
 });
 ```
 
-Note that calling this method is strictly optional.
-If you do not use it, then the client MUST continue sending the request body
-after waiting some time.
+Note that calling this method is strictly optional for HTTP/1.1 responses.
+If you do not use it, then a HTTP/1.1 client MUST continue sending the
+request body after waiting some time.
 
-This method MUST NOT be invoked after calling `writeHead()`.
-Calling this method after sending the headers will result in an `Exception`.
+This method MUST NOT be invoked after calling [`writeHead()`](#writehead).
+This method MUST NOT be invoked if this is not a HTTP/1.1 response
+(please check [`expectsContinue()`](#expectscontinue) as above).
+Calling this method after sending the headers or if this is not a HTTP/1.1
+response is an error that will result in an `Exception`.
 
 #### writeHead()
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -98,12 +98,15 @@ class Response extends EventEmitter implements WritableStreamInterface
      * });
      * ```
      *
-     * Note that calling this method is strictly optional.
-     * If you do not use it, then the client MUST continue sending the request body
-     * after waiting some time.
+     * Note that calling this method is strictly optional for HTTP/1.1 responses.
+     * If you do not use it, then a HTTP/1.1 client MUST continue sending the
+     * request body after waiting some time.
      *
      * This method MUST NOT be invoked after calling `writeHead()`.
-     * Calling this method after sending the headers will result in an `Exception`.
+     * This method MUST NOT be invoked if this is not a HTTP/1.1 response
+     * (please check [`expectsContinue()`] as above).
+     * Calling this method after sending the headers or if this is not a HTTP/1.1
+     * response is an error that will result in an `Exception`.
      *
      * @return void
      * @throws \Exception
@@ -111,6 +114,9 @@ class Response extends EventEmitter implements WritableStreamInterface
      */
     public function writeContinue()
     {
+        if ($this->protocolVersion !== '1.1') {
+            throw new \Exception('Continue requires a HTTP/1.1 message');
+        }
         if ($this->headWritten) {
             throw new \Exception('Response head has already been written.');
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -107,7 +107,7 @@ class Server extends EventEmitter
     /** @internal */
     public function handleRequest(ConnectionInterface $conn, Request $request)
     {
-        $response = new Response($conn);
+        $response = new Response($conn, $request->getProtocolVersion());
         $response->on('close', array($request, 'close'));
 
         if (!$this->listeners('request')) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -239,6 +239,20 @@ class ResponseTest extends TestCase
         $response->writeHead();
     }
 
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function writeContinueShouldThrowForHttp10()
+    {
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
+
+        $response = new Response($conn, '1.0');
+        $response->writeContinue();
+    }
+
     /** @test */
     public function shouldForwardEndDrainAndErrorEvents()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -26,6 +26,26 @@ class ResponseTest extends TestCase
         $response->writeHead();
     }
 
+    public function testResponseShouldUseGivenProtocolVersion()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.0 200 OK\r\n";
+        $expected .= "X-Powered-By: React/alpha\r\n";
+        $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn, '1.0');
+        $response->writeHead();
+    }
+
     public function testResponseShouldBeChunkedEvenWithOtherTransferEncoding()
     {
         $expected = '';
@@ -45,7 +65,6 @@ class ResponseTest extends TestCase
         $response = new Response($conn);
         $response->writeHead(200, array('transfer-encoding' => 'custom'));
     }
-
 
     public function testResponseShouldNotBeChunkedWithContentLength()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -26,12 +26,11 @@ class ResponseTest extends TestCase
         $response->writeHead();
     }
 
-    public function testResponseShouldUseGivenProtocolVersion()
+    public function testResponseShouldNotBeChunkedWhenProtocolVersionIsNot11()
     {
         $expected = '';
         $expected .= "HTTP/1.0 200 OK\r\n";
         $expected .= "X-Powered-By: React/alpha\r\n";
-        $expected .= "Transfer-Encoding: chunked\r\n";
         $expected .= "\r\n";
 
         $conn = $this

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -202,12 +202,12 @@ class ServerTest extends TestCase
         $this->assertContains("\r\nX-Powered-By: React/alpha\r\n", $buffer);
     }
 
-    public function testResponseContainsSameRequestProtocolVersionForHttp11()
+    public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
         $server = new Server($this->socket);
         $server->on('request', function (Request $request, Response $response) {
             $response->writeHead();
-            $response->end();
+            $response->end('bye');
         });
 
         $buffer = '';
@@ -229,14 +229,15 @@ class ServerTest extends TestCase
         $this->connection->emit('data', array($data));
 
         $this->assertContains("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertContains("\r\n\r\n3\r\nbye\r\n0\r\n\r\n", $buffer);
     }
 
-    public function testResponseContainsSameRequestProtocolVersionForHttp10()
+    public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
         $server = new Server($this->socket);
         $server->on('request', function (Request $request, Response $response) {
             $response->writeHead();
-            $response->end();
+            $response->end('bye');
         });
 
         $buffer = '';
@@ -258,6 +259,7 @@ class ServerTest extends TestCase
         $this->connection->emit('data', array($data));
 
         $this->assertContains("HTTP/1.0 200 OK\r\n", $buffer);
+        $this->assertContains("\r\n\r\nbye", $buffer);
     }
 
     public function testParserErrorEmitted()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -262,6 +262,38 @@ class ServerTest extends TestCase
         $this->assertContains("\r\n\r\nbye", $buffer);
     }
 
+    public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
+    {
+        $error = null;
+        $server = new Server($this->socket);
+        $server->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.2\r\nHost: localhost\r\n\r\n";
+        $this->connection->emit('data', array($data));
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+
+        $this->assertContains("HTTP/1.1 505 HTTP Version Not Supported\r\n", $buffer);
+        $this->assertContains("\r\n\r\nError 505: HTTP Version Not Supported", $buffer);
+    }
+
     public function testParserErrorEmitted()
     {
         $error = null;

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -202,6 +202,64 @@ class ServerTest extends TestCase
         $this->assertContains("\r\nX-Powered-By: React/alpha\r\n", $buffer);
     }
 
+    public function testResponseContainsSameRequestProtocolVersionForHttp11()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request, Response $response) {
+            $response->writeHead();
+            $response->end();
+        });
+
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n\r\n";
+        $this->connection->emit('data', array($data));
+
+        $this->assertContains("HTTP/1.1 200 OK\r\n", $buffer);
+    }
+
+    public function testResponseContainsSameRequestProtocolVersionForHttp10()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request, Response $response) {
+            $response->writeHead();
+            $response->end();
+        });
+
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.0\r\n\r\n";
+        $this->connection->emit('data', array($data));
+
+        $this->assertContains("HTTP/1.0 200 OK\r\n", $buffer);
+    }
+
     public function testParserErrorEmitted()
     {
         $error = null;


### PR DESCRIPTION
* Response uses same HTTP protocol version as corresponding request
* Apply chunked transfer encoding only for HTTP/1.1 responses by default
* Ensure writeContinue() only works for HTTP/1.1 messages
* Only support HTTP/1.1 and HTTP/1.0 requests

Closes #121