### PR TITLE
Target evenement 3.0 a long side 2.0 and 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6",
         "react/promise": "^2.3 || ^1.2.1",
-        "evenement/evenement": "^2.0 || ^1.0"
+        "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0` and `1.0` and `react/http` is fully compatible with all three so why not support it. It packs some neat performance upgrades without any code changes on `react/http`'s side :shipit: .