### PR TITLE
Fix parsing CONNECT request without Host header

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -77,7 +77,7 @@ class RequestHeaderParser extends EventEmitter
             // check this is a valid authority-form request-target (host:port)
             if (isset($uri['scheme'], $uri['host'], $uri['port']) && count($uri) === 3) {
                 $originalTarget = $parts[1];
-                $parts[1] = '/';
+                $parts[1] = 'http://' . $parts[1] . '/';
                 $headers = implode(' ', $parts);
             } else {
                 throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target');
@@ -135,16 +135,8 @@ class RequestHeaderParser extends EventEmitter
 
         // re-apply actual request target from above
         if ($originalTarget !== null) {
-            $uri = $request->getUri()->withPath('');
-
-            // re-apply host and port from request-target if given
-            $parts = parse_url('tcp://' . $originalTarget);
-            if (isset($parts['host'], $parts['port'])) {
-                $uri = $uri->withHost($parts['host'])->withPort($parts['port']);
-            }
-
             $request = $request->withUri(
-                $uri,
+                $request->getUri()->withPath(''),
                 true
             )->withRequestTarget($originalTarget);
         }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -225,6 +225,29 @@ class ServerTest extends TestCase
         $this->assertSame('example.com:443', $requestAssertion->getHeaderLine('Host'));
     }
 
+    public function testRequestConnectWithoutHostWillBeAdded()
+    {
+        $requestAssertion = null;
+        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+            $requestAssertion = $request;
+            return new Response();
+        });
+
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "CONNECT example.com:443 HTTP/1.1\r\n\r\n";
+        $this->connection->emit('data', array($data));
+
+        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertSame('CONNECT', $requestAssertion->getMethod());
+        $this->assertSame('example.com:443', $requestAssertion->getRequestTarget());
+        $this->assertSame('', $requestAssertion->getUri()->getPath());
+        $this->assertSame('http://example.com:443', (string)$requestAssertion->getUri());
+        $this->assertSame(443, $requestAssertion->getUri()->getPort());
+        $this->assertSame('example.com:443', $requestAssertion->getHeaderLine('Host'));
+    }
+
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;


### PR DESCRIPTION
This means that all of these examples now correctly return the same URI and also the same Host header value example.com without the default port in this case:

```
GET / HTTP/1.1\r\nHost: example.com\r\n\r\n
GET http://example.com/ HTTP/1.1\r\n\r\n
CONNECT example.com:80 HTTP/1.1\r\n\r\n
```

Builds on top of #158 and #173