### PR TITLE
Require Host on 1.1 requests

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -163,6 +163,10 @@ class RequestHeaderParser extends EventEmitter
             }
         }
 
+        if ($request->getProtocolVersion() === '1.1' && !$request->hasHeader('Host')) {
+            throw new \InvalidArgumentException('A client must send a host header field in all HTTP/1.1 request messages');
+        }
+
         // Optional Host header value MUST be valid (host and optional port)
         if ($request->hasHeader('Host')) {
             $parts = parse_url('http://' . $request->getHeaderLine('Host'));

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -234,6 +234,22 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Invalid absolute-form request-target', $error->getMessage());
     }
 
+    public function testHttp11RequestWithNoHostHeaderEmitsError()
+    {
+        $error = null;
+
+        $parser = new RequestHeaderParser();
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message) use (&$error) {
+            $error = $message;
+        });
+
+        $parser->feed("GET / HTTP/1.1\r\n\r\n");
+
+        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertSame('A client must send a host header field in all HTTP/1.1 request messages', $error->getMessage());
+    }
+
     public function testInvalidAbsoluteFormWithFragmentEmitsError()
     {
         $error = null;

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -891,7 +891,7 @@ class ServerTest extends TestCase
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
-        $data = "GET / HTTP/1.1\r\n\r\n";
+        $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nUpgrade: demo\r\nContent-Length: 3\r\nConnection: close\r\n\r\nfoo", $buffer);
@@ -919,7 +919,7 @@ class ServerTest extends TestCase
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
-        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
+        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nfoo", $buffer);
@@ -949,7 +949,7 @@ class ServerTest extends TestCase
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
-        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
+        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertEquals("HTTP/1.1 101 Switching Protocols\r\nUpgrade: demo\r\nConnection: upgrade\r\n\r\nfoo", $buffer);
@@ -979,7 +979,7 @@ class ServerTest extends TestCase
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
 
-        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\n\r\n";
+        $data = "GET / HTTP/1.1\r\nUpgrade: demo\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $stream->write('hello');


### PR DESCRIPTION
[RFC 7230](https://tools.ietf.org/html/rfc7230#section-5.4) requires "A client MUST send a Host header field in all HTTP/1.1 request messages."