### PR TITLE
Add the ability to define a custom request header size if you need bigger headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ $server = new Server(function (ServerRequestInterface $request) {
 });
 ```
 
+In some cases you may want to customize the server's behavior with your
+own [options](#options). The provided defaults should already fit
+the most use-cases.
+
+```php
+$options = array();
+$options['max_header_size'] = 1024 * 8;
+
+$server = new Server($callback, $options);
+```
+
 In order to process any connections, the server needs to be attached to an
 instance of `React\Socket\ServerInterface` which emits underlying streaming
 connections in order to then parse incoming data as HTTP.
@@ -666,8 +677,8 @@ instead of the `callable`. A middleware is expected to adhere the following rule
 * It returns a `ResponseInterface` (or any promise which can be consumed by [`Promise\resolve`](http://reactphp.org/promise/#resolve) resolving to a `ResponseInterface`)
 * It calls `$next($request)` to continue processing the next middleware function or returns explicitly to abort the chain
 
-The following example adds a middleware that adds the current time to the request as a 
-header (`Request-Time`) and middleware that always returns a 200 code without a body: 
+The following example adds a middleware that adds the current time to the request as a
+header (`Request-Time`) and middleware that always returns a 200 code without a body:
 
 ```php
 $server = new Server(new MiddlewareRunner([
@@ -719,7 +730,7 @@ Usage:
 $middlewares = new MiddlewareRunner([
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
     function (ServerRequestInterface $request, callable $next) {
-        // The body from $request->getBody() is now fully available without the need to stream it 
+        // The body from $request->getBody() is now fully available without the need to stream it
         return new Response(200);
     },
 ]);
@@ -727,7 +738,7 @@ $middlewares = new MiddlewareRunner([
 
 #### RequestBodyParserMiddleware
 
-The `RequestBodyParserMiddleware` takes a fully buffered request body (generally from [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware)), 
+The `RequestBodyParserMiddleware` takes a fully buffered request body (generally from [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware)),
 and parses the forms and uploaded files from the request body.
 
 Parsed submitted forms will be available from `$request->getParsedBody()` as
@@ -752,7 +763,7 @@ also supports `multipart/form-data`, thus supporting uploaded files available
 through `$request->getUploadedFiles()`.
 
 The `$request->getUploadedFiles(): array` will return an array with all
-uploaded files formatted like this: 
+uploaded files formatted like this:
 
 ```php
 $uploadedFiles = [
@@ -771,7 +782,7 @@ $middlewares = new MiddlewareRunner([
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
     new RequestBodyParserMiddleware(),
     function (ServerRequestInterface $request, callable $next) {
-        // If any, parsed form fields are now available from $request->getParsedBody() 
+        // If any, parsed form fields are now available from $request->getParsedBody()
         return new Response(200);
     },
 ]);
@@ -779,7 +790,7 @@ $middlewares = new MiddlewareRunner([
 
 #### Third-Party Middleware
 
-A non-exhaustive list of third-party middleware can be found at the [`Middleware`](https://github.com/reactphp/http/wiki/Middleware) wiki page. 
+A non-exhaustive list of third-party middleware can be found at the [`Middleware`](https://github.com/reactphp/http/wiki/Middleware) wiki page.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -64,17 +64,6 @@ $server = new Server(function (ServerRequestInterface $request) {
 });
 ```
 
-In some cases you may want to customize the server's behavior with your
-own [options](#options). The provided defaults should already fit
-the most use-cases.
-
-```php
-$options = array();
-$options['max_header_size'] = 1024 * 8;
-
-$server = new Server($callback, $options);
-```
-
 In order to process any connections, the server needs to be attached to an
 instance of `React\Socket\ServerInterface` which emits underlying streaming
 connections in order to then parse incoming data as HTTP.

--- a/examples/80-request-header-parser.php
+++ b/examples/80-request-header-parser.php
@@ -1,0 +1,43 @@
+<?php
+
+use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
+use React\Http\Response;
+use React\Http\RequestHeaderParser;
+use React\Http\RequestHeaderParserFactory;
+use React\Http\Server;
+use React\Socket\ConnectionInterface;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+class CustomRequestHeaderSizeFactory extends RequestHeaderParserFactory
+{
+
+    protected $size;
+
+    public function __construct($size = 1024)
+    {
+        $this->size = $size;
+    }
+
+    public function create(ConnectionInterface $conn)
+    {
+        $uriLocal = $this->getUriLocal($conn);
+        $uriRemote = $this->getUriRemote($conn);
+
+        return new RequestHeaderParser($uriLocal, $uriRemote, $this->size);
+    }
+}
+
+$loop = Factory::create();
+
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(200);
+}, new CustomRequestHeaderSizeFactory(1024 * 16)); // 16MB
+
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$server->listen($socket);
+
+echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
+
+$loop->run();

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -15,16 +15,20 @@ use RingCentral\Psr7 as g7;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $bufferMaxSize;
+    private $maxSize;
 
     private $localSocketUri;
     private $remoteSocketUri;
 
-    public function __construct($localSocketUri = null, $remoteSocketUri = null, $bufferMaxSize = null)
+    public function __construct($localSocketUri = null, $remoteSocketUri = null, $maxSize = 4096)
     {
+        if (!is_integer($maxSize)) {
+          throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
+        }
+
         $this->localSocketUri = $localSocketUri;
         $this->remoteSocketUri = $remoteSocketUri;
-        $this->bufferMaxSize = is_integer($bufferMaxSize) ? $bufferMaxSize : 4096;
+        $this->maxSize = $maxSize;
     }
 
     public function feed($data)
@@ -39,8 +43,8 @@ class RequestHeaderParser extends EventEmitter
             $currentHeaderSize = strlen($this->buffer);
         }
 
-        if ($currentHeaderSize > $this->bufferMaxSize) {
-            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->bufferMaxSize} exceeded.", 431), $this));
+        if ($currentHeaderSize > $this->maxSize) {
+            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;
         }

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -15,15 +15,16 @@ use RingCentral\Psr7 as g7;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $maxSize = 4096;
+    private $bufferMaxSize;
 
     private $localSocketUri;
     private $remoteSocketUri;
 
-    public function __construct($localSocketUri = null, $remoteSocketUri = null)
+    public function __construct($localSocketUri = null, $remoteSocketUri = null, $bufferMaxSize = null)
     {
         $this->localSocketUri = $localSocketUri;
         $this->remoteSocketUri = $remoteSocketUri;
+        $this->bufferMaxSize = is_integer($bufferMaxSize) ? $bufferMaxSize : 4096;
     }
 
     public function feed($data)
@@ -38,8 +39,8 @@ class RequestHeaderParser extends EventEmitter
             $currentHeaderSize = strlen($this->buffer);
         }
 
-        if ($currentHeaderSize > $this->maxSize) {
-            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
+        if ($currentHeaderSize > $this->bufferMaxSize) {
+            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->bufferMaxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;
         }

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -12,7 +12,7 @@ use RingCentral\Psr7 as g7;
  *
  * @internal
  */
-class RequestHeaderParser extends EventEmitter
+class RequestHeaderParser extends EventEmitter implements RequestHeaderParserInterface
 {
     private $buffer = '';
     private $maxSize;

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -23,7 +23,7 @@ class RequestHeaderParser extends EventEmitter
     public function __construct($localSocketUri = null, $remoteSocketUri = null, $maxSize = 4096)
     {
         if (!is_integer($maxSize)) {
-          throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
+            throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
         }
 
         $this->localSocketUri = $localSocketUri;

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -23,7 +23,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
      * @param ConnectionInterface $conn
      * @return string
      */
-    private function getUriLocal(ConnectionInterface $conn)
+    protected function getUriLocal(ConnectionInterface $conn)
     {
         $uriLocal = $conn->getLocalAddress();
         if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
@@ -42,7 +42,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
      * @param ConnectionInterface $conn
      * @return string
      */
-    private function getUriRemote(ConnectionInterface $conn)
+    protected function getUriRemote(ConnectionInterface $conn)
     {
         $uriRemote = $conn->getRemoteAddress();
         if ($uriRemote !== null && strpos($uriRemote, '://') === false) {

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -32,7 +32,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
             $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
         } elseif ($uriLocal !== null) {
             // local URI known, so translate transport scheme to application scheme
-            $uriLocal = strtr($uriLocal, ['tcp://' => 'http://', 'tls://' => 'https://']);
+            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
         }
 
         return $uriLocal;

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace React\Http;
+
+use React\Socket\ConnectionInterface;
+
+class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
+{
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return RequestHeaderParserInterface
+     */
+    public function create(ConnectionInterface $conn)
+    {
+        $uriLocal = $this->getUriLocal($conn);
+        $uriRemote = $this->getUriRemote($conn);
+
+        return new RequestHeaderParser($uriLocal, $uriRemote);
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriLocal(ConnectionInterface $conn)
+    {
+        $uriLocal = $conn->getLocalAddress();
+        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // try to detect transport encryption and assume default application scheme
+            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
+        } elseif ($uriLocal !== null) {
+            // local URI known, so translate transport scheme to application scheme
+            $uriLocal = strtr($uriLocal, ['tcp://' => 'http://', 'tls://' => 'https://']);
+        }
+
+        return $uriLocal;
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriRemote(ConnectionInterface $conn)
+    {
+        $uriRemote = $conn->getRemoteAddress();
+        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // actual scheme is not evaluated but required for parsing URI
+            $uriRemote = 'unused://' . $uriRemote;
+        }
+
+        return $uriRemote;
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    private function isConnectionEncrypted(ConnectionInterface $conn)
+    {
+        // Legacy PHP < 7 does not offer any direct access to check crypto parameters
+        // We work around by accessing the context options and assume that only
+        // secure connections *SHOULD* set the "ssl" context options by default.
+        if (PHP_VERSION_ID < 70000) {
+            $context = isset($conn->stream) ? stream_context_get_options($conn->stream) : array();
+
+            return (isset($context['ssl']) && $context['ssl']);
+        }
+
+        // Modern PHP 7+ offers more reliable access to check crypto parameters
+        // by checking stream crypto meta data that is only then made available.
+        $meta = isset($conn->stream) ? stream_get_meta_data($conn->stream) : array();
+
+        return (isset($meta['crypto']) && $meta['crypto']);
+    }
+
+}

--- a/src/RequestHeaderParserFactoryInterface.php
+++ b/src/RequestHeaderParserFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Http;
+
+use React\Socket\ConnectionInterface;
+
+interface RequestHeaderParserFactoryInterface
+{
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return mixed
+     */
+    public function create(ConnectionInterface $conn);
+}

--- a/src/RequestHeaderParserFactoryInterface.php
+++ b/src/RequestHeaderParserFactoryInterface.php
@@ -9,7 +9,7 @@ interface RequestHeaderParserFactoryInterface
 
     /**
      * @param ConnectionInterface $conn
-     * @return mixed
+     * @return RequestHeaderParserInterface
      */
     public function create(ConnectionInterface $conn);
 }

--- a/src/RequestHeaderParserInterface.php
+++ b/src/RequestHeaderParserInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace React\Http;
+
+interface RequestHeaderParserInterface
+{
+
+    /**
+     * Feed the RequestHeaderParser with a data chunk from the connection
+     * @param string $data
+     * @return mixed
+     */
+    public function feed($data);
+}

--- a/src/RequestHeaderParserInterface.php
+++ b/src/RequestHeaderParserInterface.php
@@ -2,13 +2,15 @@
 
 namespace React\Http;
 
-interface RequestHeaderParserInterface
+use Evenement\EventEmitterInterface;
+
+interface RequestHeaderParserInterface extends EventEmitterInterface
 {
 
     /**
      * Feed the RequestHeaderParser with a data chunk from the connection
      * @param string $data
-     * @return mixed
+     * @return void
      */
     public function feed($data);
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -91,29 +91,17 @@ class Server extends EventEmitter
      * See also [listen()](#listen) for more details.
      *
      * @param callable $callback
+     * @param RequestHeaderParserFactoryInterface $factory
      * @see self::listen()
      */
-    public function __construct($callback)
+    public function __construct($callback, RequestHeaderParserFactoryInterface $factory = null)
     {
         if (!is_callable($callback)) {
             throw new \InvalidArgumentException();
         }
 
         $this->callback = $callback;
-        $this->factory = new RequestHeaderParserFactory();
-    }
-
-    /**
-     * Adds the ability to overwrite the default RequestHeaderParser
-     *
-     * @param RequestHeaderParserFactoryInterface $factory
-     * @return $this
-     */
-    public function setRequestHeaderParserFactory(RequestHeaderParserFactoryInterface $factory)
-    {
-        $this->factory = $factory;
-
-        return $this;
+        $this->factory = $factory ? $factory : new RequestHeaderParserFactory();
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -418,13 +418,13 @@ class Server extends EventEmitter
      */
     private function getRequestHeaderParser(ConnectionInterface $conn)
     {
-      $uriLocal = $this->getUriLocal($conn);
-      $uriRemote = $this->getUriRemote($conn);
+        $uriLocal = $this->getUriLocal($conn);
+        $uriRemote = $this->getUriRemote($conn);
 
-      if (isset($this->options['max_header_size']) && is_integer($this->options['max_header_size'])) {
-        return new RequestHeaderParser($uriLocal, $uriRemote, $this->options['max_header_size']);
-      }
-      return new RequestHeaderParser($uriLocal, $uriRemote);
+        if (isset($this->options['max_header_size']) && is_integer($this->options['max_header_size'])) {
+            return new RequestHeaderParser($uriLocal, $uriRemote, $this->options['max_header_size']);
+        }
+        return new RequestHeaderParser($uriLocal, $uriRemote);
     }
 
     /**
@@ -433,17 +433,17 @@ class Server extends EventEmitter
      */
     private function getUriLocal(ConnectionInterface $conn)
     {
-      $uriLocal = $conn->getLocalAddress();
-      if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
-        // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-        // try to detect transport encryption and assume default application scheme
-        $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
-      } elseif ($uriLocal !== null) {
-        // local URI known, so translate transport scheme to application scheme
-        $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
-      }
+        $uriLocal = $conn->getLocalAddress();
+        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // try to detect transport encryption and assume default application scheme
+            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
+        } elseif ($uriLocal !== null) {
+            // local URI known, so translate transport scheme to application scheme
+            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
+        }
 
-      return $uriLocal;
+        return $uriLocal;
     }
 
     /**
@@ -452,14 +452,14 @@ class Server extends EventEmitter
      */
     private function getUriRemote(ConnectionInterface $conn)
     {
-      $uriRemote = $conn->getRemoteAddress();
-      if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
-        // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-        // actual scheme is not evaluated but required for parsing URI
-        $uriRemote = 'unused://' . $uriRemote;
-      }
+        $uriRemote = $conn->getRemoteAddress();
+        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // actual scheme is not evaluated but required for parsing URI
+            $uriRemote = 'unused://' . $uriRemote;
+        }
 
-      return $uriRemote;
+        return $uriRemote;
     }
 
     /**
@@ -487,19 +487,19 @@ class Server extends EventEmitter
 
     private function validateOptions(array $options)
     {
-      if (isset($options['max_header_size'])) {
-        $maxHeaderSize = $options['max_header_size'];
-        if (!is_integer($maxHeaderSize)) {
-          throw new \InvalidArgumentException(
-            sprintf('Parameter "%s" expected to be an integer.', 'max_header_size')
-          );
-        }
+        if (isset($options['max_header_size'])) {
+            $maxHeaderSize = $options['max_header_size'];
+            if (!is_integer($maxHeaderSize)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Parameter "%s" expected to be an integer.', 'max_header_size')
+                );
+            }
 
-        if ($maxHeaderSize < 0) {
-          throw new \InvalidArgumentException(
-            sprintf('Parameter "%s" expected to be a positive value.', 'max_header_size')
-          );
+            if ($maxHeaderSize < 0) {
+                throw new \InvalidArgumentException(
+                    sprintf('Parameter "%s" expected to be a positive value.', 'max_header_size')
+                );
+            }
         }
-      }
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -91,7 +91,7 @@ class Server extends EventEmitter
      * @param array $options
      * @see self::listen()
      */
-    public function __construct($callback, array $options = [])
+    public function __construct($callback, array $options = array())
     {
         if (!is_callable($callback)) {
             throw new \InvalidArgumentException();

--- a/src/Server.php
+++ b/src/Server.php
@@ -97,6 +97,8 @@ class Server extends EventEmitter
             throw new \InvalidArgumentException();
         }
 
+        $this->validateOptions($options);
+
         $this->callback = $callback;
         $this->options = $options;
     }
@@ -481,5 +483,23 @@ class Server extends EventEmitter
         $meta = isset($conn->stream) ? stream_get_meta_data($conn->stream) : array();
 
         return (isset($meta['crypto']) && $meta['crypto']);
+    }
+
+    private function validateOptions(array $options)
+    {
+      if (isset($options['max_header_size'])) {
+        $maxHeaderSize = $options['max_header_size'];
+        if (!is_integer($maxHeaderSize)) {
+          throw new \InvalidArgumentException(
+            sprintf('Parameter "%s" expected to be an integer.', 'max_header_size')
+          );
+        }
+
+        if ($maxHeaderSize < 0) {
+          throw new \InvalidArgumentException(
+            sprintf('Parameter "%s" expected to be a positive value.', 'max_header_size')
+          );
+        }
+      }
     }
 }

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -9,8 +9,7 @@ class RequestHeaderParserTest extends TestCase
 
     public function testMaxSizeParameterShouldFailOnWrongType()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid type for maxSize provided. Expected an integer value.');
+        $this->setExpectedException('InvalidArgumentException', 'Invalid type for maxSize provided. Expected an integer value.');
 
         new RequestHeaderParser(null, null, 'abc');
     }

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -6,6 +6,15 @@ use React\Http\RequestHeaderParser;
 
 class RequestHeaderParserTest extends TestCase
 {
+
+    public function testMaxSizeParameterShouldFailOnWrongType()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid type for maxSize provided. Expected an integer value.');
+
+        new RequestHeaderParser(null, null, 'abc');
+    }
+
     public function testSplitShouldHappenOnDoubleCrlf()
     {
         $parser = new RequestHeaderParser();
@@ -124,34 +133,11 @@ class RequestHeaderParserTest extends TestCase
         $this->assertEquals('example.com', $request->getHeaderLine('Host'));
     }
 
-    public function testBufferSizeParameterShouldFallbackOnWrongValue()
-    {
-        $error = null;
-        $passedParser = null;
-        $defaultValue = 4096;
-
-        $parser = new RequestHeaderParser(null, null, 'x-y-z');
-        $parser->on('headers', $this->expectCallableNever());
-        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
-            $error = $message;
-            $passedParser = $parser;
-        });
-
-        $this->assertSame(1, count($parser->listeners('headers')));
-        $this->assertSame(1, count($parser->listeners('error')));
-
-        $data = str_repeat('A', 4097);
-        $parser->feed($data);
-
-        $this->assertInstanceOf('OverflowException', $error);
-        $this->assertSame('Maximum header size of ' . $defaultValue . ' exceeded.', $error->getMessage());
-    }
-
     public function testCustomBufferSizeOverflowShouldEmitError()
     {
       $error = null;
       $passedParser = null;
-      $newCustomBufferSize = 1014 * 16;
+      $newCustomBufferSize = 1024 * 16;
 
       $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
       $parser->on('headers', $this->expectCallableNever());

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -134,25 +134,25 @@ class RequestHeaderParserTest extends TestCase
 
     public function testCustomBufferSizeOverflowShouldEmitError()
     {
-      $error = null;
-      $passedParser = null;
-      $newCustomBufferSize = 1024 * 16;
+        $error = null;
+        $passedParser = null;
+        $newCustomBufferSize = 1024 * 16;
 
-      $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
-      $parser->on('headers', $this->expectCallableNever());
-      $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
-        $error = $message;
-        $passedParser = $parser;
-      });
+        $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
+            $error = $message;
+            $passedParser = $parser;
+        });
 
-      $this->assertSame(1, count($parser->listeners('headers')));
-      $this->assertSame(1, count($parser->listeners('error')));
+        $this->assertSame(1, count($parser->listeners('headers')));
+        $this->assertSame(1, count($parser->listeners('error')));
 
-      $data = str_repeat('A', $newCustomBufferSize + 1);
-      $parser->feed($data);
+        $data = str_repeat('A', $newCustomBufferSize + 1);
+        $parser->feed($data);
 
-      $this->assertInstanceOf('OverflowException', $error);
-      $this->assertSame('Maximum header size of ' . $newCustomBufferSize . ' exceeded.', $error->getMessage());
+        $this->assertInstanceOf('OverflowException', $error);
+        $this->assertSame('Maximum header size of ' . $newCustomBufferSize . ' exceeded.', $error->getMessage());
     }
 
     public function testHeaderOverflowShouldEmitError()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1268,12 +1268,12 @@ class ServerTest extends TestCase
 
     public function testMaxRequestHeaderOptionShouldFailOnNegativeValue()
     {
-      $options = array();
-      $options['max_header_size'] = -1024;
+        $options = array();
+        $options['max_header_size'] = -1024;
 
-      $this->setExpectedException('InvalidArgumentException', 'Parameter "max_header_size" expected to be a positive value.');
+        $this->setExpectedException('InvalidArgumentException', 'Parameter "max_header_size" expected to be a positive value.');
 
-      new Server($this->expectCallableNever(), $options);
+        new Server($this->expectCallableNever(), $options);
     }
 
     public function testRequestHeaderOverflowWithDefaultValueWillEmitErrorAndSendErrorResponse()
@@ -1313,36 +1313,36 @@ class ServerTest extends TestCase
 
     public function testRequestHeaderOverflowWithCustomValue()
     {
-      $maxHeaderSize = 1024 * 16;
+        $maxHeaderSize = 1024 * 16;
 
-      $options = array();
-      $options['max_header_size'] = $maxHeaderSize;
+        $options = array();
+        $options['max_header_size'] = $maxHeaderSize;
 
-      $server = new Server(function (ServerRequestInterface $request) {
-        return new Response(200, array());
-      }, $options);
+        $server = new Server(function (ServerRequestInterface $request) {
+            return new Response(200, array());
+        }, $options);
 
-      $buffer = '';
+        $buffer = '';
 
-      $this->connection
-        ->expects($this->any())
-        ->method('write')
-        ->will(
-          $this->returnCallback(
-            function ($data) use (&$buffer) {
-              $buffer .= $data;
-            }
-          )
-        );
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
 
-      $server->listen($this->socket);
-      $this->socket->emit('connection', array($this->connection));
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
 
-      $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
-      $data .= str_repeat('A', $maxHeaderSize - strlen($data)) . "\r\n\r\n";
-      $this->connection->emit('data', array($data));
+        $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
+        $data .= str_repeat('A', $maxHeaderSize - strlen($data)) . "\r\n\r\n";
+        $this->connection->emit('data', array($data));
 
-      $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
     }
 
     public function testRequestHeaderOverflowWithCustomValueWillEmitErrorAndSendErrorResponse()
@@ -1355,21 +1355,21 @@ class ServerTest extends TestCase
         $error = null;
         $server = new Server($this->expectCallableNever(), $options);
         $server->on('error', function ($message) use (&$error) {
-          $error = $message;
+            $error = $message;
         });
 
         $buffer = '';
 
         $this->connection
-          ->expects($this->any())
-          ->method('write')
-          ->will(
-            $this->returnCallback(
-              function ($data) use (&$buffer) {
-                $buffer .= $data;
-              }
-            )
-          );
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1261,8 +1261,7 @@ class ServerTest extends TestCase
         $options = array();
         $options['max_header_size'] = 'abc';
 
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Parameter "max_header_size" expected to be an integer.');
+        $this->setExpectedException('InvalidArgumentException', 'Parameter "max_header_size" expected to be an integer.');
 
         new Server($this->expectCallableNever(), $options);
     }
@@ -1272,8 +1271,7 @@ class ServerTest extends TestCase
       $options = array();
       $options['max_header_size'] = -1024;
 
-      $this->expectException('InvalidArgumentException');
-      $this->expectExceptionMessage('Parameter "max_header_size" expected to be a positive value.');
+      $this->setExpectedException('InvalidArgumentException', 'Parameter "max_header_size" expected to be a positive value.');
 
       new Server($this->expectCallableNever(), $options);
     }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1294,7 +1294,7 @@ class ServerTest extends TestCase
     {
       $maxSize = 1024 * 16;
 
-      $options = [];
+      $options = array();
       $options['max_header_size'] = $maxSize;
 
       $server = new Server(function (ServerRequestInterface $request) {


### PR DESCRIPTION
This PR is a follow up of the discussion in #214. This allows us to configure the server with a max_header_size and pass it down to the RequestHeaderParser. 

Question which I asked my self during implementation:
* Do we want to fallback silently on invalid parameter usage?
* Do we want to fail early on invalid parameter usage (i.e. fail on boot before the first request arrives)