### PR TITLE
Cast getSize() to string for Content-Length header

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -341,7 +341,7 @@ class Server extends EventEmitter
         }
 
         if (!$response->getBody() instanceof HttpBodyStream) {
-            $response = $response->withHeader('Content-Length', $response->getBody()->getSize());
+            $response = $response->withHeader('Content-Length', (string)$response->getBody()->getSize());
         } elseif (!$response->hasHeader('Content-Length') && $request->getProtocolVersion() === '1.1') {
             // assign chunked transfer-encoding if no 'content-length' is given for HTTP/1.1 responses
             $response = $response->withHeader('Transfer-Encoding', 'chunked');


### PR DESCRIPTION
This probably fixes the issues with `Zend/Diactoros` mentioned here https://github.com/reactphp/http/issues/28#issuecomment-290763516. The exception is throwed since `getSize()` returns `int` instead of `string` (diactoros is very strict about this).

This fixed my issues with `Diactoros` responses.