### PR TITLE
Use duplex stream response body for CONNECT requests

### DIFF
--- a/examples/08-stream-response.php
+++ b/examples/08-stream-response.php
@@ -12,6 +12,10 @@ $loop = Factory::create();
 $socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 $server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
+    if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
+        return new Response(404);
+    }
+
     $stream = new ThroughStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {

--- a/examples/22-connect-proxy.php
+++ b/examples/22-connect-proxy.php
@@ -22,27 +22,10 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         );
     }
 
-    // pause consuming request body
-    $body = $request->getBody();
-    $body->pause();
-
-    $buffer = '';
-    $body->on('data', function ($chunk) use (&$buffer) {
-        $buffer .= $chunk;
-    });
-
     // try to connect to given target host
     return $connector->connect($request->getRequestTarget())->then(
-        function (ConnectionInterface $remote) use ($body, &$buffer) {
+        function (ConnectionInterface $remote) {
             // connection established => forward data
-            $body->pipe($remote);
-            $body->resume();
-
-            if ($buffer !== '') {
-                $remote->write($buffer);
-                $buffer = '';
-            }
-
             return new Response(
                 200,
                 array(),

--- a/src/HttpBodyStream.php
+++ b/src/HttpBodyStream.php
@@ -17,7 +17,7 @@ use React\Stream\Util;
  */
 class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableStreamInterface
 {
-    private $input;
+    public $input;
     private $closed = false;
     private $size;
 

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -79,6 +79,8 @@ class RequestHeaderParser extends EventEmitter
                 $originalTarget = $parts[1];
                 $parts[1] = '/';
                 $headers = implode(' ', $parts);
+            } else {
+                throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target');
             }
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -162,13 +162,6 @@ class Server extends EventEmitter
         $contentLength = 0;
         $stream = new CloseProtectionStream($conn);
         if ($request->getMethod() === 'CONNECT') {
-            // CONNECT method MUST use authority-form request target
-            $parts = parse_url('tcp://' . $request->getRequestTarget());
-            if (!isset($parts['scheme'], $parts['host'], $parts['port']) || count($parts) !== 3) {
-                $this->emit('error', array(new \InvalidArgumentException('CONNECT method MUST use authority-form request target')));
-                return $this->writeError($conn, 400);
-            }
-
             // CONNECT uses undelimited body until connection closes
             $request = $request->withoutHeader('Transfer-Encoding');
             $request = $request->withoutHeader('Content-Length');

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -446,6 +446,112 @@ class FunctionalServerTest extends TestCase
 
         $socket->close();
     }
+
+    public function testConnectWithThroughStreamReturnsDataAsGiven()
+    {
+        $loop = Factory::create();
+        $socket = new Socket(0, $loop);
+        $connector = new Connector($loop);
+
+        $server = new Server($socket, function (RequestInterface $request) use ($loop) {
+            $stream = new ThroughStream();
+
+            $loop->addTimer(0.1, function () use ($stream) {
+                $stream->end();
+            });
+
+            return new Response(200, array(), $stream);
+        });
+
+        $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
+            $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
+
+            $conn->once('data', function () use ($conn) {
+                $conn->write('hello');
+                $conn->write('world');
+            });
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($result, $loop, 1.0);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
+
+        $socket->close();
+    }
+
+    public function testConnectWithThroughStreamReturnedFromPromiseReturnsDataAsGiven()
+    {
+        $loop = Factory::create();
+        $socket = new Socket(0, $loop);
+        $connector = new Connector($loop);
+
+        $server = new Server($socket, function (RequestInterface $request) use ($loop) {
+            $stream = new ThroughStream();
+
+            $loop->addTimer(0.1, function () use ($stream) {
+                $stream->end();
+            });
+
+            return new Promise(function ($resolve) use ($loop, $stream) {
+                $loop->addTimer(0.001, function () use ($resolve, $stream) {
+                    $resolve(new Response(200, array(), $stream));
+                });
+            });
+        });
+
+        $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
+            $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
+
+            $conn->once('data', function () use ($conn) {
+                $conn->write('hello');
+                $conn->write('world');
+            });
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($result, $loop, 1.0);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
+
+        $socket->close();
+    }
+
+    public function testConnectWithClosedThroughStreamReturnsNoData()
+    {
+        $loop = Factory::create();
+        $socket = new Socket(0, $loop);
+        $connector = new Connector($loop);
+
+        $server = new Server($socket, function (RequestInterface $request) {
+            $stream = new ThroughStream();
+            $stream->close();
+
+            return new Response(200, array(), $stream);
+        });
+
+        $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
+            $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
+
+            $conn->once('data', function () use ($conn) {
+                $conn->write('hello');
+                $conn->write('world');
+            });
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($result, $loop, 1.0);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertStringEndsWith("\r\n\r\n", $response);
+
+        $socket->close();
+    }
 }
 
 function noScheme($uri)

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -261,6 +261,22 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Invalid Host header value', $error->getMessage());
     }
 
+    public function testInvalidConnectRequestWithNonAuthorityForm()
+    {
+        $error = null;
+
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $parser->feed("CONNECT http://example.com:8080/ HTTP/1.1\r\nHost: example.com:8080\r\n\r\n");
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertSame('CONNECT method MUST use authority-form request target', $error->getMessage());
+    }
+
     public function testInvalidHttpVersion()
     {
         $error = null;


### PR DESCRIPTION
Builds on top of #188 and #158
This is also a prerequisite for upcoming changes related to #98