### PR TITLE
Send HTTP status code 431 if request header is too large

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -105,7 +105,7 @@ class Server extends EventEmitter
 
             $that->writeError(
                 $conn,
-                400
+                ($e instanceof \OverflowException) ? 431 : 400
             );
         });
     }


### PR DESCRIPTION
Currently, sending an invalid request results in the same error message as sending a valid request that is too large: `HTTP/1.1 400 Bad Request`.

This simple PR change it so that the latter will now use the more descriptive error message: `HTTP/1.1 431 Request Header Fields Too Large`

Builds on top of #124