### PR TITLE
UploadedFile implementing UploadedFileInterface

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace React\Http;
+
+use InvalidArgumentException;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+
+final class UploadedFile implements UploadedFileInterface
+{
+    /**
+     * @var StreamInterface
+     */
+    private $stream;
+
+    /**
+     * @var int
+     */
+    private $size;
+
+    /**
+     * @var int
+     */
+    private $error;
+
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var string
+     */
+    private $mediaType;
+
+    /**
+     * @param StreamInterface $stream
+     * @param int $size
+     * @param int $error
+     * @param string $filename
+     * @param string $mediaType
+     */
+    public function __construct(StreamInterface $stream, $size, $error, $filename, $mediaType)
+    {
+        $this->stream = $stream;
+        $this->size = $size;
+
+        if (!is_int($error) || !in_array($error, [
+            UPLOAD_ERR_OK,
+            UPLOAD_ERR_INI_SIZE,
+            UPLOAD_ERR_FORM_SIZE,
+            UPLOAD_ERR_PARTIAL,
+            UPLOAD_ERR_NO_FILE,
+            UPLOAD_ERR_NO_TMP_DIR,
+            UPLOAD_ERR_CANT_WRITE,
+            UPLOAD_ERR_EXTENSION,
+        ])) {
+            throw new InvalidArgumentException(
+                'Invalid error code, must be an UPLOAD_ERR_* constant'
+            );
+        }
+        $this->error = $error;
+        $this->filename = $filename;
+        $this->mediaType = $mediaType;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStream()
+    {
+        if ($this->error !== UPLOAD_ERR_OK) {
+            throw new RuntimeException('Cannot retrieve stream due to upload error');
+        }
+
+        return $this->stream;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function moveTo($targetPath)
+    {
+       throw new RuntimeException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientFilename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientMediaType()
+    {
+        return $this->mediaType;
+    }
+}

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -7,6 +7,9 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
 
+/**
+ * @internal
+ */
 final class UploadedFile implements UploadedFileInterface
 {
     /**

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -46,7 +46,7 @@ final class UploadedFile implements UploadedFileInterface
         $this->stream = $stream;
         $this->size = $size;
 
-        if (!is_int($error) || !in_array($error, [
+        if (!is_int($error) || !in_array($error, array(
             UPLOAD_ERR_OK,
             UPLOAD_ERR_INI_SIZE,
             UPLOAD_ERR_FORM_SIZE,
@@ -55,7 +55,7 @@ final class UploadedFile implements UploadedFileInterface
             UPLOAD_ERR_NO_TMP_DIR,
             UPLOAD_ERR_CANT_WRITE,
             UPLOAD_ERR_EXTENSION,
-        ])) {
+        ))) {
             throw new InvalidArgumentException(
                 'Invalid error code, must be an UPLOAD_ERR_* constant'
             );

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -21,19 +21,21 @@ class UploadedFileTest extends TestCase
 
     /**
      * @dataProvider failtyErrorProvider
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid error code, must be an UPLOAD_ERR_* constant
      */
     public function testFailtyError($error)
     {
-        self::expectException('\InvalidArgumentException');
-        self::expectExceptionMessage('Invalid error code, must be an UPLOAD_ERR_* constant');
         $stream = new BufferStream();
         new UploadedFile($stream, 0, $error, 'foo.bar', 'foo/bar');
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Not implemented
+     */
     public function testNoMoveFile()
     {
-        self::expectException('\RuntimeException');
-        self::expectExceptionMessage('Not implemented');
         $stream = new BufferStream();
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
         $uploadedFile->moveTo('bar.foo');
@@ -50,10 +52,12 @@ class UploadedFileTest extends TestCase
         self::assertSame('foo/bar',     $uploadedFile->getClientMediaType());
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot retrieve stream due to upload error
+     */
     public function testGetStreamOnFailedUpload()
     {
-        self::expectException('\RuntimeException');
-        self::expectExceptionMessage('Cannot retrieve stream due to upload error');
         $stream = new BufferStream();
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_NO_FILE, 'foo.bar', 'foo/bar');
         $uploadedFile->getStream();

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace React\Tests\Http;
+
+use React\Http\Response;
+use React\Http\UploadedFile;
+use React\Stream\ThroughStream;
+use RingCentral\Psr7\BufferStream;
+
+class UploadedFileTest extends TestCase
+{
+    public function failtyErrorProvider()
+    {
+        return array(
+            array('a'),
+            array(null),
+            array(-1),
+            array(9),
+        );
+    }
+
+    /**
+     * @dataProvider failtyErrorProvider
+     */
+    public function testFailtyError($error)
+    {
+        self::expectException('\InvalidArgumentException');
+        self::expectExceptionMessage('Invalid error code, must be an UPLOAD_ERR_* constant');
+        $stream = new BufferStream();
+        new UploadedFile($stream, 0, $error, 'foo.bar', 'foo/bar');
+    }
+
+    public function testNoMoveFile()
+    {
+        self::expectException('\RuntimeException');
+        self::expectExceptionMessage('Not implemented');
+        $stream = new BufferStream();
+        $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
+        $uploadedFile->moveTo('bar.foo');
+    }
+
+    public function testGetters()
+    {
+        $stream = new BufferStream();
+        $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
+        self::assertSame($stream,       $uploadedFile->getStream());
+        self::assertSame(0,             $uploadedFile->getSize());
+        self::assertSame(UPLOAD_ERR_OK, $uploadedFile->getError());
+        self::assertSame('foo.bar',     $uploadedFile->getClientFilename());
+        self::assertSame('foo/bar',     $uploadedFile->getClientMediaType());
+    }
+
+    public function testGetStreamOnFailedUpload()
+    {
+        self::expectException('\RuntimeException');
+        self::expectExceptionMessage('Cannot retrieve stream due to upload error');
+        $stream = new BufferStream();
+        $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_NO_FILE, 'foo.bar', 'foo/bar');
+        $uploadedFile->getStream();
+    }
+}


### PR DESCRIPTION
To get started with the body parsers we first need an object representing uploaded files. This is a simple implementation of the PSR-7 UploadedFileInterface.

Supersedes #62 