### PR TITLE
Request closes after forwarding close event

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -174,18 +174,30 @@ class Request extends EventEmitter implements ReadableStreamInterface
 
     public function pause()
     {
+        if (!$this->readable) {
+            return;
+        }
+
         $this->emit('pause');
     }
 
     public function resume()
     {
+        if (!$this->readable) {
+            return;
+        }
+
         $this->emit('resume');
     }
 
     public function close()
     {
+        if (!$this->readable) {
+            return;
+        }
+
         $this->readable = false;
-        $this->emit('end');
+        $this->emit('close');
         $this->removeAllListeners();
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -75,4 +75,43 @@ class RequestTest extends TestCase
         $this->assertEquals(array('a', 'b'), $request->getHeader('Test'));
         $this->assertEquals('a, b', $request->getHeaderLine('Test'));
     }
+
+    public function testCloseEmitsCloseEvent()
+    {
+        $request = new Request('GET', '/');
+
+        $request->on('close', $this->expectCallableOnce());
+
+        $request->close();
+    }
+
+    public function testCloseMultipleTimesEmitsCloseEventOnce()
+    {
+        $request = new Request('GET', '/');
+
+        $request->on('close', $this->expectCallableOnce());
+
+        $request->close();
+        $request->close();
+    }
+
+    public function testIsNotReadableAfterClose()
+    {
+        $request = new Request('GET', '/');
+
+        $request->close();
+
+        $this->assertFalse($request->isReadable());
+    }
+
+    public function testPipeReturnsDest()
+    {
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $request = new Request('GET', '/');
+
+        $ret = $request->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -131,6 +131,37 @@ class ServerTest extends TestCase
         $this->connection->emit('data', array($data));
     }
 
+    public function testRequestPauseAfterCloseWillNotBeForwarded()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request) {
+            $request->close();
+            $request->pause();
+        });
+
+        $this->connection->expects($this->once())->method('pause');
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
+    public function testRequestResumeAfterCloseWillNotBeForwarded()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request) {
+            $request->close();
+            $request->resume();
+        });
+
+        $this->connection->expects($this->once())->method('pause');
+        $this->connection->expects($this->never())->method('resume');
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
     public function testRequestEventWithoutBodyWillNotEmitData()
     {
         $never = $this->expectCallableNever();
@@ -391,7 +422,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableOnceWith('hello');
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -420,7 +451,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableOnceWith('hello');
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -450,7 +481,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableNever();
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -478,7 +509,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableOnceWith('hello');
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
@@ -507,7 +538,7 @@ class ServerTest extends TestCase
 
         $dataEvent = $this->expectCallableOnceWith('hello');
         $endEvent = $this->expectCallableOnce();
-        $closeEvent = $this->expectCallableNever();
+        $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
         $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {


### PR DESCRIPTION
The `Request` now follows normal stream event semantics and actually closes after forwarding the `close` event.

Refs #104