### PR TITLE
Support Upgrade header such as `Upgrade: WebSocket` or custom protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,17 +559,33 @@ to the message if the same request would have used an (unconditional) `GET`.
   implements ReactPHP's
   [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface)
   (such as the `ThroughStream` in the above example).
-
+>
 > For *most* cases, this will simply only consume its readable side and forward
   (send) any data that is emitted by the stream, thus entirely ignoring the
   writable side of the stream.
-  If however this is a `2xx` (Successful) response to a `CONNECT` method, it
-  will also *write* data to the writable side of the stream.
+  If however this is either a `101` (Switching Protocols) response or a `2xx`
+  (Successful) response to a `CONNECT` method, it will also *write* data to the
+  writable side of the stream.
   This can be avoided by either rejecting all requests with the `CONNECT`
   method (which is what most *normal* origin HTTP servers would likely do) or
   or ensuring that only ever an instance of `ReadableStreamInterface` is
   used.
-  
+>
+> The `101` (Switching Protocols) response code is useful for the more advanced
+  `Upgrade` requests, such as upgrading to the WebSocket protocol or
+  implementing custom protocol logic that is out of scope of the HTTP specs and
+  this HTTP library.
+  If you want to handle the `Upgrade: WebSocket` header, you will likely want
+  to look into using [Ratchet](http://socketo.me/) instead.
+  If you want to handle a custom protocol, you will likely want to look into the
+  [HTTP specs](https://tools.ietf.org/html/rfc7230#section-6.7) and also see
+  [examples #31 and #32](examples) for more details.
+  In particular, the `101` (Switching Protocols) response code MUST NOT be used
+  unless you send an `Upgrade` response header value that is also present in
+  the corresponding HTTP/1.1 `Upgrade` request header value.
+  The server automatically takes care of sending a `Connection: upgrade`
+  header value in this case, so you don't have to.
+>
 > The `CONNECT` method is useful in a tunneling setup (HTTPS proxy) and not
   something most origin HTTP servers would want to care about.
   The HTTP specs define an opaque "tunneling mode" for this method and make no

--- a/examples/31-upgrade-echo.php
+++ b/examples/31-upgrade-echo.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+Here's the gist to get you started:
+
+$ telnet localhost 1080
+> GET / HTTP/1.1
+> Upgrade: echo
+>
+< HTTP/1.1 101 Switching Protocols
+< Upgrade: echo
+< Connection: upgrade
+<
+> hello
+< hello
+> world
+< world
+*/
+
+use React\EventLoop\Factory;
+use React\Http\Server;
+use React\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Stream\ReadableStream;
+use React\Stream\ThroughStream;
+use React\Stream\CompositeStream;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+
+$server = new Server($socket, function (ServerRequestInterface $request) use ($loop) {
+    if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
+        return new Response(426, array('Upgrade' => 'echo'), '"Upgrade: echo" required');
+    }
+
+    // simply return a duplex ThroughStream here
+    // it will simply emit any data that is sent to it
+    // this means that any Upgraded data will simply be sent back to the client
+    $stream = new ThroughStream();
+
+    $loop->addTimer(0, function () use ($stream) {
+        $stream->write("Hello! Anything you send will be piped back." . PHP_EOL);
+    });
+
+    return new Response(
+        101,
+        array(
+            'Upgrade' => 'echo'
+        ),
+        $stream
+    );
+});
+
+echo 'Listening on http://' . $socket->getAddress() . PHP_EOL;
+
+$loop->run();

--- a/examples/32-upgrade-chat.php
+++ b/examples/32-upgrade-chat.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+Here's the gist to get you started:
+
+$ telnet localhost 1080
+> GET / HTTP/1.1
+> Upgrade: chat
+>
+< HTTP/1.1 101 Switching Protocols
+< Upgrade: chat
+< Connection: upgrade
+<
+> hello
+< user123: hello
+> world
+< user123: world
+
+Hint: try this with multiple connections :)
+*/
+
+use React\EventLoop\Factory;
+use React\Http\Server;
+use React\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Stream\ReadableStream;
+use React\Stream\ThroughStream;
+use React\Stream\CompositeStream;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+
+// simply use a shared duplex ThroughStream for all clients
+// it will simply emit any data that is sent to it
+// this means that any Upgraded data will simply be sent back to the client
+$chat = new ThroughStream();
+
+$server = new Server($socket, function (ServerRequestInterface $request) use ($loop, $chat) {
+    if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
+        return new Response(426, array('Upgrade' => 'chat'), '"Upgrade: chat" required');
+    }
+
+    // user stream forwards chat data and accepts incoming data
+    $out = $chat->pipe(new ThroughStream());
+    $in = new ThroughStream();
+    $stream = new CompositeStream(
+        $out,
+        $in
+    );
+
+    // assign some name for this new connection
+    $username = 'user' . mt_rand();
+
+    // send anything that is received to the whole channel
+    $in->on('data', function ($data) use ($username, $chat) {
+        $data = trim(preg_replace('/[^\w\d \.\,\-\!\?]/u', '', $data));
+
+        $chat->write($username . ': ' . $data . PHP_EOL);
+    });
+
+    // say hello to new user
+    $loop->addTimer(0, function () use ($chat, $username, $out) {
+        $out->write('Welcome to this chat example, ' . $username . '!' . PHP_EOL);
+        $chat->write($username . ' joined' . PHP_EOL);
+    });
+
+    // send goodbye to channel once connection closes
+    $stream->on('close', function () use ($username, $chat) {
+        $chat->write($username . ' left' . PHP_EOL);
+    });
+
+    return new Response(
+        101,
+        array(
+            'Upgrade' => 'chat'
+        ),
+        $stream
+    );
+});
+
+echo 'Listening on http://' . $socket->getAddress() . PHP_EOL;
+
+$loop->run();


### PR DESCRIPTION
The title says it all. If you want to understand my excitement, try out the new example 32 :tada: :tada: :tada: 

Builds on top of #189 which implements the base logic also for the `CONNECT` request method.
Resolves / closes #98
Supersedes / closes #159