### PR TITLE
Trim leading zeros of chunk headers in ChunkedDecoder

### DIFF
--- a/src/ChunkedDecoder.php
+++ b/src/ChunkedDecoder.php
@@ -108,6 +108,13 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                     $hexValue = $array[0];
                 }
 
+                if ($hexValue !== '') {
+                    $hexValue = ltrim($hexValue, "0");
+                    if ($hexValue === '') {
+                        $hexValue = "0";
+                    }
+                }
+
                 $this->chunkSize = hexdec($hexValue);
                 if (dechex($this->chunkSize) !== $hexValue) {
                     $this->handleError(new \Exception($hexValue . ' is not a valid hexadecimal number'));


### PR DESCRIPTION
Thanks to @maciejmrozinski that found this behavior in the http-client([link to PR](https://github.com/reactphp/http-client/pull/73)).

According to https://tools.ietf.org/html/rfc7230#section-4.1

>  chunk-size     = 1\*HEXDIG
>  last-chunk     = 1*("0") [ chunk-ext ] CRLF

leading zeros are allowed as value for the header of each chunk.
So e.g. `0005` `00ab` and `000000` are valid values.

Currently this will lead to an error event, because `hexdec` and `dechex` will remove the leading zeros, so the assertion will fail. This PR takes care of this problem and will allow leading zeros.