### PR TITLE
Emit end event for requests without body

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -170,6 +170,12 @@ class Server extends EventEmitter
 
         $this->emit('request', array($request, $response));
 
+        if ($stream instanceof CloseProtectionStream) {
+            $request->emit('end');
+            $request->close();
+            return;
+        }
+
         if ($stream instanceof LengthLimitedStream && $contentLength === 0) {
             // Content-Length is 0 and won't emit further data,
             // 'handleData' from LengthLimitedStream won't be called anymore

--- a/src/Server.php
+++ b/src/Server.php
@@ -140,12 +140,14 @@ class Server extends EventEmitter
 
         $response = new Response($conn, $request->getProtocolVersion());
 
+        $contentLength = 0;
         $stream = new CloseProtectionStream($conn);
         if ($request->hasHeader('Transfer-Encoding')) {
             $transferEncodingHeader = $request->getHeader('Transfer-Encoding');
             // 'chunked' must always be the final value of 'Transfer-Encoding' according to: https://tools.ietf.org/html/rfc7230#section-3.3.1
             if (strtolower(end($transferEncodingHeader)) === 'chunked') {
                 $stream = new ChunkedDecoder($stream);
+                $contentLength = null;
             }
         } elseif ($request->hasHeader('Content-Length')) {
             $string = $request->getHeaderLine('Content-Length');
@@ -170,15 +172,9 @@ class Server extends EventEmitter
 
         $this->emit('request', array($request, $response));
 
-        if ($stream instanceof CloseProtectionStream) {
-            $request->emit('end');
-            $request->close();
-            return;
-        }
-
-        if ($stream instanceof LengthLimitedStream && $contentLength === 0) {
-            // Content-Length is 0 and won't emit further data,
-            // 'handleData' from LengthLimitedStream won't be called anymore
+        if ($contentLength === 0) {
+            // If Body is empty or Content-Length is 0 and won't emit further data,
+            // 'data' events from other streams won't be called anymore
             $stream->emit('end');
             $stream->close();
         }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1205,6 +1205,30 @@ class ServerTest extends TestCase
         $this->connection->emit('data', array($data));
     }
 
+    public function testRequestWithoutDefinedLengthWillIgnoreDataEvent()
+    {
+        $server = new Server($this->socket);
+
+        $dataEvent = $this->expectCallableNever();
+        $endEvent = $this->expectCallableOnce();
+        $closeEvent = $this->expectCallableOnce();
+        $errorEvent = $this->expectCallableNever();
+
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+            $request->on('data', $dataEvent);
+            $request->on('end', $endEvent);
+            $request->on('close', $closeEvent);
+            $request->on('error', $errorEvent);
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $data .= "hello world";
+
+        $this->connection->emit('data', array($data));
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
Currently only requests with a body will emit the `end` event ( #116 and #129).

This ensures that a completed request without a body (e.g. GET-Request) will emit an `end` event.