### PR TITLE
Handle 'Content-Length' requests

### DIFF
--- a/src/LengthLimitedStream.php
+++ b/src/LengthLimitedStream.php
@@ -95,8 +95,7 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
     public function handleEnd()
     {
         if (!$this->closed) {
-            $this->emit('end');
-            $this->close();
+            $this->handleError(new \Exception('Unexpected end event'));
         }
     }
 

--- a/src/LengthLimitedStream.php
+++ b/src/LengthLimitedStream.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+/** @internal */
+class LengthLimitedStream extends EventEmitter implements ReadableStreamInterface
+{
+    private $stream;
+    private $closed = false;
+    private $encoder;
+    private $transferredLength = 0;
+    private $maxLength;
+
+    public function __construct(ReadableStreamInterface $stream, $maxLength)
+    {
+        $this->stream = $stream;
+        $this->maxLength = $maxLength;
+
+        $this->stream->on('data', array($this, 'handleData'));
+        $this->stream->on('end', array($this, 'handleEnd'));
+        $this->stream->on('error', array($this, 'handleError'));
+        $this->stream->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->stream->isReadable();
+    }
+
+    public function pause()
+    {
+        $this->stream->pause();
+    }
+
+    public function resume()
+    {
+        $this->stream->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        $this->stream->close();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    /** @internal */
+    public function handleData($data)
+    {
+        if (($this->transferredLength + strlen($data)) > $this->maxLength) {
+            // Only emit data until the value of 'Content-Length' is reached, the rest will be ignored
+            $data = (string)substr($data, 0, $this->maxLength - $this->transferredLength);
+        }
+
+        if ($data !== '') {
+            $this->transferredLength += strlen($data);
+            $this->emit('data', array($data));
+        }
+
+        if ($this->transferredLength === $this->maxLength) {
+            // 'Content-Length' reached, stream will end
+            $this->emit('end');
+            $this->close();
+            $this->stream->removeListener('data', array($this, 'handleData'));
+        }
+    }
+
+    /** @internal */
+    public function handleError(\Exception $e)
+    {
+        $this->emit('error', array($e));
+        $this->close();
+    }
+
+    /** @internal */
+    public function handleEnd()
+    {
+        if (!$this->closed) {
+            $this->emit('end');
+            $this->close();
+        }
+    }
+
+}

--- a/tests/LengthLimitedStreamTest.php
+++ b/tests/LengthLimitedStreamTest.php
@@ -105,4 +105,16 @@ class LengthLimitedStreamTest extends TestCase
 
         $this->assertFalse($input->isReadable());
     }
+
+    public function testHandleUnexpectedEnd()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+
+        $stream->on('data', $this->expectCallableNever());
+        $stream->on('close', $this->expectCallableOnce());
+        $stream->on('end', $this->expectCallableNever());
+        $stream->on('error', $this->expectCallableOnce());
+
+        $this->input->emit('end');
+    }
 }

--- a/tests/LengthLimitedStreamTest.php
+++ b/tests/LengthLimitedStreamTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace React\Tests\Http;
+
+use React\Http\LengthLimitedStream;
+use React\Stream\ReadableStream;
+
+class LengthLimitedStreamTest extends TestCase
+{
+    private $input;
+    private $stream;
+
+    public function setUp()
+    {
+        $this->input = new ReadableStream();
+    }
+
+    public function testSimpleChunk()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+        $stream->on('data', $this->expectCallableOnceWith('hello'));
+        $stream->on('end', $this->expectCallableOnce());
+        $this->input->emit('data', array("hello world"));
+    }
+
+    public function testInputStreamKeepsEmitting()
+    {
+        $stream = new LengthLimitedStream($this->input, 5);
+        $stream->on('data', $this->expectCallableOnceWith('hello'));
+        $stream->on('end', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("hello world"));
+        $this->input->emit('data', array("world"));
+        $this->input->emit('data', array("world"));
+    }
+
+    public function testZeroLengthInContentLengthWillIgnoreEmittedDataEvents()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('data', $this->expectCallableNever());
+        $stream->on('end', $this->expectCallableOnce());
+        $this->input->emit('data', array("hello world"));
+    }
+
+    public function testHandleError()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('error', $this->expectCallableOnce());
+        $stream->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('error', array(new \RuntimeException()));
+
+        $this->assertFalse($stream->isReadable());
+    }
+
+    public function testPauseStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->pause();
+    }
+
+    public function testResumeStream()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input->expects($this->once())->method('pause');
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->pause();
+        $stream->resume();
+    }
+
+    public function testPipeStream()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $ret = $stream->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testHandleClose()
+    {
+        $stream = new LengthLimitedStream($this->input, 0);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $this->input->close();
+        $this->input->emit('end', array());
+
+        $this->assertFalse($stream->isReadable());
+    }
+
+    public function testOutputStreamCanCloseInputStream()
+    {
+        $input = new ReadableStream();
+        $input->on('close', $this->expectCallableOnce());
+
+        $stream = new LengthLimitedStream($input, 0);
+        $stream->on('close', $this->expectCallableOnce());
+
+        $stream->close();
+
+        $this->assertFalse($input->isReadable());
+    }
+}

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -775,7 +775,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableNever();
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -802,7 +802,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableNever();
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -830,7 +830,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableNever();
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -853,6 +853,156 @@ class ServerTest extends TestCase
         $data = "hello";
 
         $this->connection->emit('data', array($data));
+    }
+
+    public function testContentLengthWillBeIgnoredIfTransferEncodingIsSet()
+    {
+        $server = new Server($this->socket);
+
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+        $closeEvent = $this->expectCallableOnce();
+        $errorEvent = $this->expectCallableNever();
+
+        $requestValidation = null;
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
+            $request->on('close', $closeEvent);
+            $request->on('error', $errorEvent);
+            $requestValidation = $request;
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Content-Length: 4\r\n";
+        $data .= "Transfer-Encoding: chunked\r\n";
+        $data .= "\r\n";
+
+        $this->connection->emit('data', array($data));
+
+        $data = "5\r\nhello\r\n";
+        $data .= "0\r\n\r\n";
+
+        $this->connection->emit('data', array($data));
+        $this->assertEquals('4', $requestValidation->getHeaderLine('Content-Length'));
+        $this->assertEquals('chunked', $requestValidation->getHeaderLine('Transfer-Encoding'));
+    }
+
+    public function testInvalidContentLengthWillBeIgnoreddIfTransferEncodingIsSet()
+    {
+        $server = new Server($this->socket);
+
+        $dataEvent = $this->expectCallableOnceWith('hello');
+        $endEvent = $this->expectCallableOnce();
+        $closeEvent = $this->expectCallableOnce();
+        $errorEvent = $this->expectCallableNever();
+
+        $requestValidation = null;
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
+            $request->on('close', $closeEvent);
+            $request->on('error', $errorEvent);
+            $requestValidation = $request;
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Content-Length: hello world\r\n";
+        $data .= "Transfer-Encoding: chunked\r\n";
+        $data .= "\r\n";
+
+        $this->connection->emit('data', array($data));
+
+        $data = "5\r\nhello\r\n";
+        $data .= "0\r\n\r\n";
+
+        $this->connection->emit('data', array($data));
+
+        // this is valid behavior according to: https://www.ietf.org/rfc/rfc2616.txt chapter 4.4
+        $this->assertEquals('hello world', $requestValidation->getHeaderLine('Content-Length'));
+        $this->assertEquals('chunked', $requestValidation->getHeaderLine('Transfer-Encoding'));
+    }
+
+    public function testNonIntegerContentLengthValueWillLeadToError()
+    {
+        $error = null;
+        $server = new Server($this->socket);
+        $server->on('request', $this->expectCallableNever());
+        $server->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Content-Length: bla\r\n";
+        $data .= "\r\n";
+        $data .= "hello";
+
+        $this->connection->emit('data', array($data));
+
+        $this->assertContains("HTTP/1.1 400 Bad Request\r\n", $buffer);
+        $this->assertContains("\r\n\r\nError 400: Bad Request", $buffer);
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+    }
+
+    public function testMultipleIntegerInContentLengthWillLeadToError()
+    {
+        $error = null;
+        $server = new Server($this->socket);
+        $server->on('request', $this->expectCallableNever());
+        $server->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Content-Length: 5, 3, 4\r\n";
+        $data .= "\r\n";
+        $data .= "hello";
+
+        $this->connection->emit('data', array($data));
+
+        $this->assertContains("HTTP/1.1 400 Bad Request\r\n", $buffer);
+        $this->assertContains("\r\n\r\nError 400: Bad Request", $buffer);
+        $this->assertInstanceOf('InvalidArgumentException', $error);
     }
 
     private function createGetRequest()


### PR DESCRIPTION
Currently `Content-Length` requests aren't checked for the transferred length.
The new class ensures that only the correct length will be transferred and a correct `end` event will be emitted.
