### PR TITLE
Remove 'Transfer-Encoding' before emitting to the request event

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ can still be sent.
 
 The `Request` class is responsible for streaming the incoming request body
 and contains meta data which was parsed from the request headers.
+If the request body is chunked-encoded, the data will be decoded and emitted on the data event.
+The `Transfer-Encoding` header will be removed.
 
 It implements the `ReadableStreamInterface`.
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -147,6 +147,9 @@ class Server extends EventEmitter
             // 'chunked' must always be the final value of 'Transfer-Encoding' according to: https://tools.ietf.org/html/rfc7230#section-3.3.1
             if (strtolower(end($transferEncodingHeader)) === 'chunked') {
                 $stream = new ChunkedDecoder($stream);
+
+                $request = $request->withoutHeader('Transfer-Encoding');
+
                 $contentLength = null;
             }
         } elseif ($request->hasHeader('Content-Length')) {
@@ -162,6 +165,7 @@ class Server extends EventEmitter
             $stream = new LengthLimitedStream($stream, $contentLength);
         }
 
+        $request = $request->withoutHeader('Content-Length');
         $request = new Request($request, $stream);
 
         // attach remote ip to the request as metadata

--- a/src/Server.php
+++ b/src/Server.php
@@ -149,6 +149,7 @@ class Server extends EventEmitter
                 $stream = new ChunkedDecoder($stream);
 
                 $request = $request->withoutHeader('Transfer-Encoding');
+                $request = $request->withoutHeader('Content-Length');
 
                 $contentLength = null;
             }
@@ -165,7 +166,6 @@ class Server extends EventEmitter
             $stream = new LengthLimitedStream($stream, $contentLength);
         }
 
-        $request = $request->withoutHeader('Content-Length');
         $request = new Request($request, $stream);
 
         // attach remote ip to the request as metadata

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -487,12 +487,14 @@ class ServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
+        $requestValidation = null;
 
-        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server->on('request', function (Request $request, Response $response) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->on('data', $dataEvent);
             $request->on('end', $endEvent);
             $request->on('close', $closeEvent);
             $request->on('error', $errorEvent);
+            $requestValidation = $request;
         });
 
         $this->socket->emit('connection', array($this->connection));
@@ -506,6 +508,8 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
+
+        $this->assertFalse($requestValidation->hasHeader('Transfer-Encoding'));
     }
 
     public function testChunkedEncodedRequestAdditionalDataWontBeEmitted()
@@ -911,8 +915,9 @@ class ServerTest extends TestCase
         $data .= "0\r\n\r\n";
 
         $this->connection->emit('data', array($data));
-        $this->assertEquals('4', $requestValidation->getHeaderLine('Content-Length'));
-        $this->assertEquals('chunked', $requestValidation->getHeaderLine('Transfer-Encoding'));
+
+        $this->assertFalse($requestValidation->hasHeader('Content-Length'));
+        $this->assertFalse($requestValidation->hasHeader('Transfer-Encoding'));
     }
 
     public function testInvalidContentLengthWillBeIgnoreddIfTransferEncodingIsSet()
@@ -938,6 +943,7 @@ class ServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com:80\r\n";
         $data .= "Connection: close\r\n";
+        // this is valid behavior according to: https://www.ietf.org/rfc/rfc2616.txt chapter 4.4
         $data .= "Content-Length: hello world\r\n";
         $data .= "Transfer-Encoding: chunked\r\n";
         $data .= "\r\n";
@@ -949,9 +955,8 @@ class ServerTest extends TestCase
 
         $this->connection->emit('data', array($data));
 
-        // this is valid behavior according to: https://www.ietf.org/rfc/rfc2616.txt chapter 4.4
-        $this->assertEquals('hello world', $requestValidation->getHeaderLine('Content-Length'));
-        $this->assertEquals('chunked', $requestValidation->getHeaderLine('Transfer-Encoding'));
+        $this->assertFalse($requestValidation->hasHeader('Content-Length'));
+        $this->assertFalse($requestValidation->hasHeader('Transfer-Encoding'));
     }
 
     public function testNonIntegerContentLengthValueWillLeadToError()


### PR DESCRIPTION
Currently the complete header will be emitted to the request event. The request event will always receive decoded data. So at this point there is no need to keep the header lines.

Builds on top of #116