### PR TITLE
Response closes after forwarding close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ This method MUST NOT be invoked after calling [`writeHead()`](#writehead).
 This method MUST NOT be invoked if this is not a HTTP/1.1 response
 (please check [`expectsContinue()`](#expectscontinue) as above).
 Calling this method after sending the headers or if this is not a HTTP/1.1
-response is an error that will result in an `Exception`.
+response is an error that will result in an `Exception`
+(unless the response has ended/closed already).
+Calling this method after the response has ended/closed is a NOOP.
 
 #### writeHead()
 
@@ -248,7 +250,9 @@ $response->writeHead(200, array(
 $response->end('Hello World!');
 ```
 
-Calling this method more than once will result in an `Exception`.
+Calling this method more than once will result in an `Exception`
+(unless the response has ended/closed already).
+Calling this method after the response has ended/closed is a NOOP.
 
 Unless you specify a `Content-Length` header yourself, HTTP/1.1 responses
 will automatically use chunked transfer encoding and send the respective header

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -249,6 +249,23 @@ class ServerTest extends TestCase
         $this->assertContains("\r\nX-Powered-By: React/alpha\r\n", $buffer);
     }
 
+    public function testClosingResponseDoesNotSendAnyData()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function (Request $request, Response $response) {
+            $response->close();
+        });
+
+        $this->connection->expects($this->never())->method('write');
+        $this->connection->expects($this->never())->method('end');
+        $this->connection->expects($this->once())->method('close');
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
         $server = new Server($this->socket);


### PR DESCRIPTION
The `Response` now follows normal stream event semantics and actually closes after forwarding the `close` event. In the same vein, writing after an `end()` or `close()` is now a NOOP as expected.

Refs #104
Refs #130