### PR TITLE
Add tests to test case sensitivity for ChunkedDecoder

### DIFF
--- a/tests/ChunkedDecoderTest.php
+++ b/tests/ChunkedDecoderTest.php
@@ -447,4 +447,36 @@ class ChunkedDecoderTest extends TestCase
 
         $this->input->emit('data', array("\r\nhello\r\n"));
     }
+
+    public function testUpperCaseHexWillBeHandled()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('0123456790'));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("A\r\n0123456790\r\n"));
+    }
+
+    public function testLowerCaseHexWillBeHandled()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith('0123456790'));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("a\r\n0123456790\r\n"));
+    }
+
+    public function testMixedUpperAndLowerCaseHexValuesInHeaderWillBeHandled()
+    {
+        $data = str_repeat('1', (int)hexdec('AA'));
+
+        $this->parser->on('data', $this->expectCallableOnceWith($data));
+        $this->parser->on('error', $this->expectCallableNever());
+        $this->parser->on('end', $this->expectCallableNever());
+        $this->parser->on('close', $this->expectCallableNever());
+
+        $this->input->emit('data', array("aA\r\n" . $data . "\r\n"));
+    }
 }


### PR DESCRIPTION
Thanks to @mdrost who found a bug with case-insensitve chunk headers: https://github.com/reactphp/http-client/pull/77

Luckily the Server is not affected. I  added just some tests to verify this behavior.