### PR TITLE
Stricter check for invalid request-line in HTTP requests

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -46,7 +46,7 @@ class RequestHeaderParser extends EventEmitter
 
         if (false !== $endOfHeader) {
             try {
-                $this->parseAndEmitRequest();
+                $this->parseAndEmitRequest($endOfHeader);
             } catch (Exception $exception) {
                 $this->emit('error', array($exception));
             }
@@ -54,16 +54,15 @@ class RequestHeaderParser extends EventEmitter
         }
     }
 
-    private function parseAndEmitRequest()
+    private function parseAndEmitRequest($endOfHeader)
     {
-        list($request, $bodyBuffer) = $this->parseRequest($this->buffer);
+        $request = $this->parseRequest((string)substr($this->buffer, 0, $endOfHeader));
+        $bodyBuffer = isset($this->buffer[$endOfHeader + 4]) ? substr($this->buffer, $endOfHeader + 4) : '';
         $this->emit('headers', array($request, $bodyBuffer));
     }
 
-    private function parseRequest($data)
+    private function parseRequest($headers)
     {
-        list($headers, $bodyBuffer) = explode("\r\n\r\n", $data, 2);
-
         // parser does not support asterisk-form and authority-form
         // remember original target and temporarily replace and re-apply below
         $originalTarget = null;
@@ -221,6 +220,6 @@ class RequestHeaderParser extends EventEmitter
         // always sanitize Host header because it contains critical routing information
         $request = $request->withUri($request->getUri()->withUserInfo('u')->withUserInfo(''));
 
-        return array($request, $bodyBuffer);
+        return $request;
     }
 }

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -63,6 +63,14 @@ class RequestHeaderParser extends EventEmitter
 
     private function parseRequest($headers)
     {
+        // additional, stricter safe-guard for request line
+        // because request parser doesn't properly cope with invalid ones
+        if (!preg_match('#^[^ ]+ [^ ]+ HTTP/\d\.\d#m', $headers)) {
+            throw new \InvalidArgumentException('Unable to parse invalid request-line');
+        }
+
+        $lines = explode("\r\n", $headers);
+
         // parser does not support asterisk-form and authority-form
         // remember original target and temporarily replace and re-apply below
         $originalTarget = null;


### PR DESCRIPTION
Passing certain invalid requests would previously result in an "invalid offset" warning being raised, this PR ensures we properly check the request-line as per RFC 7230 before passing it to the actual message parser.

See also https://tools.ietf.org/html/rfc7230#section-3.1.1