### PR TITLE
Automatically close response stream once client connection closes

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,12 @@ or use it for body data that needs to calculated.
 
 If the request handler resolves with a response stream that is already closed,
 it will simply send an empty response body.
+If the client closes the connection while the stream is still open, the
+response stream will automatically be closed.
+If a promise is resolved with a streaming body after the client closes, the
+response stream will automatically be closed.
+The `close` event can be used to clean up any pending resources allocated
+in this case (if applicable).
 
 If the response body is a `string`, a `Content-Length` header will be added
 automatically.

--- a/README.md
+++ b/README.md
@@ -507,6 +507,9 @@ This is just a example you could use of the streaming,
 you could also send a big amount of data via little chunks 
 or use it for body data that needs to calculated.
 
+If the request handler resolves with a response stream that is already closed,
+it will simply send an empty response body.
+
 If the response body is a `string`, a `Content-Length` header will be added
 automatically.
 If the response body is a ReactPHP `ReadableStreamInterface` and you do not

--- a/src/ChunkedEncoder.php
+++ b/src/ChunkedEncoder.php
@@ -52,11 +52,9 @@ class ChunkedEncoder extends EventEmitter implements ReadableStreamInterface
         }
 
         $this->closed = true;
-
-        $this->readable = false;
+        $this->input->close();
 
         $this->emit('close');
-
         $this->removeAllListeners();
     }
 

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -16,6 +16,7 @@ use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 use React\Promise\Stream;
+use React\Stream\ThroughStream;
 
 class FunctionalServerTest extends TestCase
 {
@@ -348,6 +349,33 @@ class FunctionalServerTest extends TestCase
 
         $this->assertContains("HTTP/1.0 200 OK", $response);
         $this->assertContains('https://127.0.0.1:80/', $response);
+
+        $socket->close();
+    }
+
+    public function testClosedStreamFromRequestHandlerWillBeSendEmptyBody()
+    {
+        $loop = Factory::create();
+        $socket = new Socket(0, $loop);
+        $connector = new Connector($loop);
+
+        $stream = new ThroughStream();
+        $stream->close();
+
+        $server = new Server($socket, function (RequestInterface $request) use ($stream) {
+            return new Response(200, array(), $stream);
+        });
+
+        $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
+            $conn->write("GET / HTTP/1.0\r\n\r\n");
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($result, $loop, 1.0);
+
+        $this->assertStringStartsWith("HTTP/1.0 200 OK", $response);
+        $this->assertStringEndsWith("\r\n\r\n", $response);
 
         $socket->close();
     }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -677,7 +677,39 @@ class ServerTest extends TestCase
         $this->assertStringEndsWith("\r\n\r\n0\r\n\r\n", $buffer);
     }
 
-    public function testStreamAlreadyClosedWillSendEmptyBodyPlainHttp10()
+    public function testResponseStreamEndingWillSendEmptyBodyChunkedEncoded()
+    {
+        $stream = new ThroughStream();
+
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+            return new Response(200, array(), $stream);
+        });
+
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $this->connection->emit('data', array($data));
+
+        $stream->end();
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringEndsWith("\r\n\r\n0\r\n\r\n", $buffer);
+    }
+
+    public function testResponseStreamAlreadyClosedWillSendEmptyBodyPlainHttp10()
     {
         $stream = new ThroughStream();
         $stream->close();
@@ -706,7 +738,73 @@ class ServerTest extends TestCase
 
         $this->assertStringStartsWith("HTTP/1.0 200 OK\r\n", $buffer);
         $this->assertStringEndsWith("\r\n\r\n", $buffer);
-}
+    }
+
+    public function testResponseStreamWillBeClosedIfConnectionIsAlreadyClosed()
+    {
+        $stream = new ThroughStream();
+        $stream->on('close', $this->expectCallableOnce());
+
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+            return new Response(200, array(), $stream);
+        });
+
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+
+        $this->connection = $this->getMockBuilder('React\Socket\Connection')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                array(
+                    'write',
+                    'end',
+                    'close',
+                    'pause',
+                    'resume',
+                    'isReadable',
+                    'isWritable',
+                    'getRemoteAddress',
+                    'getLocalAddress',
+                    'pipe'
+                )
+            )
+            ->getMock();
+
+        $this->connection->expects($this->once())->method('isWritable')->willReturn(false);
+        $this->connection->expects($this->never())->method('write');
+        $this->connection->expects($this->never())->method('write');
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+    }
+
+    public function testResponseStreamWillBeClosedIfConnectionEmitsCloseEvent()
+    {
+        $stream = new ThroughStream();
+        $stream->on('close', $this->expectCallableOnce());
+
+        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+            return new Response(200, array(), $stream);
+        });
+
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = $this->createGetRequest();
+        $this->connection->emit('data', array($data));
+        $this->connection->emit('close');
+    }
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {


### PR DESCRIPTION
Builds on top of #187
This is also a prerequisite for upcoming changes related to #98