### PR TITLE
Request stream will now be handled internally

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -55,21 +55,7 @@ class RequestHeaderParser extends EventEmitter
     {
         list($headers, $bodyBuffer) = explode("\r\n\r\n", $data, 2);
 
-        $psrRequest = g7\parse_request($headers);
-
-        $parsedQuery = array();
-        $queryString = $psrRequest->getUri()->getQuery();
-        if ($queryString) {
-            parse_str($queryString, $parsedQuery);
-        }
-
-        $request = new Request(
-            $psrRequest->getMethod(),
-            $psrRequest->getUri()->getPath(),
-            $parsedQuery,
-            $psrRequest->getProtocolVersion(),
-            $psrRequest->getHeaders()
-        );
+        $request = g7\parse_request($headers);
 
         return array($request, $bodyBuffer);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -149,30 +149,13 @@ class Server extends EventEmitter
             }
         }
 
-        $request = new Request($request);
+        $request = new Request($request, $stream);
 
         // attach remote ip to the request as metadata
         $request->remoteAddress = trim(
             parse_url('tcp://' . $conn->getRemoteAddress(), PHP_URL_HOST),
             '[]'
         );
-
-        // forward pause/resume calls to underlying connection
-        $request->on('pause', array($conn, 'pause'));
-        $request->on('resume', array($conn, 'resume'));
-
-        // request closed => stop reading from the stream by pausing it
-        // stream closed => close request
-        $request->on('close', array($stream, 'pause'));
-        $stream->on('close', array($request, 'close'));
-
-        // forward data and end events from body stream to request
-        $stream->on('end', function() use ($request) {
-            $request->emit('end');
-        });
-        $stream->on('data', function ($data) use ($request) {
-            $request->emit('data', array($data));
-        });
 
         $this->emit('request', array($request, $response));
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ namespace React\Http;
 use Evenement\EventEmitter;
 use React\Socket\ServerInterface as SocketServerInterface;
 use React\Socket\ConnectionInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * The `Server` class is responsible for handling incoming connections and then
@@ -87,7 +88,7 @@ class Server extends EventEmitter
         $that = $this;
         $parser = new RequestHeaderParser();
         $listener = array($parser, 'feed');
-        $parser->on('headers', function (Request $request, $bodyBuffer) use ($conn, $listener, $parser, $that) {
+        $parser->on('headers', function (RequestInterface $request, $bodyBuffer) use ($conn, $listener, $parser, $that) {
             // parsing request completed => stop feeding parser
             $conn->removeListener('data', $listener);
 
@@ -111,7 +112,7 @@ class Server extends EventEmitter
     }
 
     /** @internal */
-    public function handleRequest(ConnectionInterface $conn, Request $request)
+    public function handleRequest(ConnectionInterface $conn, RequestInterface $request)
     {
         // only support HTTP/1.1 and HTTP/1.0 requests
         if ($request->getProtocolVersion() !== '1.1' && $request->getProtocolVersion() !== '1.0') {
@@ -138,13 +139,6 @@ class Server extends EventEmitter
         }
 
         $response = new Response($conn, $request->getProtocolVersion());
-        $response->on('close', array($request, 'close'));
-
-        // attach remote ip to the request as metadata
-        $request->remoteAddress = trim(
-            parse_url('tcp://' . $conn->getRemoteAddress(), PHP_URL_HOST),
-            '[]'
-        );
 
         $stream = $conn;
         if ($request->hasHeader('Transfer-Encoding')) {
@@ -154,6 +148,26 @@ class Server extends EventEmitter
                 $stream = new ChunkedDecoder($conn);
             }
         }
+
+        $parsedQuery = array();
+        $queryString = $request->getUri()->getQuery();
+        if ($queryString) {
+            parse_str($queryString, $parsedQuery);
+        }
+
+        $request = new Request(
+            $request->getMethod(),
+            $request->getUri()->getPath(),
+            $parsedQuery,
+            $request->getProtocolVersion(),
+            $request->getHeaders()
+        );
+
+        // attach remote ip to the request as metadata
+        $request->remoteAddress = trim(
+            parse_url('tcp://' . $conn->getRemoteAddress(), PHP_URL_HOST),
+            '[]'
+        );
 
         // forward pause/resume calls to underlying connection
         $request->on('pause', array($conn, 'pause'));

--- a/src/Server.php
+++ b/src/Server.php
@@ -149,19 +149,7 @@ class Server extends EventEmitter
             }
         }
 
-        $parsedQuery = array();
-        $queryString = $request->getUri()->getQuery();
-        if ($queryString) {
-            parse_str($queryString, $parsedQuery);
-        }
-
-        $request = new Request(
-            $request->getMethod(),
-            $request->getUri()->getPath(),
-            $parsedQuery,
-            $request->getProtocolVersion(),
-            $request->getHeaders()
-        );
+        $request = new Request($request);
 
         // attach remote ip to the request as metadata
         $request->remoteAddress = trim(

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -45,10 +45,9 @@ class RequestHeaderParserTest extends TestCase
         $data .= 'RANDOM DATA';
         $parser->feed($data);
 
-        $this->assertInstanceOf('React\Http\Request', $request);
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
         $this->assertSame('GET', $request->getMethod());
-        $this->assertSame('/', $request->getPath());
-        $this->assertSame(array(), $request->getQueryParams());
+        $this->assertEquals('http://example.com/', $request->getUri());
         $this->assertSame('1.1', $request->getProtocolVersion());
         $this->assertSame(array('Host' => array('example.com:80'), 'Connection' => array('close')), $request->getHeaders());
 
@@ -83,10 +82,9 @@ class RequestHeaderParserTest extends TestCase
         $data = $this->createAdvancedPostRequest();
         $parser->feed($data);
 
-        $this->assertInstanceOf('React\Http\Request', $request);
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
         $this->assertSame('POST', $request->getMethod());
-        $this->assertSame('/foo', $request->getPath());
-        $this->assertSame(array('bar' => 'baz'), $request->getQueryParams());
+        $this->assertEquals('http://example.com/foo?bar=baz', $request->getUri());
         $this->assertSame('1.1', $request->getProtocolVersion());
         $headers = array(
             'Host' => array('example.com:80'),

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -7,11 +7,18 @@ use RingCentral\Psr7\Request as Psr;
 
 class RequestTest extends TestCase
 {
+    private $stream;
+
+    public function setUp()
+    {
+        $this->stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+    }
+
     /** @test */
     public function expectsContinueShouldBeFalseByDefault()
     {
         $headers = array();
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
 
         $this->assertFalse($request->expectsContinue());
     }
@@ -20,7 +27,7 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeTrueIfContinueExpected()
     {
         $headers = array('Expect' => array('100-continue'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
 
         $this->assertTrue($request->expectsContinue());
     }
@@ -29,7 +36,7 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
     {
         $headers = array('EXPECT' => array('100-CONTINUE'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
 
         $this->assertTrue($request->expectsContinue());
     }
@@ -38,14 +45,14 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeFalseForHttp10()
     {
         $headers = array('Expect' => array('100-continue'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.0'));
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.0'), $this->stream);
 
         $this->assertFalse($request->expectsContinue());
     }
 
     public function testEmptyHeader()
     {
-        $request = new Request(new Psr('GET', '/', array()));
+        $request = new Request(new Psr('GET', '/', array()), $this->stream);
 
         $this->assertEquals(array(), $request->getHeaders());
         $this->assertFalse($request->hasHeader('Test'));
@@ -57,7 +64,7 @@ class RequestTest extends TestCase
     {
         $request = new Request(new Psr('GET', '/', array(
             'TEST' => array('Yes'),
-        )));
+        )), $this->stream);
 
         $this->assertEquals(array('TEST' => array('Yes')), $request->getHeaders());
         $this->assertTrue($request->hasHeader('Test'));
@@ -69,7 +76,7 @@ class RequestTest extends TestCase
     {
         $request = new Request(new Psr('GET', '/', array(
             'Test' => array('a', 'b'),
-        )));
+        )), $this->stream);
 
         $this->assertEquals(array('Test' => array('a', 'b')), $request->getHeaders());
         $this->assertTrue($request->hasHeader('Test'));
@@ -79,7 +86,7 @@ class RequestTest extends TestCase
 
     public function testCloseEmitsCloseEvent()
     {
-        $request = new Request(new Psr('GET', '/'));
+        $request = new Request(new Psr('GET', '/'), $this->stream);
 
         $request->on('close', $this->expectCallableOnce());
 
@@ -88,7 +95,7 @@ class RequestTest extends TestCase
 
     public function testCloseMultipleTimesEmitsCloseEventOnce()
     {
-        $request = new Request(new Psr('GET', '/'));
+        $request = new Request(new Psr('GET', '/'), $this->stream);
 
         $request->on('close', $this->expectCallableOnce());
 
@@ -96,20 +103,48 @@ class RequestTest extends TestCase
         $request->close();
     }
 
+    public function testCloseWillPauseUnderlyingStream()
+    {
+        $this->stream->expects($this->once())->method('pause');
+        $this->stream->expects($this->never())->method('close');
+
+        $request = new Request(new Psr('GET', '/'), $this->stream);
+
+        $request->close();
+    }
+
     public function testIsNotReadableAfterClose()
     {
-        $request = new Request(new Psr('GET', '/'));
+        $request = new Request(new Psr('GET', '/'), $this->stream);
 
         $request->close();
 
         $this->assertFalse($request->isReadable());
     }
 
+    public function testPauseWillBeForwarded()
+    {
+        $this->stream->expects($this->once())->method('pause');
+
+        $request = new Request(new Psr('GET', '/'), $this->stream);
+
+        $request->pause();
+    }
+
+    public function testResumeWillBeForwarded()
+    {
+        $this->stream->expects($this->once())->method('resume');
+
+        $request = new Request(new Psr('GET', '/'), $this->stream);
+
+        $request->resume();
+    }
+
     public function testPipeReturnsDest()
     {
         $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
 
-        $request = new Request(new Psr('GET', '/'));
+        $request = new Request(new Psr('GET', '/'), $this->stream);
 
         $ret = $request->pipe($dest);
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Http;
 
 use React\Http\Request;
+use RingCentral\Psr7\Request as Psr;
 
 class RequestTest extends TestCase
 {
@@ -10,7 +11,7 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeFalseByDefault()
     {
         $headers = array();
-        $request = new Request('GET', '/', array(), '1.1', $headers);
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
 
         $this->assertFalse($request->expectsContinue());
     }
@@ -19,7 +20,7 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeTrueIfContinueExpected()
     {
         $headers = array('Expect' => array('100-continue'));
-        $request = new Request('GET', '/', array(), '1.1', $headers);
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
 
         $this->assertTrue($request->expectsContinue());
     }
@@ -28,7 +29,7 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
     {
         $headers = array('EXPECT' => array('100-CONTINUE'));
-        $request = new Request('GET', '/', array(), '1.1', $headers);
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'));
 
         $this->assertTrue($request->expectsContinue());
     }
@@ -37,14 +38,14 @@ class RequestTest extends TestCase
     public function expectsContinueShouldBeFalseForHttp10()
     {
         $headers = array('Expect' => array('100-continue'));
-        $request = new Request('GET', '/', array(), '1.0', $headers);
+        $request = new Request(new Psr('GET', '/', $headers, null, '1.0'));
 
         $this->assertFalse($request->expectsContinue());
     }
 
     public function testEmptyHeader()
     {
-        $request = new Request('GET', '/');
+        $request = new Request(new Psr('GET', '/', array()));
 
         $this->assertEquals(array(), $request->getHeaders());
         $this->assertFalse($request->hasHeader('Test'));
@@ -54,9 +55,9 @@ class RequestTest extends TestCase
 
     public function testHeaderIsCaseInsensitive()
     {
-        $request = new Request('GET', '/', array(), '1.1', array(
+        $request = new Request(new Psr('GET', '/', array(
             'TEST' => array('Yes'),
-        ));
+        )));
 
         $this->assertEquals(array('TEST' => array('Yes')), $request->getHeaders());
         $this->assertTrue($request->hasHeader('Test'));
@@ -66,9 +67,9 @@ class RequestTest extends TestCase
 
     public function testHeaderWithMultipleValues()
     {
-        $request = new Request('GET', '/', array(), '1.1', array(
+        $request = new Request(new Psr('GET', '/', array(
             'Test' => array('a', 'b'),
-        ));
+        )));
 
         $this->assertEquals(array('Test' => array('a', 'b')), $request->getHeaders());
         $this->assertTrue($request->hasHeader('Test'));
@@ -78,7 +79,7 @@ class RequestTest extends TestCase
 
     public function testCloseEmitsCloseEvent()
     {
-        $request = new Request('GET', '/');
+        $request = new Request(new Psr('GET', '/'));
 
         $request->on('close', $this->expectCallableOnce());
 
@@ -87,7 +88,7 @@ class RequestTest extends TestCase
 
     public function testCloseMultipleTimesEmitsCloseEventOnce()
     {
-        $request = new Request('GET', '/');
+        $request = new Request(new Psr('GET', '/'));
 
         $request->on('close', $this->expectCallableOnce());
 
@@ -97,7 +98,7 @@ class RequestTest extends TestCase
 
     public function testIsNotReadableAfterClose()
     {
-        $request = new Request('GET', '/');
+        $request = new Request(new Psr('GET', '/'));
 
         $request->close();
 
@@ -108,7 +109,7 @@ class RequestTest extends TestCase
     {
         $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
 
-        $request = new Request('GET', '/');
+        $request = new Request(new Psr('GET', '/'));
 
         $ret = $request->pipe($dest);
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -83,6 +83,7 @@ class ServerTest extends TestCase
         $this->assertSame(1, $i);
         $this->assertInstanceOf('React\Http\Request', $requestAssertion);
         $this->assertSame('/', $requestAssertion->getPath());
+        $this->assertSame(array(), $requestAssertion->getQueryParams());
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('127.0.0.1', $requestAssertion->remoteAddress);
 


### PR DESCRIPTION
Refactor the `Request` object to handle its request stream internally (Law of Demeter). This helps reducing coupling and simplifies adding future PSR-7 methods. All public interfaces are preserved as-is.

Builds on top of #130 and #123
This is now in line with #131 (`Response` side of things)
Refs #104
Refs #28