### PR TITLE
Protect the TCP connection against close from other streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ $http->on('error', function (Exception $e) {
 });
 ```
 
+An `error` event will be emitted for the `Request` if the validation of the body data fails.
+This can be e.g. invalid chunked decoded data or an unexpected `end` event.
+
+```php
+$http->on('request', function (Request $request, Response $response) {
+    $request->on('error', function (\Exception $error) {
+        echo $error->getMessage();
+    });
+});
+```
+
+Such an error will `pause` the connection instead of closing it. A response message
+can still be sent.
+
 ### Request
 
 The `Request` class is responsible for streaming the incoming request body

--- a/src/CloseProtectionStream.php
+++ b/src/CloseProtectionStream.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace React\Http;
+
+use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+/** @internal
+ * This stream is used to protect the passed stream against closing.
+ * */
+class CloseProtectionStream extends EventEmitter implements ReadableStreamInterface
+{
+    private $connection;
+    private $closed = false;
+
+    /**
+     * @param ReadableStreamInterface $input stream that will be paused instead of closed on an 'close' event.
+     */
+    public function __construct(ReadableStreamInterface $input)
+    {
+        $this->input = $input;
+
+        $this->input->on('data', array($this, 'handleData'));
+        $this->input->on('end', array($this, 'handleEnd'));
+        $this->input->on('error', array($this, 'handleError'));
+        $this->input->on('close', array($this, 'close'));
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed && $this->input->isReadable();
+    }
+
+    public function pause()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->input->pause();
+    }
+
+    public function resume()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->input->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        Util::pipe($this, $dest, $options);
+
+        return $dest;
+    }
+
+     public function close()
+     {
+         if ($this->closed) {
+             return;
+         }
+
+         $this->closed = true;
+
+         $this->emit('close');
+
+         // 'pause' the stream avoids additional traffic transferred by this stream
+         $this->input->pause();
+
+         $this->input->removeListener('data', array($this, 'handleData'));
+         $this->input->removeListener('error', array($this, 'handleError'));
+         $this->input->removeListener('end', array($this, 'handleEnd'));
+         $this->input->removeListener('close', array($this, 'close'));
+
+         $this->removeAllListeners();
+     }
+
+     /** @internal */
+     public function handleData($data)
+     {
+        $this->emit('data', array($data));
+     }
+
+     /** @internal */
+     public function handleEnd()
+     {
+         $this->emit('end');
+         $this->close();
+     }
+
+     /** @internal */
+     public function handleError(\Exception $e)
+     {
+         $this->emit('error', array($e));
+     }
+
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -196,9 +196,8 @@ class Request extends EventEmitter implements ReadableStreamInterface
             return;
         }
 
-        // request closed => stop reading from the stream by pausing it
         $this->readable = false;
-        $this->stream->pause();
+        $this->stream->close();
 
         $this->emit('close');
         $this->removeAllListeners();

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -103,10 +103,9 @@ class RequestTest extends TestCase
         $request->close();
     }
 
-    public function testCloseWillPauseUnderlyingStream()
+    public function testCloseWillCloseUnderlyingStream()
     {
-        $this->stream->expects($this->once())->method('pause');
-        $this->stream->expects($this->never())->method('close');
+        $this->stream->expects($this->once())->method('close');
 
         $request = new Request(new Psr('GET', '/'), $this->stream);
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1031,6 +1031,9 @@ class ServerTest extends TestCase
             $request->on('error', $errorEvent);
         });
 
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1050,6 +1053,9 @@ class ServerTest extends TestCase
         $server->on('request', function ($request, $response) use ($errorEvent){
             $request->on('error', $errorEvent);
         });
+
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
 
         $this->socket->emit('connection', array($this->connection));
 
@@ -1073,6 +1079,9 @@ class ServerTest extends TestCase
             $request->on('error', $errorEvent);
         });
 
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1093,6 +1102,9 @@ class ServerTest extends TestCase
             $request->on('error', $errorEvent);
         });
 
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1111,6 +1123,9 @@ class ServerTest extends TestCase
         $server = new Server($this->socket);
         $server->on('request', $this->expectCallableOnce());
 
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1128,6 +1143,9 @@ class ServerTest extends TestCase
         $server = new Server($this->socket);
         $server->on('request', $this->expectCallableOnce());
 
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1139,6 +1157,22 @@ class ServerTest extends TestCase
 
         $this->connection->emit('data', array($data));
         $this->connection->emit('end');
+    }
+
+    public function testCloseRequestWillPauseConnection()
+    {
+        $server = new Server($this->socket);
+        $server->on('request', function ($request, $response) {
+            $request->close();
+        });
+
+        $this->connection->expects($this->never())->method('close');
+        $this->connection->expects($this->once())->method('pause');
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
     }
 
     private function createGetRequest()


### PR DESCRIPTION
Currently the `ChunkedDecoder ` and the `LengthLimitedStream` emit errors, but these errors aren't handled anywhere.
This takes care that theses errors will be forwarded to the request object.

This PR also adds an CloseProtectionStream to protect the TCP connection against a close , when an error occurs in any stream. Instead of closing the TCP stream it will be paused, similar to the current behavior of the request object.