### PR TITLE
Add cookies to request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ For more details about the request object, check out the documentation of
 and
 [PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface).
 
-> Currently the cookies and uploaded files are not added by the
+> Currently the uploaded files are not added by the
   `Server`, but you can add these parameters by yourself using the given methods.
   The next versions of this project will cover these features.
 
@@ -377,6 +377,43 @@ Allowed).
   This implies that that a `2xx` (Successful) response to a `CONNECT` request
   can in fact use a streaming response body for the tunneled application data.
   See also [example #21](examples) for more details.
+
+The `getCookieParams(): string[]` method can be used to
+get all cookies sent with the current request.
+
+```php 
+$http = new Server($socket, function (ServerRequestInterface $request) {
+    $key = 'react\php';
+
+    if (isset($request->getCookieParams()[$key])) {
+        $body = "Your cookie value is: " . $request->getCookieParams()[$key];
+
+        return new Response(
+            200,
+            array('Content-Type' => 'text/plain'),
+            $body
+        );
+    }
+
+    return new Response(
+        200,
+        array(
+            'Content-Type' => 'text/plain',
+            'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')
+        ),
+        "Your cookie has been set."
+    );
+});
+```
+
+The above example will try to set a cookie on first access and
+will try to print the cookie value on all subsequent tries.
+Note how the example uses the `urlencode()` function to encode
+non-alphanumeric characters.
+This encoding is also used internally when decoding the name and value of cookies
+(which is in line with other implementations, such as PHP's cookie functions).
+
+See also [example #6](examples) for more details.
 
 ### Response
 

--- a/examples/06-cookie-handling.php
+++ b/examples/06-cookie-handling.php
@@ -1,0 +1,38 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\Socket\Server;
+use React\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+
+$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+    $key = 'react\php';
+
+    if (isset($request->getCookieParams()[$key])) {
+        $body = "Your cookie value is: " . $request->getCookieParams()[$key];
+
+        return new Response(
+            200,
+            array('Content-Type' => 'text/plain'),
+            $body
+        );
+    }
+
+    return new Response(
+        200,
+        array(
+            'Content-Type' => 'text/plain',
+            'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')
+        ),
+        "Your cookie has been set."
+    );
+});
+
+echo 'Listening on http://' . $socket->getAddress() . PHP_EOL;
+
+$loop->run();

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -126,6 +126,11 @@ class RequestHeaderParser extends EventEmitter
             $request = $request->withQueryParams($queryParams);
         }
 
+        $cookies = ServerRequest::parseCookie($request->getHeaderLine('Cookie'));
+        if ($cookies !== false) {
+            $request = $request->withCookieParams($cookies);
+        }
+
         // re-apply actual request target from above
         if ($originalTarget !== null) {
             $uri = $request->getUri()->withPath('');

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -117,4 +117,33 @@ class ServerRequest extends Request implements ServerRequestInterface
         unset($new->attributes[$name]);
         return $new;
     }
+
+    /**
+     * @internal
+     * @param string $cookie
+     * @return boolean|mixed[]
+     */
+    public static function parseCookie($cookie)
+    {
+        // PSR-7 `getHeadline('Cookies')` will return multiple
+        // cookie header coma-seperated. Multiple cookie headers
+        // are not allowed according to https://tools.ietf.org/html/rfc6265#section-5.4
+        if (strpos($cookie, ',') !== false) {
+            return false;
+        }
+
+        $cookieArray = explode(';', $cookie);
+        $result = array();
+
+        foreach ($cookieArray as $pair) {
+            $nameValuePair = explode('=', $pair, 2);
+            if (count($nameValuePair) === 2) {
+                $key = urldecode($nameValuePair[0]);
+                $value = urldecode($nameValuePair[1]);
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -125,8 +125,8 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function parseCookie($cookie)
     {
-        // PSR-7 `getHeadline('Cookies')` will return multiple
-        // cookie header coma-seperated. Multiple cookie headers
+        // PSR-7 `getHeaderLine('Cookies')` will return multiple
+        // cookie header comma-seperated. Multiple cookie headers
         // are not allowed according to https://tools.ietf.org/html/rfc6265#section-5.4
         if (strpos($cookie, ',') !== false) {
             return false;
@@ -136,7 +136,9 @@ class ServerRequest extends Request implements ServerRequestInterface
         $result = array();
 
         foreach ($cookieArray as $pair) {
+            $pair = trim($pair);
             $nameValuePair = explode('=', $pair, 2);
+
             if (count($nameValuePair) === 2) {
                 $key = urldecode($nameValuePair[0]);
                 $value = urldecode($nameValuePair[1]);

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -105,4 +105,81 @@ class ServerRequestTest extends TestCase
         $this->assertEquals('1.0', $request->getProtocolVersion());
         $this->assertEquals('127.0.0.1', $serverParams['SERVER_ADDR']);
     }
+
+    public function testParseSingleCookieNameValuePairWillReturnValidArray()
+    {
+        $cookieString = 'hello=world';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'world'), $cookies);
+    }#
+
+    public function testParseMultipleCookieNameValuePaiWillReturnValidArray()
+    {
+        $cookieString = 'hello=world;test=abc';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $cookies);
+    }
+
+    public function testParseMultipleCookieNameValuePairWillReturnFalse()
+    {
+        // Could be done through multiple 'Cookie' headers
+        // getHeaderLine('Cookie') will return a value seperated by coma
+        // e.g.
+        // GET / HTTP/1.1\r\n
+        // Host: test.org\r\n
+        // Cookie: hello=world\r\n
+        // Cookie: test=abc\r\n\r\n
+        $cookieString = 'hello=world,test=abc';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(false, $cookies);
+    }
+
+    public function testOnlyFirstSetWillBeAddedToCookiesArray()
+    {
+        $cookieString = 'hello=world;hello=abc';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'abc'), $cookies);
+    }
+
+    public function testOtherEqualSignsWillBeAddedToValueAndWillReturnValidArray()
+    {
+        $cookieString = 'hello=world=test=php';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'world=test=php'), $cookies);
+    }
+
+    public function testSingleCookieValueInCookiesReturnsEmptyArray()
+    {
+        $cookieString = 'world';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array(), $cookies);
+    }
+
+    public function testSingleMutlipleCookieValuesReturnsEmptyArray()
+    {
+        $cookieString = 'world;test';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array(), $cookies);
+    }
+
+    public function testSingleValueIsValidInMultipleValueCookieWillReturnValidArray()
+    {
+        $cookieString = 'world;test=php';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('test' => 'php'), $cookies);
+    }
+
+    public function testUrlEncodingForValueWillReturnValidArray()
+    {
+        $cookieString = 'hello=world%21;test=100%25%20coverage';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'world!', 'test' => '100% coverage'), $cookies);
+    }
+
+    public function testUrlEncodingForKeyWillReturnValidArray()
+    {
+        $cookieString = 'react%3Bphp=is%20great';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('react;php' => 'is great'), $cookies);
+    }
 }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -111,11 +111,11 @@ class ServerRequestTest extends TestCase
         $cookieString = 'hello=world';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('hello' => 'world'), $cookies);
-    }#
+    }
 
     public function testParseMultipleCookieNameValuePaiWillReturnValidArray()
     {
-        $cookieString = 'hello=world;test=abc';
+        $cookieString = 'hello=world; test=abc';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $cookies);
     }
@@ -123,7 +123,7 @@ class ServerRequestTest extends TestCase
     public function testParseMultipleCookieNameValuePairWillReturnFalse()
     {
         // Could be done through multiple 'Cookie' headers
-        // getHeaderLine('Cookie') will return a value seperated by coma
+        // getHeaderLine('Cookie') will return a value seperated by comma
         // e.g.
         // GET / HTTP/1.1\r\n
         // Host: test.org\r\n
@@ -136,7 +136,7 @@ class ServerRequestTest extends TestCase
 
     public function testOnlyFirstSetWillBeAddedToCookiesArray()
     {
-        $cookieString = 'hello=world;hello=abc';
+        $cookieString = 'hello=world; hello=abc';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('hello' => 'abc'), $cookies);
     }
@@ -157,21 +157,21 @@ class ServerRequestTest extends TestCase
 
     public function testSingleMutlipleCookieValuesReturnsEmptyArray()
     {
-        $cookieString = 'world;test';
+        $cookieString = 'world; test';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array(), $cookies);
     }
 
     public function testSingleValueIsValidInMultipleValueCookieWillReturnValidArray()
     {
-        $cookieString = 'world;test=php';
+        $cookieString = 'world; test=php';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('test' => 'php'), $cookies);
     }
 
     public function testUrlEncodingForValueWillReturnValidArray()
     {
-        $cookieString = 'hello=world%21;test=100%25%20coverage';
+        $cookieString = 'hello=world%21; test=100%25%20coverage';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('hello' => 'world!', 'test' => '100% coverage'), $cookies);
     }
@@ -181,5 +181,12 @@ class ServerRequestTest extends TestCase
         $cookieString = 'react%3Bphp=is%20great';
         $cookies = ServerRequest::parseCookie($cookieString);
         $this->assertEquals(array('react;php' => 'is great'), $cookies);
+    }
+
+    public function testCookieWithoutSpaceAfterSeparatorWillBeAccepted()
+    {
+        $cookieString = 'hello=world;react=php';
+        $cookies = ServerRequest::parseCookie($cookieString);
+        $this->assertEquals(array('hello' => 'world', 'react' => 'php'), $cookies);
     }
 }


### PR DESCRIPTION
This PR adds cookies to the PSR-7 ServerRequest. The implementation of cookies is line with the implementation of PHP.

I added a simple example to this to test this via a web browser.