### PR TITLE
Sanitize Host header value across all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ URI which provides you access to individiual URI components.
 Note that (depending on the given `request-target`) certain URI components may
 or may not be present, for example the `getPath(): string` method will return
 an empty string for requests in `asterisk-form` or `authority-form`.
+Its `getHost(): string` method will return the host as determined by the
+effective request URI, which defaults to the local socket address if a HTTP/1.0
+client did not specify one (i.e. no `Host` header).
+Its `getScheme(): string` method will return `http` or `https` depending
+on whether the request was made over a secure TLS connection to the target host.
+
 You can use `getMethod(): string` and `getRequestTarget(): string` to
 check this is an accepted request and may want to reject other requests with
 an appropriate error code, such as `400` (Bad Request) or `405` (Method Not

--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ client did not specify one (i.e. no `Host` header).
 Its `getScheme(): string` method will return `http` or `https` depending
 on whether the request was made over a secure TLS connection to the target host.
 
+The `Host` header value will be sanitized to match this host component plus the
+port component only if it is non-standard for this URI scheme.
+
 You can use `getMethod(): string` and `getRequestTarget(): string` to
 check this is an accepted request and may want to reject other requests with
 an appropriate error code, such as `400` (Bad Request) or `405` (Method Not
@@ -300,7 +303,7 @@ Allowed).
 > The `CONNECT` method is useful in a tunneling setup (HTTPS proxy) and not
   something most HTTP servers would want to care about.
   Note that if you want to handle this method, the client MAY send a different
-  request-target than the `Host` header field (such as removing default ports)
+  request-target than the `Host` header value (such as removing default ports)
   and the request-target MUST take precendence when forwarding.
   The HTTP specs define an opaque "tunneling mode" for this method and make no
   use of the message body.

--- a/src/Server.php
+++ b/src/Server.php
@@ -198,6 +198,16 @@ class Server extends EventEmitter
             }
         }
 
+        // set URI components from socket address if not already filled via Host header
+        if ($request->getUri()->getHost() === '') {
+            $parts = parse_url('tcp://' . $conn->getLocalAddress());
+
+            $request = $request->withUri(
+                $request->getUri()->withScheme('http')->withHost($parts['host'])->withPort($parts['port']),
+                true
+            );
+        }
+
         $contentLength = 0;
         $stream = new CloseProtectionStream($conn);
         if ($request->getMethod() === 'CONNECT') {

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -199,6 +199,39 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Invalid absolute-form request-target', $error->getMessage());
     }
 
+    public function testInvalidHostHeaderForHttp11()
+    {
+        $error = null;
+
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $parser->feed("GET / HTTP/1.1\r\nHost: a/b/c\r\n\r\n");
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertSame('Invalid Host header for HTTP/1.1 request', $error->getMessage());
+    }
+
+    public function testInvalidHttpVersion()
+    {
+        $error = null;
+
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $parser->feed("GET / HTTP/1.2\r\n\r\n");
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertSame(505, $error->getCode());
+        $this->assertSame('Received request with invalid protocol version', $error->getMessage());
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -256,6 +256,17 @@ class ServerTest extends TestCase
         $this->assertSame('example.com', $requestAssertion->getHeaderLine('host'));
     }
 
+    public function testRequestConnectOriginFormRequestTargetWillReject()
+    {
+        $server = new Server($this->socket, $this->expectCallableNever());
+        $server->on('error', $this->expectCallableOnce());
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "CONNECT / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        $this->connection->emit('data', array($data));
+    }
+
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
         $server = new Server($this->socket, $this->expectCallableNever());

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -88,7 +88,7 @@ class ServerTest extends TestCase
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
         $this->assertSame('http://example.com/', (string)$requestAssertion->getUri());
-        $this->assertSame('example.com:80', $requestAssertion->getHeaderLine('Host'));
+        $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
         $this->assertSame('127.0.0.1', $requestAssertion->remoteAddress);
     }
 
@@ -155,7 +155,7 @@ class ServerTest extends TestCase
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
         $this->assertSame('http://example.com/', (string)$requestAssertion->getUri());
         $this->assertSame(null, $requestAssertion->getUri()->getPort());
-        $this->assertSame('example.com:80', $requestAssertion->getHeaderLine('Host'));
+        $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
     }
 
     public function testRequestOptionsAsterisk()
@@ -209,7 +209,7 @@ class ServerTest extends TestCase
         $this->assertSame('', $requestAssertion->getUri()->getPath());
         $this->assertSame('http://example.com:443', (string)$requestAssertion->getUri());
         $this->assertSame(443, $requestAssertion->getUri()->getPort());
-        $this->assertSame('example.com:443', $requestAssertion->getHeaderLine('host'));
+        $this->assertSame('example.com:443', $requestAssertion->getHeaderLine('Host'));
     }
 
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
@@ -231,10 +231,10 @@ class ServerTest extends TestCase
         $this->assertSame('', $requestAssertion->getUri()->getPath());
         $this->assertSame('http://example.com', (string)$requestAssertion->getUri());
         $this->assertSame(null, $requestAssertion->getUri()->getPort());
-        $this->assertSame('example.com:80', $requestAssertion->getHeaderLine('Host'));
+        $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
     }
 
-    public function testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs()
+    public function testRequestConnectAuthorityFormNonMatchingHostWillBeOverwritten()
     {
         $requestAssertion = null;
         $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
@@ -244,7 +244,7 @@ class ServerTest extends TestCase
 
         $this->socket->emit('connection', array($this->connection));
 
-        $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
@@ -253,7 +253,7 @@ class ServerTest extends TestCase
         $this->assertSame('', $requestAssertion->getUri()->getPath());
         $this->assertSame('http://example.com', (string)$requestAssertion->getUri());
         $this->assertSame(null, $requestAssertion->getUri()->getPort());
-        $this->assertSame('example.com', $requestAssertion->getHeaderLine('host'));
+        $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
     }
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
@@ -349,7 +349,7 @@ class ServerTest extends TestCase
         $this->assertSame('example.com:8080', $requestAssertion->getHeaderLine('Host'));
     }
 
-    public function testRequestAbsoluteNonMatchingHostWillBePassedAsIs()
+    public function testRequestAbsoluteNonMatchingHostWillBeOverwritten()
     {
         $requestAssertion = null;
 
@@ -368,7 +368,7 @@ class ServerTest extends TestCase
         $this->assertSame('http://example.com/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com/test', $requestAssertion->getUri());
         $this->assertSame('/test', $requestAssertion->getUri()->getPath());
-        $this->assertSame('other.example.org', $requestAssertion->getHeaderLine('Host'));
+        $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
     }
 
     public function testRequestOptionsAsteriskEvent()
@@ -1002,39 +1002,7 @@ class ServerTest extends TestCase
         $this->connection->emit('data', array($data));
     }
 
-    public function testRequestHttp11WithoutHostWillEmitErrorAndSendErrorResponse()
-    {
-        $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
-        $server->on('error', function ($message) use (&$error) {
-            $error = $message;
-        });
-
-        $buffer = '';
-
-        $this->connection
-            ->expects($this->any())
-            ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
-            );
-
-        $this->socket->emit('connection', array($this->connection));
-
-        $data = "GET / HTTP/1.1\r\n\r\n";
-        $this->connection->emit('data', array($data));
-
-        $this->assertInstanceOf('InvalidArgumentException', $error);
-
-        $this->assertContains("HTTP/1.1 400 Bad Request\r\n", $buffer);
-        $this->assertContains("\r\n\r\nError 400: Bad Request", $buffer);
-    }
-
-    public function testRequestHttp11WithMalformedHostWillEmitErrorAndSendErrorResponse()
+    public function testRequestWithMalformedHostWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
         $server = new Server($this->socket, $this->expectCallableNever());
@@ -1066,7 +1034,7 @@ class ServerTest extends TestCase
         $this->assertContains("\r\n\r\nError 400: Bad Request", $buffer);
     }
 
-    public function testRequestHttp11WithInvalidHostUriComponentsWillEmitErrorAndSendErrorResponse()
+    public function testRequestWithInvalidHostUriComponentsWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
         $server = new Server($this->socket, $this->expectCallableNever());
@@ -1096,19 +1064,6 @@ class ServerTest extends TestCase
 
         $this->assertContains("HTTP/1.1 400 Bad Request\r\n", $buffer);
         $this->assertContains("\r\n\r\nError 400: Bad Request", $buffer);
-    }
-
-    public function testRequestHttp10WithoutHostEmitsRequestWithNoError()
-    {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
-            return \React\Promise\resolve(new Response());
-        });
-        $server->on('error', $this->expectCallableNever());
-
-        $this->socket->emit('connection', array($this->connection));
-
-        $data = "GET / HTTP/1.0\r\n\r\n";
-        $this->connection->emit('data', array($data));
     }
 
     public function testWontEmitFurtherDataWhenContentLengthIsReached()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -287,12 +287,12 @@ class ServerTest extends TestCase
             return new Response();
         });
 
-        $this->socket->emit('connection', array($this->connection));
-
         $this->connection
             ->expects($this->once())
             ->method('getLocalAddress')
             ->willReturn('127.0.0.1:80');
+
+        $this->socket->emit('connection', array($this->connection));
 
         $data = "GET /test HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', array($data));


### PR DESCRIPTION
This PR makes sure to sanitize the `Host` header value across all requests.

This means that all of these examples now correctly return the same URI and also the same `Host` header value `example.com` without the default port in this case:

```
GET / HTTP/1.0\r\nHost: example.com\r\n\r\n
GET / HTTP/1.0\r\nHost: example.com:80\r\n\r\n
GET http://example.com/ HTTP/1.0\r\n\r\n
GET http://example.com:80/ HTTP/1.0\r\n\r\n
```

Also, HTTP/1.0 allows requests with no `Host` header at all. In this case, it will simply use the local socket address as the host value. This ensures that `getUri()` always returns a full URI.

This PR may look a bit heavy, but most of the changes are actually added tests and some of the existing URI validation logic moved from the `Server` to the `RequestHeaderParser`.

Builds on top of #169, which builds on top of #167, #158 and #157.