### PR TITLE
Forward compatibility with Stream v0.5 and upcoming v0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.0",
         "ringcentral/psr7": "^1.2",
         "react/socket": "^0.5",
-        "react/stream": "^0.4.4",
+        "react/stream": "^0.6 || ^0.5 || ^0.4.4",
         "evenement/evenement": "^2.0 || ^1.0"
     },
     "autoload": {


### PR DESCRIPTION
This component is in fact already compatible with v0.4, the new v0.5 and the upcoming v0.6, see also https://github.com/reactphp/stream/issues/67.

Depends on https://github.com/reactphp/socket/pull/79