### PR TITLE
(WIP) feat(server-params): further define common server params

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -91,7 +91,12 @@ class RequestHeaderParser extends EventEmitter
         // previous properties and restoring original request-target
         $serverParams = array(
             'REQUEST_TIME' => time(),
-            'REQUEST_TIME_FLOAT' => microtime(true)
+            'REQUEST_TIME_FLOAT' => microtime(true),
+            'REQUEST_METHOD' => $request->getMethod(),
+            'CONTENT_LENGTH' => strlen($data),
+            'QUERY_STRING' => (string)parse_url($request->getUri(), PHP_URL_QUERY),
+            'SERVER_SOFTWARE' => 'reactphp/http',
+            'SERVER_PROTOCOL' => $request->getProtocolVersion(),
         );
 
         if ($this->remoteSocketUri !== null) {


### PR DESCRIPTION
Marking this is a WIP for now, need to further look at the best way to get `SCRIPT_FILENAME`.. somewhat might not be possible.. unless its passed as an option or defined elsewhere... if nothing else I think it should be set to an empty string though due to https://github.com/reactphp/http/issues/192

```
'SCRIPT_FILENAME'
The absolute pathname of the currently executing script.
```

- [ ] HTTP_HOST
- [ ] SCRIPT_FILENAME
- [ ] HTTP_USER_AGENT
- [ ] Should HTTPS be set to an empty string on non-https? (think so)
- [ ] Convert to long array Syntax to support an unsupported PHP version from 8 years ago

https://secure.php.net/manual/en/reserved.variables.server.php