### PR TITLE
Remove Transfer-Encoding if Content-Length is given in Response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,9 @@ Calling this method after the response has ended/closed is a NOOP.
 
 Unless you specify a `Content-Length` header yourself, HTTP/1.1 responses
 will automatically use chunked transfer encoding and send the respective header
-(`Transfer-Encoding: chunked`) automatically. If you know the length of your
-body, you MAY specify it like this instead:
+(`Transfer-Encoding: chunked`) automatically. The server is responsible for handling
+`Transfer-Encoding` so you SHOULD NOT pass it yourself.
+If you know the length of your body, you MAY specify it like this instead:
 
 ```php
 $data = 'Hello World!';

--- a/src/Response.php
+++ b/src/Response.php
@@ -204,14 +204,15 @@ class Response extends EventEmitter implements WritableStreamInterface
             );
         }
 
+        // always remove transfer-encoding
+        foreach($headers as $name => $value) {
+            if (strtolower($name) === 'transfer-encoding') {
+                unset($headers[$name]);
+            }
+        }
+
         // assign chunked transfer-encoding if no 'content-length' is given for HTTP/1.1 responses
         if (!isset($lower['content-length']) && $this->protocolVersion === '1.1') {
-            foreach($headers as $name => $value) {
-                if (strtolower($name) === 'transfer-encoding') {
-                    unset($headers[$name]);
-                }
-            }
-
             $headers['Transfer-Encoding'] = 'chunked';
             $this->chunkedEncoding = true;
         }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -596,4 +596,37 @@ class ResponseTest extends TestCase
 
         $input->emit('drain');
     }
+
+    public function testContentLengthWillBeRemovedIfTransferEncodingIsGiven()
+    {
+        $expectedHeader = '';
+        $expectedHeader .= "HTTP/1.1 200 OK\r\n";
+        $expectedHeader .= "X-Powered-By: React/alpha\r\n";
+        $expectedHeader .= "Content-Length: 4\r\n";
+        $expectedHeader .= "Connection: close\r\n";
+        $expectedHeader .= "\r\n";
+
+        $expectedBody = "hello";
+
+        $conn = $this
+            ->getMockBuilder('React\Socket\ConnectionInterface')
+            ->getMock();
+        $conn
+            ->expects($this->exactly(2))
+            ->method('write')
+            ->withConsecutive(
+                array($expectedHeader),
+                array($expectedBody)
+            );
+
+        $response = new Response($conn, '1.1');
+        $response->writeHead(
+            200,
+            array(
+                'Content-Length' => 4,
+                'Transfer-Encoding' => 'chunked'
+            )
+        );
+        $response->write('hello');
+    }
 }


### PR DESCRIPTION
The Transfer-Encoding should always be removed if a Content-Length  is given.
The user should never be able to set the Transfer-Encoding

Is the equivalent to #137.