### PR TITLE
Add date header to server responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,24 @@ $response->writeHead(200, array(
 $response->end($data);
 ```
 
+A `Date` header will be automatically added with the system date and time if none is given.
+You can add a custom `Date` header yourself like this:
+
+```php
+$response->writeHead(200, array(
+    'Date' => date('D, d M Y H:i:s T')
+));
+```
+
+If you don't have a appropriate clock to rely on, you should
+unset this header with an empty array:
+
+```php
+$response->writeHead(200, array(
+    'Date' => array()
+));
+```
+
 Note that it will automatically assume a `X-Powered-By: react/alpha` header
 unless your specify a custom `X-Powered-By` header yourself:
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -211,6 +211,12 @@ class Response extends EventEmitter implements WritableStreamInterface
             }
         }
 
+        // assign date header if no 'date' is given, use the current time where this code is running
+        if (!isset($lower['date'])) {
+            // IMF-fixdate  = day-name "," SP date1 SP time-of-day SP GMT
+            $headers['Date'] = gmdate('D, d M Y H:i:s') . ' GMT';
+        }
+
         // assign chunked transfer-encoding if no 'content-length' is given for HTTP/1.1 responses
         if (!isset($lower['content-length']) && $this->protocolVersion === '1.1') {
             $headers['Transfer-Encoding'] = 'chunked';


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7231#section-7.1.1.2 a `Date` header should be added to the response message.

The date of a server will only be added when none date is given in the response header.


