### PR TITLE
Add listen() method to support multiple listening sockets

### DIFF
--- a/examples/01-hello-world.php
+++ b/examples/01-hello-world.php
@@ -1,16 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -19,6 +18,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         "Hello world\n"
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/02-count-visitors.php
+++ b/examples/02-count-visitors.php
@@ -1,23 +1,25 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 $counter = 0;
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use (&$counter) {
+$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
         "Welcome number " . ++$counter . "!\n"
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/03-client-ip.php
+++ b/examples/03-client-ip.php
@@ -1,16 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
@@ -19,6 +18,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         $body
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/04-query-parameter.php
+++ b/examples/04-query-parameter.php
@@ -1,16 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -26,6 +25,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         $body
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/05-cookie-handling.php
+++ b/examples/05-cookie-handling.php
@@ -1,16 +1,15 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -32,6 +31,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         "Your cookie has been set."
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/06-sleep.php
+++ b/examples/06-sleep.php
@@ -3,15 +3,14 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
+use React\Http\Server;
 use React\Promise\Promise;
-use React\Socket\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(
@@ -23,6 +22,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         });
     });
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/07-error-handling.php
+++ b/examples/07-error-handling.php
@@ -1,18 +1,17 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 $count = 0;
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use (&$count) {
+$server = new Server(function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 
@@ -29,6 +28,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         $resolve($response);
     });
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/08-stream-response.php
+++ b/examples/08-stream-response.php
@@ -1,17 +1,16 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop,function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }
@@ -33,6 +32,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         $stream
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/09-stream-request.php
+++ b/examples/09-stream-request.php
@@ -1,17 +1,16 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
         $request->getBody()->on('data', function ($data) use (&$contentLength) {
@@ -38,6 +37,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         });
     });
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/11-hello-world-https.php
+++ b/examples/11-hello-world-https.php
@@ -1,26 +1,27 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
-use React\Socket\SecureServer;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
-$socket = new SecureServer($socket, $loop, array(
-    'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
-));
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
         "Hello world!\n"
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\SecureServer($socket, $loop, array(
+    'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
+));
+$server->listen($socket);
 
 //$socket->on('error', 'printf');
 

--- a/examples/21-http-proxy.php
+++ b/examples/21-http-proxy.php
@@ -1,17 +1,16 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\RequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new \React\Http\Server($socket, function (RequestInterface $request) {
+$server = new Server(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,
@@ -38,7 +37,8 @@ $server = new \React\Http\Server($socket, function (RequestInterface $request) {
     );
 });
 
-//$server->on('error', 'printf');
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/22-connect-proxy.php
+++ b/examples/22-connect-proxy.php
@@ -1,19 +1,18 @@
 <?php
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 $connector = new Connector($loop);
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($connector) {
+$server = new Server(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,
@@ -42,7 +41,8 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
     );
 });
 
-//$server->on('error', 'printf');
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/31-upgrade-echo.php
+++ b/examples/31-upgrade-echo.php
@@ -17,20 +17,17 @@ $ telnet localhost 1080
 < world
 */
 
-use React\EventLoop\Factory;
-use React\Http\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
-use React\Stream\ReadableStream;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Stream\ThroughStream;
-use React\Stream\CompositeStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
-$server = new Server($socket, function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(426, array('Upgrade' => 'echo'), '"Upgrade: echo" required');
     }
@@ -52,6 +49,9 @@ $server = new Server($socket, function (ServerRequestInterface $request) use ($l
         $stream
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/32-upgrade-chat.php
+++ b/examples/32-upgrade-chat.php
@@ -19,25 +19,23 @@ $ telnet localhost 1080
 Hint: try this with multiple connections :)
 */
 
-use React\EventLoop\Factory;
-use React\Http\Server;
-use React\Http\Response;
 use Psr\Http\Message\ServerRequestInterface;
-use React\Stream\ReadableStream;
-use React\Stream\ThroughStream;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Stream\CompositeStream;
+use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 // simply use a shared duplex ThroughStream for all clients
 // it will simply emit any data that is sent to it
 // this means that any Upgraded data will simply be sent back to the client
 $chat = new ThroughStream();
 
-$server = new Server($socket, function (ServerRequestInterface $request) use ($loop, $chat) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop, $chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(426, array('Upgrade' => 'chat'), '"Upgrade: chat" required');
     }
@@ -79,6 +77,9 @@ $server = new Server($socket, function (ServerRequestInterface $request) use ($l
         $stream
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/examples/99-benchmark-download.php
+++ b/examples/99-benchmark-download.php
@@ -6,18 +6,17 @@
 // $ ab -n10 -c10 http://localhost:8080/1g.bin
 // $ docker run -it --rm --net=host jordi/ab ab -n10 -c10 http://localhost:8080/1g.bin
 
-use React\EventLoop\Factory;
-use React\Socket\Server;
-use React\Http\Response;
-use Psr\Http\Message\ServerRequestInterface;
 use Evenement\EventEmitter;
+use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\Server;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
-$socket = new Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 
 /** A readable stream that can emit a lot of data */
 class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
@@ -87,7 +86,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-$server = new \React\Http\Server($socket, function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
@@ -113,6 +112,9 @@ $server = new \React\Http\Server($socket, function (ServerRequestInterface $requ
         $stream
     );
 });
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
 

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -12,7 +12,6 @@ use Clue\React\Block;
 use React\Http\Response;
 use React\Socket\SecureServer;
 use React\Stream\ReadableStreamInterface;
-use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 use React\Promise\Stream;
@@ -23,12 +22,14 @@ class FunctionalServerTest extends TestCase
     public function testPlainHttpOnRandomPort()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: " . noScheme($conn->getRemoteAddress()) . "\r\n\r\n");
@@ -47,12 +48,14 @@ class FunctionalServerTest extends TestCase
     public function testPlainHttpOnRandomPortWithoutHostHeaderUsesSocketUri()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -71,12 +74,14 @@ class FunctionalServerTest extends TestCase
     public function testPlainHttpOnRandomPortWithOtherHostHeaderTakesPrecedence()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: localhost:1000\r\n\r\n");
@@ -99,17 +104,19 @@ class FunctionalServerTest extends TestCase
         }
 
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
-        $socket = new SecureServer($socket, $loop, array(
-            'local_cert' => __DIR__ . '/../examples/localhost.pem'
-        ));
         $connector = new Connector($loop, array(
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $socket = new Socket(0, $loop);
+        $socket = new SecureServer($socket, $loop, array(
+            'local_cert' => __DIR__ . '/../examples/localhost.pem'
+        ));
+        $server->listen($socket);
 
         $result = $connector->connect('tls://' . noScheme($socket->getAddress()))->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: " . noScheme($conn->getRemoteAddress()) . "\r\n\r\n");
@@ -132,17 +139,19 @@ class FunctionalServerTest extends TestCase
         }
 
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
-        $socket = new SecureServer($socket, $loop, array(
-            'local_cert' => __DIR__ . '/../examples/localhost.pem'
-        ));
         $connector = new Connector($loop, array(
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $socket = new Socket(0, $loop);
+        $socket = new SecureServer($socket, $loop, array(
+            'local_cert' => __DIR__ . '/../examples/localhost.pem'
+        ));
+        $server->listen($socket);
 
         $result = $connector->connect('tls://' . noScheme($socket->getAddress()))->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -168,9 +177,11 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n");
@@ -196,9 +207,11 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -233,9 +246,11 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect('tls://' . noScheme($socket->getAddress()))->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n");
@@ -270,9 +285,11 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect('tls://' . noScheme($socket->getAddress()))->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -298,9 +315,11 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: " . noScheme($conn->getRemoteAddress()) . "\r\n\r\n");
@@ -335,9 +354,11 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri() . 'x' . $request->getHeaderLine('Host'));
         });
+
+        $server->listen($socket);
 
         $result = $connector->connect('tls://' . noScheme($socket->getAddress()))->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: " . noScheme($conn->getRemoteAddress()) . "\r\n\r\n");
@@ -356,15 +377,17 @@ class FunctionalServerTest extends TestCase
     public function testClosedStreamFromRequestHandlerWillSendEmptyBody()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server($socket, function (RequestInterface $request) use ($stream) {
+        $server = new Server(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -383,15 +406,17 @@ class FunctionalServerTest extends TestCase
     public function testStreamFromRequestHandlerWillBeClosedIfConnectionClosesWhileSendingBody()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server($socket, function (RequestInterface $request) use ($stream) {
+        $server = new Server(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
             $conn->write("GET / HTTP/1.0\r\nContent-Length: 100\r\n\r\n");
@@ -414,15 +439,17 @@ class FunctionalServerTest extends TestCase
     public function testStreamFromRequestHandlerWillBeClosedIfConnectionClosesButWillOnlyBeDetectedOnNextWrite()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server($socket, function (RequestInterface $request) use ($stream) {
+        $server = new Server(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
@@ -450,10 +477,9 @@ class FunctionalServerTest extends TestCase
     public function testUpgradeWithThroughStreamReturnsDataAsGiven()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) use ($loop) {
+        $server = new Server(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -462,6 +488,9 @@ class FunctionalServerTest extends TestCase
 
             return new Response(101, array('Upgrade' => 'echo'), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.1\r\nHost: example.com:80\r\nUpgrade: echo\r\n\r\n");
@@ -485,10 +514,9 @@ class FunctionalServerTest extends TestCase
     public function testConnectWithThroughStreamReturnsDataAsGiven()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) use ($loop) {
+        $server = new Server(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -497,6 +525,9 @@ class FunctionalServerTest extends TestCase
 
             return new Response(200, array(), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
@@ -520,10 +551,9 @@ class FunctionalServerTest extends TestCase
     public function testConnectWithThroughStreamReturnedFromPromiseReturnsDataAsGiven()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) use ($loop) {
+        $server = new Server(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -536,6 +566,9 @@ class FunctionalServerTest extends TestCase
                 });
             });
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");
@@ -559,15 +592,17 @@ class FunctionalServerTest extends TestCase
     public function testConnectWithClosedThroughStreamReturnsNoData()
     {
         $loop = Factory::create();
-        $socket = new Socket(0, $loop);
         $connector = new Connector($loop);
 
-        $server = new Server($socket, function (RequestInterface $request) {
+        $server = new Server(function (RequestInterface $request) {
             $stream = new ThroughStream();
             $stream->close();
 
             return new Response(200, array(), $stream);
         });
+
+        $socket = new Socket(0, $loop);
+        $server->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n");

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -41,8 +41,9 @@ class ServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = '';
@@ -52,10 +53,11 @@ class ServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -66,7 +68,7 @@ class ServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
 
@@ -78,6 +80,7 @@ class ServerTest extends TestCase
             ->method('getRemoteAddress')
             ->willReturn('127.0.0.1:8080');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -99,11 +102,12 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
@@ -121,11 +125,12 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
@@ -143,11 +148,12 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
@@ -165,11 +171,12 @@ class ServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -185,9 +192,10 @@ class ServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET * HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -197,11 +205,12 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
@@ -219,11 +228,12 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
@@ -241,11 +251,12 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBeOverwritten()
     {
         $requestAssertion = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
@@ -262,9 +273,10 @@ class ServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "CONNECT / HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -273,9 +285,10 @@ class ServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET example.com:80 HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -286,7 +299,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
@@ -296,6 +309,7 @@ class ServerTest extends TestCase
             ->method('getLocalAddress')
             ->willReturn('127.0.0.1:80');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET /test HTTP/1.0\r\n\r\n";
@@ -312,11 +326,12 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -334,12 +349,13 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
         $server->on('error', 'printf');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET http://example.com:8080/test HTTP/1.0\r\n\r\n";
@@ -357,11 +373,12 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
@@ -379,11 +396,12 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -401,11 +419,12 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "OPTIONS http://example.com HTTP/1.1\r\nHost: example.com\r\n\r\n";
@@ -421,12 +440,14 @@ class ServerTest extends TestCase
 
     public function testRequestPauseWillbeForwardedToConnection()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $request->getBody()->pause();
             return new Response();
         });
 
         $this->connection->expects($this->once())->method('pause');
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -440,12 +461,14 @@ class ServerTest extends TestCase
 
     public function testRequestResumeWillbeForwardedToConnection()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $request->getBody()->resume();
             return new Response();
         });
 
         $this->connection->expects($this->once())->method('resume');
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -454,12 +477,14 @@ class ServerTest extends TestCase
 
     public function testRequestCloseWillPauseConnection()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             return new Response();
         });
 
         $this->connection->expects($this->once())->method('pause');
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -468,7 +493,7 @@ class ServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();#
 
@@ -476,6 +501,8 @@ class ServerTest extends TestCase
         });
 
         $this->connection->expects($this->once())->method('pause');
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -484,7 +511,7 @@ class ServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
 
@@ -493,6 +520,8 @@ class ServerTest extends TestCase
 
         $this->connection->expects($this->once())->method('pause');
         $this->connection->expects($this->never())->method('resume');
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -503,12 +532,13 @@ class ServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($never) {
+        $server = new Server(function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
 
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -519,12 +549,13 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($once) {
+        $server = new Server(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
 
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = '';
@@ -540,12 +571,13 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($once) {
+        $server = new Server(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
 
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = '';
@@ -562,7 +594,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsPoweredByHeader()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -579,6 +611,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -591,7 +624,7 @@ class ServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($never) {
+        $server = new Server(function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -608,6 +641,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -620,7 +654,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($once) {
+        $server = new Server(function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -637,6 +671,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -651,7 +686,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -668,6 +703,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -681,7 +717,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -698,6 +734,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -714,7 +751,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -731,6 +768,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n";
@@ -745,7 +783,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -784,6 +822,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('write');
         $this->connection->expects($this->never())->method('write');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -795,10 +834,11 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -808,7 +848,7 @@ class ServerTest extends TestCase
 
     public function testUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(200, array('date' => '', 'x-powered-by' => '', 'Upgrade' => 'demo'), 'foo');
         });
 
@@ -825,6 +865,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n\r\n";
@@ -835,7 +876,7 @@ class ServerTest extends TestCase
 
     public function testUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(200, array('date' => '', 'x-powered-by' => ''), 'foo');
         });
 
@@ -852,6 +893,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
@@ -862,7 +904,7 @@ class ServerTest extends TestCase
 
     public function testUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(101, array('date' => '', 'x-powered-by' => '', 'Upgrade' => 'demo'), 'foo');
         });
 
@@ -881,6 +923,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
@@ -893,7 +936,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(101, array('date' => '', 'x-powered-by' => '', 'Upgrade' => 'demo'), $stream);
         });
 
@@ -910,6 +953,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
@@ -925,7 +969,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -942,6 +986,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
@@ -958,10 +1003,11 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $this->connection->expects($this->once())->method('pipe')->with($stream);
@@ -972,7 +1018,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $response = new Response(200, array(), 'bye');
             return \React\Promise\resolve($response);
         });
@@ -990,6 +1036,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -1001,7 +1048,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $response = new Response(200, array(), 'bye');
             return \React\Promise\resolve($response);
         });
@@ -1019,6 +1066,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -1031,7 +1079,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(200, array(), 'bye');
         });
 
@@ -1047,6 +1095,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -1058,7 +1107,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(204, array(), 'bye');
         });
 
@@ -1074,6 +1123,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -1086,7 +1136,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(304, array(), 'bye');
         });
 
@@ -1102,6 +1152,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
@@ -1115,7 +1166,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1133,6 +1184,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.2\r\nHost: localhost\r\n\r\n";
@@ -1148,7 +1200,7 @@ class ServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1166,6 +1218,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
@@ -1181,7 +1234,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1199,6 +1252,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "bad request\r\n\r\n";
@@ -1217,7 +1271,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1226,6 +1280,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1246,7 +1301,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1256,6 +1311,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1278,7 +1334,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1287,7 +1343,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
-
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1309,7 +1365,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1318,6 +1374,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1337,7 +1394,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1346,7 +1403,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
-
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1367,7 +1424,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1376,7 +1433,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
-
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1392,7 +1449,7 @@ class ServerTest extends TestCase
     public function testRequestWithMalformedHostWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1410,6 +1467,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: ///\r\n\r\n";
@@ -1424,7 +1482,7 @@ class ServerTest extends TestCase
     public function testRequestWithInvalidHostUriComponentsWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1442,6 +1500,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: localhost:80/test\r\n\r\n";
@@ -1460,7 +1519,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1469,6 +1528,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1490,7 +1550,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1499,7 +1559,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
-
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1524,7 +1584,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1533,6 +1593,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1551,7 +1612,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1560,6 +1621,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1579,7 +1641,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1588,6 +1650,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1611,7 +1674,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1621,6 +1684,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1649,7 +1713,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1659,6 +1723,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1683,7 +1748,7 @@ class ServerTest extends TestCase
     public function testNonIntegerContentLengthValueWillLeadToError()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1700,6 +1765,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1719,7 +1785,7 @@ class ServerTest extends TestCase
     public function testNonIntegerContentLengthValueWillLeadToErrorWithNoBodyForHeadRequest()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1736,6 +1802,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "HEAD / HTTP/1.1\r\n";
@@ -1755,7 +1822,7 @@ class ServerTest extends TestCase
     public function testMultipleIntegerInContentLengthWillLeadToError()
     {
         $error = null;
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1772,6 +1839,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1791,7 +1859,7 @@ class ServerTest extends TestCase
     public function testInvalidChunkHeaderResultsInErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server($this->socket, function ($request) use ($errorEvent){
+        $server = new Server(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1799,6 +1867,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1814,7 +1883,7 @@ class ServerTest extends TestCase
     public function testTooLongChunkHeaderResultsInErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server($this->socket, function ($request) use ($errorEvent){
+        $server = new Server(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1822,6 +1891,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1839,7 +1909,7 @@ class ServerTest extends TestCase
     public function testTooLongChunkBodyResultsInErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server($this->socket, function ($request) use ($errorEvent){
+        $server = new Server(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1847,6 +1917,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1862,7 +1933,7 @@ class ServerTest extends TestCase
     public function testUnexpectedEndOfConnectionWillResultsInErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server($this->socket, function ($request) use ($errorEvent){
+        $server = new Server(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1870,6 +1941,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1885,13 +1957,14 @@ class ServerTest extends TestCase
 
     public function testErrorInChunkedDecoderNeverClosesConnection()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1906,13 +1979,14 @@ class ServerTest extends TestCase
 
     public function testErrorInLengthLimitedStreamNeverClosesConnection()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -1928,7 +2002,7 @@ class ServerTest extends TestCase
 
     public function testCloseRequestWillPauseConnection()
     {
-        $server = new Server($this->socket, function ($request) {
+        $server = new Server(function ($request) {
             $request->getBody()->close();
             return \React\Promise\resolve(new Response());
         });
@@ -1936,6 +2010,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
         $this->connection->expects($this->once())->method('pause');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -1949,7 +2024,7 @@ class ServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = new Server(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -1961,6 +2036,7 @@ class ServerTest extends TestCase
         $this->connection->expects($this->once())->method('pause');
         $this->connection->expects($this->never())->method('close');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -1975,7 +2051,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1984,6 +2060,7 @@ class ServerTest extends TestCase
             return \React\Promise\resolve(new Response());
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -1995,7 +2072,7 @@ class ServerTest extends TestCase
     public function testResponseWillBeChunkDecodedByDefault()
     {
         $stream = new ThroughStream();
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             $response = new Response(200, array(), $stream);
             return \React\Promise\resolve($response);
         });
@@ -2012,6 +2089,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2025,7 +2103,7 @@ class ServerTest extends TestCase
 
     public function testContentLengthWillBeRemovedForResponseStream()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $response = new Response(
                 200,
                 array(
@@ -2050,6 +2128,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2064,7 +2143,7 @@ class ServerTest extends TestCase
     public function testOnlyAllowChunkedEncoding()
     {
         $stream = new ThroughStream();
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($stream) {
+        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
             $response = new Response(
                 200,
                 array(
@@ -2088,6 +2167,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2102,7 +2182,7 @@ class ServerTest extends TestCase
 
     public function testDateHeaderWillBeAddedWhenNoneIsGiven()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2118,6 +2198,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2131,7 +2212,7 @@ class ServerTest extends TestCase
 
     public function testAddCustomDateHeader()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $response = new Response(200, array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT"));
             return \React\Promise\resolve($response);
         });
@@ -2148,6 +2229,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2161,7 +2243,7 @@ class ServerTest extends TestCase
 
     public function testRemoveDateHeader()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             $response = new Response(200, array('Date' => ''));
             return \React\Promise\resolve($response);
         });
@@ -2178,6 +2260,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2193,7 +2276,7 @@ class ServerTest extends TestCase
     {
         $error = null;
 
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($exception) use (&$error) {
             $error = $exception;
         });
@@ -2209,6 +2292,8 @@ class ServerTest extends TestCase
                     }
                 )
             );
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -2228,7 +2313,7 @@ class ServerTest extends TestCase
     {
         $error = null;
 
-        $server = new Server($this->socket, $this->expectCallableNever());
+        $server = new Server($this->expectCallableNever());
         $server->on('error', function ($exception) use (&$error) {
             $error = $exception;
         });
@@ -2244,6 +2329,8 @@ class ServerTest extends TestCase
                     }
                 )
             );
+
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n";
@@ -2259,7 +2346,7 @@ class ServerTest extends TestCase
 
     public function test100ContinueRequestWillBeHandled()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2275,6 +2362,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -2290,7 +2378,7 @@ class ServerTest extends TestCase
 
     public function testContinueWontBeSendForHttp10()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2306,6 +2394,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n";
@@ -2319,7 +2408,7 @@ class ServerTest extends TestCase
 
     public function testContinueWithLaterResponse()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2336,6 +2425,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -2355,14 +2445,14 @@ class ServerTest extends TestCase
      */
     public function testInvalidCallbackFunctionLeadsToException()
     {
-        $server = new Server($this->socket, 'invalid');
+        $server = new Server('invalid');
     }
 
     public function testHttpBodyStreamAsBodyWillStreamData()
     {
         $input = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($input) {
+        $server = new Server(function (ServerRequestInterface $request) use ($input) {
             $response = new Response(200, array(), $input);
             return \React\Promise\resolve($response);
         });
@@ -2379,6 +2469,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2397,7 +2488,7 @@ class ServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use ($input) {
+        $server = new Server(function (ServerRequestInterface $request) use ($input) {
             $response = new Response(200, array('Content-Length' => 5), $input);
             return \React\Promise\resolve($response);
         });
@@ -2414,6 +2505,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2431,7 +2523,7 @@ class ServerTest extends TestCase
 
     public function testCallbackFunctionReturnsPromise()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2447,6 +2539,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2458,7 +2551,7 @@ class ServerTest extends TestCase
 
     public function testReturnInvalidTypeWillResultInError()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2479,6 +2572,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2493,7 +2587,7 @@ class ServerTest extends TestCase
 
     public function testResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2509,6 +2603,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2522,7 +2617,7 @@ class ServerTest extends TestCase
 
     public function testRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2541,6 +2636,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2554,7 +2650,7 @@ class ServerTest extends TestCase
 
     public function testExcpetionInCallbackWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2573,6 +2669,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2586,7 +2683,7 @@ class ServerTest extends TestCase
 
     public function testHeaderWillAlwaysBeContentLengthForStringBody()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response(200, array('Transfer-Encoding' => 'chunked'), 'hello');
         });
 
@@ -2602,6 +2699,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2619,7 +2717,7 @@ class ServerTest extends TestCase
 
     public function testReturnRequestWillBeHandled()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2635,6 +2733,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2648,7 +2747,7 @@ class ServerTest extends TestCase
 
     public function testExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2669,6 +2768,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2684,7 +2784,7 @@ class ServerTest extends TestCase
 
     public function testRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new Server($this->socket, function (ServerRequestInterface $request) {
+        $server = new Server(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2707,6 +2807,7 @@ class ServerTest extends TestCase
                 )
             );
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.0\r\n\r\n";
@@ -2722,7 +2823,7 @@ class ServerTest extends TestCase
     public function testServerRequestParams()
     {
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
             return new Response();
         });
@@ -2737,6 +2838,7 @@ class ServerTest extends TestCase
             ->method('getLocalAddress')
             ->willReturn('127.0.0.1:8080');
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = $this->createGetRequest();
@@ -2756,11 +2858,12 @@ class ServerTest extends TestCase
     public function testQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET /foo.php?hello=world&test=bar HTTP/1.0\r\n\r\n";
@@ -2776,11 +2879,12 @@ class ServerTest extends TestCase
     public function testCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -2797,11 +2901,12 @@ class ServerTest extends TestCase
     public function testMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";
@@ -2818,11 +2923,12 @@ class ServerTest extends TestCase
     public function testCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server($this->socket, function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
             return new Response();
         });
 
+        $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
The new `listen()` method allows the server to listen on multiple sockets (such as multiple IPs and/or HTTP and HTTPS).

In the future, the `listen()` method may also support specifying an address string, but specifics have yet to be worked out.

Builds on top of #97 and prepares this for future middleware support via #179.