### PR TITLE
 Add PSR-7 ServerRequestInterface to the PSR-7 Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is an HTTP server which responds with `Hello World` to every request.
 $loop = React\EventLoop\Factory::create();
 $socket = new React\Socket\Server(8080, $loop);
 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -54,7 +54,7 @@ constructor with the respective [request](#request) and
 ```php
 $socket = new React\Socket\Server(8080, $loop);
 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -75,7 +75,7 @@ $socket = new React\Socket\SecureServer($socket, $loop, array(
     'local_cert' => __DIR__ . '/localhost.pem'
 ));
 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -137,11 +137,13 @@ connections and then processing each incoming HTTP request.
 The request object will be processed once the request headers have
 been received by the client.
 This request object implements the
+[PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface)
+which in turn extends the
 [PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface)
 and will be passed to the callback function like this.
 
  ```php 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     $body = "The method of the request is: " . $request->getMethod();
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
@@ -154,7 +156,13 @@ $http = new Server($socket, function (RequestInterface $request) {
 ```
 
 For more details about the request object, check out the documentation of
+[PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface)
+and
 [PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface).
+
+> Currently the the server params, cookies and uploaded files are not added by the
+  `Server`, but you can add these parameters by yourself using the given methods.
+  The next versions of this project will cover these features.
 
 Note that the request object will be processed once the request headers have
 been received.
@@ -184,7 +192,7 @@ Instead, you should use the `ReactPHP ReadableStreamInterface` which
 gives you access to the incoming request body as the individual chunks arrive:
 
 ```php
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
         $request->getBody()->on('data', function ($data) use (&$contentLength) {
@@ -248,7 +256,7 @@ Note that this value may be `null` if the request body size is unknown in
 advance because the request message uses chunked transfer encoding.
 
 ```php 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     $size = $request->getBody()->getSize();
     if ($size === null) {
         $body = 'The request does not contain an explicit length.';
@@ -308,7 +316,7 @@ but feel free to use any implemantation of the
 `PSR-7 ResponseInterface` you prefer.
 
 ```php 
-$http = new Server($socket, function (RequestInterface $request) {
+$http = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -327,7 +335,7 @@ To prevent this you SHOULD use a
 This example shows how such a long-term action could look like:
 
 ```php
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use ($loop) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(
@@ -355,7 +363,7 @@ Note that other implementations of the `PSR-7 ResponseInterface` likely
 only support string.
 
 ```php
-$server = new Server($socket, function (RequestInterface $request) use ($loop) {
+$server = new Server($socket, function (ServerRequestInterface $request) use ($loop) {
     $stream = new ReadableStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
@@ -389,7 +397,7 @@ If you know the length of your stream body, you MAY specify it like this instead
 
 ```php
 $stream = new ReadableStream()
-$server = new Server($socket, function (RequestInterface $request) use ($loop, $stream) {
+$server = new Server($socket, function (ServerRequestInterface $request) use ($loop, $stream) {
     return new Response(
         200,
         array(
@@ -437,7 +445,7 @@ A `Date` header will be automatically added with the system date and time if non
 You can add a custom `Date` header yourself like this:
 
 ```php
-$server = new Server($socket, function (RequestInterface $request) {
+$server = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(200, array('Date' => date('D, d M Y H:i:s T')));
 });
 ```
@@ -446,7 +454,7 @@ If you don't have a appropriate clock to rely on, you should
 unset this header with an empty string:
 
 ```php
-$server = new Server($socket, function (RequestInterface $request) {
+$server = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(200, array('Date' => ''));
 });
 ```
@@ -455,7 +463,7 @@ Note that it will automatically assume a `X-Powered-By: react/alpha` header
 unless your specify a custom `X-Powered-By` header yourself:
 
 ```php
-$server = new Server($socket, function (RequestInterface $request) {
+$server = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(200, array('X-Powered-By' => 'PHP 3'));
 });
 ```
@@ -464,7 +472,7 @@ If you do not want to send this header at all, you can use an empty string as
 value like this:
 
 ```php
-$server = new Server($socket, function (RequestInterface $request) {
+$server = new Server($socket, function (ServerRequestInterface $request) {
     return new Response(200, array('X-Powered-By' => ''));
 });
 ```

--- a/examples/01-hello-world.php
+++ b/examples/01-hello-world.php
@@ -3,15 +3,14 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
-use React\Promise\Promise;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(

--- a/examples/02-count-visitors.php
+++ b/examples/02-count-visitors.php
@@ -3,7 +3,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -11,7 +11,7 @@ $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 $counter = 0;
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use (&$counter) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),

--- a/examples/03-stream-response.php
+++ b/examples/03-stream-response.php
@@ -3,7 +3,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Stream\ReadableStream;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use ($loop) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
     $stream = new ReadableStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {

--- a/examples/04-stream-request.php
+++ b/examples/04-stream-request.php
@@ -3,7 +3,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
         $request->getBody()->on('data', function ($data) use (&$contentLength) {

--- a/examples/05-error-handling.php
+++ b/examples/05-error-handling.php
@@ -3,7 +3,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -12,7 +12,7 @@ $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 $count = 0;
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use (&$count) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 

--- a/examples/11-hello-world-https.php
+++ b/examples/11-hello-world-https.php
@@ -4,7 +4,7 @@ use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
 use React\Socket\SecureServer;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -14,7 +14,7 @@ $socket = new SecureServer($socket, $loop, array(
     'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
 ));
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),

--- a/examples/21-connect-proxy.php
+++ b/examples/21-connect-proxy.php
@@ -3,7 +3,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
@@ -13,7 +13,7 @@ $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 $connector = new Connector($loop);
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use ($connector) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,

--- a/examples/99-benchmark-download.php
+++ b/examples/99-benchmark-download.php
@@ -9,7 +9,7 @@
 use React\EventLoop\Factory;
 use React\Socket\Server;
 use React\Http\Response;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Stream\ReadableStream;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -62,7 +62,7 @@ class ChunkRepeater extends ReadableStream
     }
 }
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) use ($loop) {
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -72,6 +72,13 @@ class RequestHeaderParser extends EventEmitter
         }
 
         $request = g7\parse_request($headers);
+        $request = new ServerRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getHeaders(),
+            $request->getBody(),
+            $request->getProtocolVersion()
+        );
 
         // Do not assume this is HTTPS when this happens to be port 443
         // detecting HTTPS is left up to the socket layer (TLS detection)

--- a/src/Server.php
+++ b/src/Server.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\Promise\Promise;
 use RingCentral\Psr7 as Psr7Implementation;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * The `Server` class is responsible for handling incoming connections and then
@@ -170,7 +171,7 @@ class Server extends EventEmitter
     }
 
     /** @internal */
-    public function handleRequest(ConnectionInterface $conn, RequestInterface $request)
+    public function handleRequest(ConnectionInterface $conn, ServerRequestInterface $request)
     {
         // only support HTTP/1.1 and HTTP/1.0 requests
         if ($request->getProtocolVersion() !== '1.1' && $request->getProtocolVersion() !== '1.0') {
@@ -306,7 +307,7 @@ class Server extends EventEmitter
     }
 
     /** @internal */
-    public function writeError(ConnectionInterface $conn, $code, RequestInterface $request = null)
+    public function writeError(ConnectionInterface $conn, $code, ServerRequestInterface $request = null)
     {
         $message = 'Error ' . $code;
         if (isset(ResponseCodes::$statusTexts[$code])) {
@@ -322,7 +323,7 @@ class Server extends EventEmitter
         );
 
         if ($request === null) {
-            $request = new Psr7Implementation\Request('GET', '/', array(), null, '1.1');
+            $request = new ServerRequest('GET', '/', array(), null, '1.1');
         }
 
         $this->handleResponse($conn, $request, $response);
@@ -330,7 +331,7 @@ class Server extends EventEmitter
 
 
     /** @internal */
-    public function handleResponse(ConnectionInterface $connection, RequestInterface $request, ResponseInterface $response)
+    public function handleResponse(ConnectionInterface $connection, ServerRequestInterface $request, ResponseInterface $response)
     {
         $response = $response->withProtocolVersion($request->getProtocolVersion());
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace React\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RingCentral\Psr7\Request;
+
+/** @internal */
+class ServerRequest extends Request implements ServerRequestInterface
+{
+    private $attributes = array();
+
+    private $serverParams = array();
+    private $fileParams = array();
+    private $cookies = array();
+    private $queryParams = array();
+    private $parsedBody = null;
+
+    public function getServerParams()
+    {
+        return $this->serverParams;
+    }
+
+    public function getCookieParams()
+    {
+        return $this->cookies;
+    }
+
+    public function withCookieParams(array $cookies)
+    {
+        $new = clone $this;
+        $new->cookies = $cookies;
+        return $new;
+    }
+
+    public function getQueryParams()
+    {
+        return $this->queryParams;
+    }
+
+    public function withQueryParams(array $query)
+    {
+        $new = clone $this;
+        $new->queryParams = $query;
+        return $new;
+    }
+
+    public function getUploadedFiles()
+    {
+        return $this->fileParams;
+    }
+
+    public function withUploadedFiles(array $uploadedFiles)
+    {
+        $new = clone $this;
+        $new->fileParams = $uploadedFiles;
+        return $new;
+    }
+
+    public function getParsedBody()
+    {
+        return $this->parsedBody;
+    }
+
+    public function withParsedBody($data)
+    {
+        $new = clone $this;
+        $new->parsedBody = $data;
+        return $new;
+    }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getAttribute($name, $default = null)
+    {
+        if (!array_key_exists($name, $this->attributes)) {
+            return $default;
+        }
+        return $this->attributes[$name];
+    }
+
+    public function withAttribute($name, $value)
+    {
+        $new = clone $this;
+        $new->attributes[$name] = $value;
+        return $new;
+    }
+
+    public function withoutAttribute($name)
+    {
+        $new = clone $this;
+        unset($new->attributes[$name]);
+        return $new;
+    }
+}

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace React\Tests\Http;
+
+use React\Http\ServerRequest;
+
+class ServerRequestTest extends TestCase
+{
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new ServerRequest('GET', 'http://localhost');
+    }
+
+    public function testGetNoAttributes()
+    {
+        $this->assertEquals(array(), $this->request->getAttributes());
+    }
+
+    public function testWithAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('hello' => 'world'), $request->getAttributes());
+    }
+
+    public function testGetAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals('world', $request->getAttribute('hello'));
+    }
+
+    public function testGetDefaultAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(null, $request->getAttribute('hi', null));
+    }
+
+    public function testWithoutAttribute()
+    {
+        $request = $this->request->withAttribute('hello', 'world');
+        $request = $request->withAttribute('test', 'nice');
+
+        $request = $request->withoutAttribute('hello');
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'nice'), $request->getAttributes());
+    }
+
+    public function testWithCookieParams()
+    {
+        $request = $this->request->withCookieParams(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getCookieParams());
+    }
+
+    public function testWithQueryParams()
+    {
+        $request = $this->request->withQueryParams(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getQueryParams());
+    }
+
+    public function testWithUploadedFiles()
+    {
+        $request = $this->request->withUploadedFiles(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getUploadedFiles());
+    }
+
+    public function testWithParsedBody()
+    {
+        $request = $this->request->withParsedBody(array('test' => 'world'));
+
+        $this->assertNotSame($request, $this->request);
+        $this->assertEquals(array('test' => 'world'), $request->getParsedBody());
+    }
+}

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Http;
 
 use React\Http\Server;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Response;
 use React\Stream\ReadableStream;
 use React\Promise\Promise;
@@ -52,7 +52,7 @@ class ServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -66,7 +66,7 @@ class ServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
             return \React\Promise\resolve(new Response());
@@ -95,7 +95,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -117,7 +117,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -139,7 +139,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -161,7 +161,7 @@ class ServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -193,7 +193,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -215,7 +215,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -237,7 +237,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use (&$requestAssertion) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -269,7 +269,7 @@ class ServerTest extends TestCase
 
     public function testRequestPauseWillbeForwardedToConnection()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $request->getBody()->pause();
             return \React\Promise\resolve(new Response());
         });
@@ -288,7 +288,7 @@ class ServerTest extends TestCase
 
     public function testRequestResumeWillbeForwardedToConnection()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $request->getBody()->resume();
             return \React\Promise\resolve(new Response());
         });
@@ -302,7 +302,7 @@ class ServerTest extends TestCase
 
     public function testRequestCloseWillPauseConnection()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $request->getBody()->close();
             return \React\Promise\resolve(new Response());
         });
@@ -316,7 +316,7 @@ class ServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();#
 
@@ -332,7 +332,7 @@ class ServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
 
@@ -351,7 +351,7 @@ class ServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($never) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
 
             return \React\Promise\resolve(new Response());
@@ -367,7 +367,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($once) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
 
             return \React\Promise\resolve(new Response());
@@ -388,7 +388,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($once) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
 
             return \React\Promise\resolve(new Response());
@@ -410,7 +410,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsPoweredByHeader()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -437,7 +437,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $response = new Response(200, array(), 'bye');
             return \React\Promise\resolve($response);
         });
@@ -466,7 +466,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $response = new Response(200, array(), 'bye');
             return \React\Promise\resolve($response);
         });
@@ -496,7 +496,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Response(200, array(), 'bye');
         });
 
@@ -523,7 +523,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Response(204, array(), 'bye');
         });
 
@@ -551,7 +551,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Response(304, array(), 'bye');
         });
 
@@ -682,7 +682,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -711,7 +711,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -743,7 +743,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -774,7 +774,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -802,7 +802,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -832,7 +832,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -952,7 +952,7 @@ class ServerTest extends TestCase
 
     public function testRequestHttp10WithoutHostEmitsRequestWithNoError()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
         $server->on('error', $this->expectCallableNever());
@@ -970,7 +970,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1000,7 +1000,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1034,7 +1034,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1061,7 +1061,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1089,7 +1089,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1121,7 +1121,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1159,7 +1159,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1395,7 +1395,7 @@ class ServerTest extends TestCase
 
     public function testErrorInChunkedDecoderNeverClosesConnection()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1416,7 +1416,7 @@ class ServerTest extends TestCase
 
     public function testErrorInLengthLimitedStreamNeverClosesConnection()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1485,7 +1485,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1505,7 +1505,7 @@ class ServerTest extends TestCase
     public function testResponseWillBeChunkDecodedByDefault()
     {
         $stream = new ReadableStream();
-        $server = new Server($this->socket, function (RequestInterface $request) use ($stream) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
             $response = new Response(200, array(), $stream);
             return \React\Promise\resolve($response);
         });
@@ -1535,7 +1535,7 @@ class ServerTest extends TestCase
 
     public function testContentLengthWillBeRemovedForResponseStream()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $response = new Response(
                 200,
                 array(
@@ -1574,7 +1574,7 @@ class ServerTest extends TestCase
     public function testOnlyAllowChunkedEncoding()
     {
         $stream = new ReadableStream();
-        $server = new Server($this->socket, function (RequestInterface $request) use ($stream) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
             $response = new Response(
                 200,
                 array(
@@ -1612,7 +1612,7 @@ class ServerTest extends TestCase
 
     public function testDateHeaderWillBeAddedWhenNoneIsGiven()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1641,7 +1641,7 @@ class ServerTest extends TestCase
 
     public function testAddCustomDateHeader()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $response = new Response(200, array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT"));
             return \React\Promise\resolve($response);
         });
@@ -1671,7 +1671,7 @@ class ServerTest extends TestCase
 
     public function testRemoveDateHeader()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             $response = new Response(200, array('Date' => ''));
             return \React\Promise\resolve($response);
         });
@@ -1769,7 +1769,7 @@ class ServerTest extends TestCase
 
     public function test100ContinueRequestWillBeHandled()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1800,7 +1800,7 @@ class ServerTest extends TestCase
 
     public function testContinueWontBeSendForHttp10()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1829,7 +1829,7 @@ class ServerTest extends TestCase
 
     public function testContinueWithLaterResponse()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1872,7 +1872,7 @@ class ServerTest extends TestCase
     {
         $input = new ReadableStream();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($input) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($input) {
             $response = new Response(200, array(), $input);
             return \React\Promise\resolve($response);
         });
@@ -1907,7 +1907,7 @@ class ServerTest extends TestCase
     {
         $input = new ReadableStream();
 
-        $server = new Server($this->socket, function (RequestInterface $request) use ($input) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($input) {
             $response = new Response(200, array('Content-Length' => 5), $input);
             return \React\Promise\resolve($response);
         });
@@ -1941,7 +1941,7 @@ class ServerTest extends TestCase
 
     public function testCallbackFunctionReturnsPromise()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -1968,7 +1968,7 @@ class ServerTest extends TestCase
 
     public function testReturnInvalidTypeWillResultInError()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2003,7 +2003,7 @@ class ServerTest extends TestCase
 
     public function testResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2032,7 +2032,7 @@ class ServerTest extends TestCase
 
     public function testRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2064,7 +2064,7 @@ class ServerTest extends TestCase
 
     public function testExcpetionInCallbackWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2096,7 +2096,7 @@ class ServerTest extends TestCase
 
     public function testHeaderWillAlwaysBeContentLengthForStringBody()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Response(200, array('Transfer-Encoding' => 'chunked'), 'hello');
         });
 
@@ -2129,7 +2129,7 @@ class ServerTest extends TestCase
 
     public function testReturnRequestWillBeHandled()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2158,7 +2158,7 @@ class ServerTest extends TestCase
 
     public function testExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2194,7 +2194,7 @@ class ServerTest extends TestCase
 
     public function testRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (RequestInterface $request) {
+        $server = new Server($this->socket, function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });


### PR DESCRIPTION
This PR adds a PSR-ServerRequestInterface to the request.
This won't handle server params, cookies or uploaded files. This will be addressed in several other PRs.
The new class makes it possible to handle parsed request bodies (#105 for v0.8.0).