### PR TITLE
Ignore HHVM test failures for now until Travis tests work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
     - php: 7.0
       env:
         - DEPENDENCIES=lowest
+  allow_failures:
+    - php: hhvm
 
 install:
   - composer install --no-interaction


### PR DESCRIPTION
Ignore HHVM test failures for now until Travis tests work again.

Refs #183 and #184 (unrelated test failures)