### PR TITLE
Allow connection upgrades

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -242,6 +242,16 @@ class Server extends EventEmitter
             $stream = new LengthLimitedStream($stream, $contentLength);
         }
 
+        $upgradeRequest = false;
+        if ($request->getProtocolVersion() !== '1.0' && $request->hasHeader('Connection') && strtolower($request->getHeaderLine('Connection')) === "upgrade") {
+            if (!$request->hasHeader('Upgrade') || empty($request->getHeaderLine('Upgrade'))) {
+                // MUST have Upgrade options
+                $this->emit('error', array(new \InvalidArgumentException('Connection upgrade must specify upgrade protocol.')));
+                return $this->writeError($conn, 400, $request);
+            }
+            $upgradeRequest = true;
+        }
+
         $request = $request->withBody(new HttpBodyStream($stream, $contentLength));
 
         if ($request->getProtocolVersion() !== '1.0' && '100-continue' === strtolower($request->getHeaderLine('Expect'))) {
@@ -261,7 +271,7 @@ class Server extends EventEmitter
 
         $that = $this;
         $promise->then(
-            function ($response) use ($that, $conn, $request) {
+            function ($response) use ($that, $conn, $request, $contentLength, $stream, $upgradeRequest) {
                 if (!$response instanceof ResponseInterface) {
                     $message = 'The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but resolved with "%s" instead.';
                     $message = sprintf($message, is_object($response) ? get_class($response) : gettype($response));
@@ -270,6 +280,71 @@ class Server extends EventEmitter
                     $that->emit('error', array($exception));
                     return $that->writeError($conn, 500, $request);
                 }
+
+                if ($response->getStatusCode() === 426) {
+                    if (!$response->hasHeader('Upgrade') || $response->getHeaderLine('Upgrade') === '') {
+                        $message = 'HTTP 1.1 426 response requires `Upgrade` header.';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+                }
+
+                $upgradeConnection = false;
+                if ($response->getStatusCode() === 101) {
+                    if (!$upgradeRequest) {
+                        $message = 'HTTP status 101 is not valid when no upgrade was requested';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+
+                    if ($response->getProtocolVersion() === '1.0') {
+                        $message = 'HTTP status 101 is not valid with protocol version 1.0';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+
+                    if (!$response->hasHeader('Connection') || strtolower($response->getHeaderLine('Connection')) !== 'upgrade') {
+                        $message = 'HTTP 1.1 Upgrade requires `Connection: upgrade` header.';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+
+                    if (!$response->hasHeader('Upgrade') || $response->getHeaderLine('Upgrade') === '') {
+                        $message = 'HTTP 1.1 Upgrade requires `Upgrade` header with exactly one protocol specified.';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+
+                    $requestedProtocols = explode(',', preg_replace('/\s+/', '', $request->getHeaderLine('Upgrade')));
+
+                    if (!in_array(trim($response->getHeaderLine('Upgrade')), $requestedProtocols)) {
+                        $message = 'Upgrade requires response protocol to be one of the `Upgrade` protocols specified by the request.';
+                        $exception = new \RuntimeException($message);
+
+                        $that->emit('error', array($exception));
+                        return $that->writeError($conn, 500, $request);
+                    }
+
+                    $upgradeConnection = true;
+                }
+
+                if (!$upgradeConnection && $contentLength === 0) {
+                    // If Body is empty or Content-Length is 0 and won't emit further data,
+                    // 'data' events from other streams won't be called anymore
+                    $stream->emit('end');
+                    $stream->close();
+                }
+
                 $that->handleResponse($conn, $request, $response);
             },
             function ($error) use ($that, $conn, $request) {
@@ -281,15 +356,6 @@ class Server extends EventEmitter
                 return $that->writeError($conn, 500, $request);
             }
         );
-
-        $upgradeConnection = $request->hasHeader('Connection') && $request->getHeaderLine('Connection') === 'Upgrade';
-
-        if (!$upgradeConnection && $contentLength === 0) {
-            // If Body is empty or Content-Length is 0 and won't emit further data,
-            // 'data' events from other streams won't be called anymore
-            $stream->emit('end');
-            $stream->close();
-        }
     }
 
     /** @internal */

--- a/src/Server.php
+++ b/src/Server.php
@@ -244,7 +244,7 @@ class Server extends EventEmitter
 
         $upgradeRequest = false;
         if ($request->getProtocolVersion() !== '1.0' && $request->hasHeader('Connection') && strtolower($request->getHeaderLine('Connection')) === "upgrade") {
-            if (!$request->hasHeader('Upgrade') || empty($request->getHeaderLine('Upgrade'))) {
+            if (!$request->hasHeader('Upgrade') || $request->getHeaderLine('Upgrade') === '') {
                 // MUST have Upgrade options
                 $this->emit('error', array(new \InvalidArgumentException('Connection upgrade must specify upgrade protocol.')));
                 return $this->writeError($conn, 400, $request);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2241,14 +2241,15 @@ class ServerTest extends TestCase
 
     public function testConnectionUpgradeEcho()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $that = $this;
+        $server = new Server($this->socket, function (RequestInterface $request) use ($that) {
             $responseStream = new ReadableStream();
             $request->getBody()->on('data', function ($data) use ($responseStream) {
-                $responseStream->emit('data', [$data]);
+                $responseStream->emit('data', array($data));
             });
 
-            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
-            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+            $that->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $that->assertEquals('echo', $request->getHeaderLine('Upgrade'));
 
             $response = new Response(
                 101,
@@ -2286,8 +2287,9 @@ class ServerTest extends TestCase
 
     public function testUpgradeWithNoProtocolRespondsWithError()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
-            $this->fail('Callback should not be called');
+        $that = $this;
+        $server = new Server($this->socket, function (RequestInterface $request) use ($that) {
+            $that->fail('Callback should not be called');
         });
 
         $exception = null;
@@ -2321,10 +2323,11 @@ class ServerTest extends TestCase
 
     public function testUpgrade101MustContainUpgradeHeaderWithNewProtocol()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $that = $this;
+        $server = new Server($this->socket, function (RequestInterface $request) use ($that) {
             $responseStream = new ReadableStream();
-            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
-            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+            $that->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $that->assertEquals('echo', $request->getHeaderLine('Upgrade'));
 
             $response = new Response(
                 101,
@@ -2362,10 +2365,11 @@ class ServerTest extends TestCase
 
     public function testUpgradeProtocolMustBeOneRequested()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $that = $this;
+        $server = new Server($this->socket, function (RequestInterface $request) use ($that) {
             $responseStream = new ReadableStream();
-            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
-            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+            $that->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $that->assertEquals('echo', $request->getHeaderLine('Upgrade'));
 
             $response = new Response(
                 101,

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2229,6 +2229,248 @@ class ServerTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $exception);
     }
 
+    private function getUpgradeHeader()
+    {
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: localhost\r\n";
+        $data .= "Connection: Upgrade\r\n";
+        $data .= "Upgrade: echo\r\n\r\n";
+
+        return $data;
+    }
+
+    public function testConnectionUpgradeEcho()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $responseStream = new ReadableStream();
+            $request->getBody()->on('data', function ($data) use ($responseStream) {
+                $responseStream->emit('data', [$data]);
+            });
+
+            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+
+            $response = new Response(
+                101,
+                array(
+                    'Connection' => 'Upgrade',
+                    'Upgrade'    => 'echo'
+                ),
+                $responseStream);
+            return $response;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->connection->emit('data', array('text to be echoed'));
+
+        $this->assertStringStartsWith("HTTP/1.1 101 Switching Protocols\r\n", $buffer);
+        $this->assertContains("\r\nConnection: Upgrade\r\n", $buffer);
+        $this->assertContains("\r\nUpgrade: echo\r\n", $buffer);
+        $this->assertStringEndsWith("\r\n\r\ntext to be echoed", $buffer);
+    }
+
+    public function testUpgradeWithNoProtocolRespondsWithError()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $this->fail('Callback should not be called');
+        });
+
+        $exception = null;
+        $server->on('error', function (\Exception $ex) use (&$exception) {
+            $exception = $ex;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: localhost\r\n";
+        $data .= "Connection: Upgrade\r\n\r\n";
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->assertStringStartsWith("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf('RuntimeException', $exception);
+    }
+
+    public function testUpgrade101MustContainUpgradeHeaderWithNewProtocol()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $responseStream = new ReadableStream();
+            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+
+            $response = new Response(
+                101,
+                array(
+                    'Connection' => 'Upgrade'
+                ),
+                $responseStream);
+            return $response;
+        });
+
+        $exception = null;
+        $server->on('error', function (\Exception $ex) use (&$exception) {
+            $exception = $ex;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->assertStringStartsWith("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf('RuntimeException', $exception);
+    }
+
+    public function testUpgradeProtocolMustBeOneRequested()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $responseStream = new ReadableStream();
+            $this->assertEquals('Upgrade', $request->getHeaderLine('Connection'));
+            $this->assertEquals('echo', $request->getHeaderLine('Upgrade'));
+
+            $response = new Response(
+                101,
+                array(
+                    'Connection' => 'Upgrade',
+                    'Upgrade'    => 'notecho'
+                ),
+                $responseStream);
+            return $response;
+        });
+
+        $exception = null;
+        $server->on('error', function (\Exception $ex) use (&$exception) {
+            $exception = $ex;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->assertStringStartsWith("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf('RuntimeException', $exception);
+    }
+
+    public function testUpgrade426WithUpgradeHeader()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $response = new Response(
+                426,
+                array(
+                    'Upgrade' => 'something'
+                ));
+            return $response;
+        });
+
+        $exception = null;
+        $server->on('error', function (\Exception $ex) use (&$exception) {
+            $exception = $ex;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->assertStringStartsWith("HTTP/1.1 426 Upgrade Required\r\n", $buffer);
+    }
+
+    public function testUpgrade426MustContainUpgradeHeaderWithProtocol()
+    {
+        $server = new Server($this->socket, function (RequestInterface $request) {
+            $response = new Response(
+                426,
+                array());
+            return $response;
+        });
+
+        $exception = null;
+        $server->on('error', function (\Exception $ex) use (&$exception) {
+            $exception = $ex;
+        });
+
+        $buffer = '';
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $this->connection->emit('data', array($this->getUpgradeHeader()));
+
+        $this->assertStringStartsWith("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf('RuntimeException', $exception);
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
Don't close the connection when `Connection: Upgrade` request and `101 Switching Protocols` response are encountered.

This allows other protocols (WebSocket) to use react/http to start up the connection.