### PR TITLE
Send '100 Continue' response automatically via Server

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -149,24 +149,6 @@ class Request extends EventEmitter implements ReadableStreamInterface
         return $this->request->hasHeader($name);
     }
 
-    /**
-     * Checks if the request headers contain the `Expect: 100-continue` header.
-     *
-     * This header MAY be included when an HTTP/1.1 client wants to send a bigger
-     * request body.
-     * See [`writeContinue()`] for more details.
-     *
-     * This will always be `false` for HTTP/1.0 requests, regardless of what
-     * any header values say.
-     *
-     * @return bool
-     * @see Response::writeContinue()
-     */
-    public function expectsContinue()
-    {
-        return $this->getProtocolVersion() !== '1.0' && '100-continue' === strtolower($this->getHeaderLine('Expect'));
-    }
-
     public function isReadable()
     {
         return $this->readable;

--- a/src/Response.php
+++ b/src/Response.php
@@ -67,65 +67,6 @@ class Response extends EventEmitter implements WritableStreamInterface
     }
 
     /**
-     * Sends an intermediary `HTTP/1.1 100 continue` response.
-     *
-     * This is a feature that is implemented by *many* HTTP/1.1 clients.
-     * When clients want to send a bigger request body, they MAY send only the request
-     * headers with an additional `Expect: 100-continue` header and wait before
-     * sending the actual (large) message body.
-     *
-     * The server side MAY use this header to verify if the request message is
-     * acceptable by checking the request headers (such as `Content-Length` or HTTP
-     * authentication) and then ask the client to continue with sending the message body.
-     * Otherwise, the server can send a normal HTTP response message and save the
-     * client from transfering the whole body at all.
-     *
-     * This method is mostly useful in combination with the
-     * [`expectsContinue()`] method like this:
-     *
-     * ```php
-     * $http->on('request', function (Request $request, Response $response) {
-     *     if ($request->expectsContinue()) {
-     *         $response->writeContinue();
-     *     }
-     *
-     *     $response->writeHead(200, array('Content-Type' => 'text/plain'));
-     *     $response->end("Hello World!\n");
-     * });
-     * ```
-     *
-     * Note that calling this method is strictly optional for HTTP/1.1 responses.
-     * If you do not use it, then a HTTP/1.1 client MUST continue sending the
-     * request body after waiting some time.
-     *
-     * This method MUST NOT be invoked after calling `writeHead()`.
-     * This method MUST NOT be invoked if this is not a HTTP/1.1 response
-     * (please check [`expectsContinue()`] as above).
-     * Calling this method after sending the headers or if this is not a HTTP/1.1
-     * response is an error that will result in an `Exception`
-     * (unless the response has ended/closed already).
-     * Calling this method after the response has ended/closed is a NOOP.
-     *
-     * @return void
-     * @throws \Exception
-     * @see Request::expectsContinue()
-     */
-    public function writeContinue()
-    {
-        if (!$this->writable) {
-            return;
-        }
-        if ($this->protocolVersion !== '1.1') {
-            throw new \Exception('Continue requires a HTTP/1.1 message');
-        }
-        if ($this->headWritten) {
-            throw new \Exception('Response head has already been written.');
-        }
-
-        $this->conn->write("HTTP/1.1 100 Continue\r\n\r\n");
-    }
-
-    /**
      * Writes the given HTTP message header.
      *
      * This method MUST be invoked once before calling `write()` or `end()` to send

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,6 +27,15 @@ use Psr\Http\Message\RequestInterface;
  * });
  * ```
  *
+ * When HTTP/1.1 clients want to send a bigger request body, they MAY send only
+ * the request headers with an additional `Expect: 100-continue` header and
+ * wait before sending the actual (large) message body.
+ * In this case the server will automatically send an intermediary
+ * `HTTP/1.1 100 Continue` response to the client.
+ * This ensures you will receive the request body without a delay as expected.
+ * The [Response](#response) still needs to be created as described in the
+ * examples above.
+ *
  * See also [`Request`](#request) and [`Response`](#response) for more details.
  *
  * > Note that you SHOULD always listen for the `request` event.
@@ -43,6 +52,8 @@ use Psr\Http\Message\RequestInterface;
  *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
  * });
  * ```
+ * The request object can also emit an error. Checkout [Request](#request)
+ * for more details.
  *
  * @see Request
  * @see Response
@@ -169,6 +180,10 @@ class Server extends EventEmitter
         }
 
         $request = new Request($request, $stream);
+
+        if ($request->getProtocolVersion() !== '1.0' && '100-continue' === strtolower($request->getHeaderLine('Expect'))) {
+            $conn->write("HTTP/1.1 100 Continue\r\n\r\n");
+        }
 
         // attach remote ip to the request as metadata
         $request->remoteAddress = trim(

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -14,42 +14,6 @@ class RequestTest extends TestCase
         $this->stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
     }
 
-    /** @test */
-    public function expectsContinueShouldBeFalseByDefault()
-    {
-        $headers = array();
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
-
-        $this->assertFalse($request->expectsContinue());
-    }
-
-    /** @test */
-    public function expectsContinueShouldBeTrueIfContinueExpected()
-    {
-        $headers = array('Expect' => array('100-continue'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
-
-        $this->assertTrue($request->expectsContinue());
-    }
-
-    /** @test */
-    public function expectsContinueShouldBeTrueIfContinueExpectedCaseInsensitive()
-    {
-        $headers = array('EXPECT' => array('100-CONTINUE'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.1'), $this->stream);
-
-        $this->assertTrue($request->expectsContinue());
-    }
-
-    /** @test */
-    public function expectsContinueShouldBeFalseForHttp10()
-    {
-        $headers = array('Expect' => array('100-continue'));
-        $request = new Request(new Psr('GET', '/', $headers, null, '1.0'), $this->stream);
-
-        $this->assertFalse($request->expectsContinue());
-    }
-
     public function testEmptyHeader()
     {
         $request = new Request(new Psr('GET', '/', array()), $this->stream);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -331,55 +331,6 @@ class ResponseTest extends TestCase
     }
 
     /** @test */
-    public function writeContinueShouldSendContinueLineBeforeRealHeaders()
-    {
-        $conn = $this
-            ->getMockBuilder('React\Socket\ConnectionInterface')
-            ->getMock();
-        $conn
-            ->expects($this->at(3))
-            ->method('write')
-            ->with("HTTP/1.1 100 Continue\r\n\r\n");
-        $conn
-            ->expects($this->at(4))
-            ->method('write')
-            ->with($this->stringContains("HTTP/1.1 200 OK\r\n"));
-
-        $response = new Response($conn);
-        $response->writeContinue();
-        $response->writeHead();
-    }
-
-    /**
-     * @test
-     * @expectedException Exception
-     */
-    public function writeContinueShouldThrowForHttp10()
-    {
-        $conn = $this
-            ->getMockBuilder('React\Socket\ConnectionInterface')
-            ->getMock();
-
-        $response = new Response($conn, '1.0');
-        $response->writeContinue();
-    }
-
-    /** @expectedException Exception */
-    public function testWriteContinueAfterWriteHeadShouldThrowException()
-    {
-        $conn = $this
-            ->getMockBuilder('React\Socket\ConnectionInterface')
-            ->getMock();
-        $conn
-            ->expects($this->once())
-            ->method('write');
-
-        $response = new Response($conn);
-        $response->writeHead();
-        $response->writeContinue();
-    }
-
-    /** @test */
     public function shouldRemoveNewlinesFromHeaders()
     {
         $expected = '';
@@ -549,18 +500,6 @@ class ResponseTest extends TestCase
         $response->close();
 
         $response->writeHead();
-    }
-
-    public function testWriteContinueAfterCloseIsNoOp()
-    {
-        $input = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
-        $input->expects($this->once())->method('close');
-        $input->expects($this->never())->method('write');
-
-        $response = new Response($input);
-        $response->close();
-
-        $response->writeContinue();
     }
 
     public function testEndAfterCloseIsNoOp()


### PR DESCRIPTION
As preparation for the upcoming PSR-7 feature, this PR will remove the `expectsContinue` and `writeContinues` methods from the Response and Request classes, because it is not compatible with the [ResponseInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#33-psrhttpmessageresponseinterface) and the [RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface) of PSR-7.

The server sends now a the `HTTP/1.1 100 Continue` response automatically.
The possibility to handle this behavior is removed, but will be added again after the PSR-7 implemantation is completed.

Some of the details are already discussed in #109.