### PR TITLE
Support multipart parsing for RequestBodyParserMiddleware (file uploads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,6 @@ For more details about the request object, check out the documentation of
 and
 [PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface).
 
-> Currently the uploaded files are not added by the
-  `Server`, but you can add these parameters by yourself using the given methods.
-  The next versions of this project will cover these features.
-
 Note that by default, the request object will be processed once the request headers have
 been received (see also [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware)
 for an alternative).
@@ -265,7 +261,8 @@ designed under the assumption of being in control of the request body.
 Given that this does not apply to this server, the following
 `PSR-7 StreamInterface` methods are not used and SHOULD NOT be called:
 `tell()`, `eof()`, `seek()`, `rewind()`, `write()` and `read()`.
-If this is an issue for your use case, it's highly recommended to use the
+If this is an issue for your use case and/or you want to access uploaded files,
+it's highly recommended to use the
 [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware) instead.
 The `ReactPHP ReadableStreamInterface` gives you access to the incoming
 request body as the individual chunks arrive:
@@ -732,7 +729,9 @@ $middlewares = new MiddlewareRunner([
 The `RequestBodyParserMiddleware` takes a fully buffered request body (generally from [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware)), 
 and parses the forms and uploaded files from the request body.
 
-Parsed submitted forms will be available from `$request->getParsedBody()` as array. For example the following submitted body:
+Parsed submitted forms will be available from `$request->getParsedBody()` as
+array.
+For example the following submitted body (`application/x-www-form-urlencoded`):
 
 `bar[]=beer&bar[]=wine`
 
@@ -743,6 +742,23 @@ $parsedBody = [
     'bar' => [
         'beer',
         'wine',
+    ],
+];
+```
+
+Aside from `application/x-www-form-urlencoded`, this middleware handler
+also supports `multipart/form-data`, thus supporting uploaded files available
+through `$request->getUploadedFiles()`.
+
+The `$request->getUploadedFiles(): array` will return an array with all
+uploaded files formatted like this: 
+
+```php
+$uploadedFiles = [
+    'avatar' => new UploadedFile(/**...**/),
+    'screenshots' => [
+        new UploadedFile(/**...**/),
+        new UploadedFile(/**...**/),
     ],
 ];
 ```

--- a/src/Middleware/MultipartParser.php
+++ b/src/Middleware/MultipartParser.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace React\Http\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\HttpBodyStream;
+use React\Http\UploadedFile;
+use RingCentral\Psr7;
+
+/**
+ * @internal
+ */
+final class MultipartParser
+{
+    /**
+     * @var string
+     */
+    protected $buffer = '';
+
+    /**
+     * @var string
+     */
+    protected $boundary;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var HttpBodyStream
+     */
+    protected $body;
+
+    /**
+     * @var callable
+     */
+    protected $onDataCallable;
+
+    public static function parseRequest(ServerRequestInterface $request)
+    {
+        $parser = new self($request);
+        return $parser->parse();
+    }
+
+    private function __construct(ServerRequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    private function parse()
+    {
+        $this->buffer = (string)$this->request->getBody();
+
+        $this->determineStartMethod();
+
+        return $this->request;
+    }
+
+    private function determineStartMethod()
+    {
+        if (!$this->request->hasHeader('content-type')) {
+            $this->findBoundary();
+            return;
+        }
+
+        $contentType = $this->request->getHeaderLine('content-type');
+        preg_match('/boundary="?(.*)"?$/', $contentType, $matches);
+        if (isset($matches[1])) {
+            $this->boundary = $matches[1];
+            $this->parseBuffer();
+            return;
+        }
+
+        $this->findBoundary();
+    }
+
+    private function findBoundary()
+    {
+        if (substr($this->buffer, 0, 3) === '---' && strpos($this->buffer, "\r\n") !== false) {
+            $boundary = substr($this->buffer, 2, strpos($this->buffer, "\r\n"));
+            $boundary = substr($boundary, 0, -2);
+            $this->boundary = $boundary;
+            $this->parseBuffer();
+        }
+    }
+
+    private function parseBuffer()
+    {
+        $chunks = explode('--' . $this->boundary, $this->buffer);
+        $this->buffer = array_pop($chunks);
+        foreach ($chunks as $chunk) {
+            $chunk = $this->stripTrailingEOL($chunk);
+            $this->parseChunk($chunk);
+        }
+    }
+
+    private function parseChunk($chunk)
+    {
+        if ($chunk === '') {
+            return;
+        }
+
+        list ($header, $body) = explode("\r\n\r\n", $chunk, 2);
+        $headers = $this->parseHeaders($header);
+
+        if (!isset($headers['content-disposition'])) {
+            return;
+        }
+
+        if ($this->headerStartsWith($headers['content-disposition'], 'filename')) {
+            $this->parseFile($headers, $body);
+            return;
+        }
+
+        if ($this->headerStartsWith($headers['content-disposition'], 'name')) {
+            $this->parsePost($headers, $body);
+            return;
+        }
+    }
+
+    private function parseFile($headers, $body)
+    {
+        if (
+            !$this->headerContains($headers['content-disposition'], 'name=') ||
+            !$this->headerContains($headers['content-disposition'], 'filename=')
+        ) {
+            return;
+        }
+
+        $this->request = $this->request->withUploadedFiles($this->extractPost(
+            $this->request->getUploadedFiles(),
+            $this->getFieldFromHeader($headers['content-disposition'], 'name'),
+            new UploadedFile(
+                Psr7\stream_for($body),
+                strlen($body),
+                UPLOAD_ERR_OK,
+                $this->getFieldFromHeader($headers['content-disposition'], 'filename'),
+                $headers['content-type'][0]
+            )
+        ));
+    }
+
+    private function parsePost($headers, $body)
+    {
+        foreach ($headers['content-disposition'] as $part) {
+            if (strpos($part, 'name') === 0) {
+                preg_match('/name="?(.*)"$/', $part, $matches);
+                $this->request = $this->request->withParsedBody($this->extractPost(
+                    $this->request->getParsedBody(),
+                    $matches[1],
+                    $body
+                ));
+            }
+        }
+    }
+
+    private function parseHeaders($header)
+    {
+        $headers = array();
+
+        foreach (explode("\r\n", trim($header)) as $line) {
+            list($key, $values) = explode(':', $line, 2);
+            $key = trim($key);
+            $key = strtolower($key);
+            $values = explode(';', $values);
+            $values = array_map('trim', $values);
+            $headers[$key] = $values;
+        }
+
+        return $headers;
+    }
+
+    private function headerStartsWith(array $header, $needle)
+    {
+        foreach ($header as $part) {
+            if (strpos($part, $needle) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function headerContains(array $header, $needle)
+    {
+        foreach ($header as $part) {
+            if (strpos($part, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getFieldFromHeader(array $header, $field)
+    {
+        foreach ($header as $part) {
+            if (strpos($part, $field) === 0) {
+                preg_match('/' . $field . '="?(.*)"$/', $part, $matches);
+                return $matches[1];
+            }
+        }
+
+        return '';
+    }
+
+    private function stripTrailingEOL($chunk)
+    {
+        if (substr($chunk, -2) === "\r\n") {
+            return substr($chunk, 0, -2);
+        }
+
+        return $chunk;
+    }
+
+    private function extractPost($postFields, $key, $value)
+    {
+        $chunks = explode('[', $key);
+        if (count($chunks) == 1) {
+            $postFields[$key] = $value;
+            return $postFields;
+        }
+
+        $chunkKey = $chunks[0];
+        if (!isset($postFields[$chunkKey])) {
+            $postFields[$chunkKey] = array();
+        }
+
+        $parent = &$postFields;
+        for ($i = 1; $i < count($chunks); $i++) {
+            $previousChunkKey = $chunkKey;
+            if (!isset($parent[$previousChunkKey])) {
+                $parent[$previousChunkKey] = array();
+            }
+            $parent = &$parent[$previousChunkKey];
+            $chunkKey = $chunks[$i];
+
+            if ($chunkKey == ']') {
+                $parent[] = $value;
+                return $postFields;
+            }
+
+            $chunkKey = rtrim($chunkKey, ']');
+            if ($i == count($chunks) - 1) {
+                $parent[$chunkKey] = $value;
+                return $postFields;
+            }
+        }
+
+        return $postFields;
+    }
+}

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -9,9 +9,14 @@ final class RequestBodyParserMiddleware
     public function __invoke(ServerRequestInterface $request, $next)
     {
         $type = strtolower($request->getHeaderLine('Content-Type'));
+        list ($type) = explode(';', $type);
 
         if ($type === 'application/x-www-form-urlencoded') {
             return $next($this->parseFormUrlencoded($request));
+        }
+
+        if ($type === 'multipart/form-data') {
+            return $next(MultipartParser::parseRequest($request));
         }
 
         return $next($request);

--- a/tests/Middleware/MultipartParserTest.php
+++ b/tests/Middleware/MultipartParserTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace React\Tests\Http\Middleware;
+
+use React\Http\Middleware\MultipartParser;
+use React\Http\ServerRequest;
+use React\Tests\Http\TestCase;
+
+final class MultipartParserTest extends TestCase
+{
+    public function testPostKey()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[one]\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[two]\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary--\r\n";
+
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+        ), $data, 1.1);
+
+        $parsedRequest = MultipartParser::parseRequest($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertSame(
+            array(
+                'users' => array(
+                    'one' => 'single',
+                    'two' => 'second',
+                ),
+            ),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
+    public function testFileUpload()
+    {
+        $boundary = "---------------------------12758086162038677464950549563";
+
+        $file = base64_decode("R0lGODlhAQABAIAAAP///wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==");
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[one]\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[two]\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-disposition: form-data; name=\"user\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "content-Disposition: form-data; name=\"user2\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[]\"\r\n";
+        $data .= "\r\n";
+        $data .= "first in array\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[]\"\r\n";
+        $data .= "\r\n";
+        $data .= "second in array\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"file\"; filename=\"Us er.php\"\r\n";
+        $data .= "Content-type: text/php\r\n";
+        $data .= "\r\n";
+        $data .= "<?php echo 'User';\r\n";
+        $data .= "\r\n";
+        $data .= "--$boundary";
+        $data .= "\r\n";
+        $data .= "Content-Disposition: form-data; name=\"files[]\"; filename=\"blank.gif\"\r\n";
+        $data .= "content-Type: image/gif\r\n";
+        $data .= "X-Foo-Bar: base64\r\n";
+        $data .= "\r\n";
+        $data .= $file . "\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"files[]\"; filename=\"User.php\"\r\n";
+        $data .= "Content-Type: text/php\r\n";
+        $data .= "\r\n";
+        $data .= "<?php echo 'User';\r\n\r\n";
+        $data .= "\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"files[]\"; filename=\"Owner.php\"\r\n";
+        $data .= "Content-Type: text/php\r\n";
+        $data .= "\r\n";
+        $data .= "<?php echo 'Owner';\r\n\r\n";
+        $data .= "\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data',
+        ), $data, 1.1);
+
+        $parsedRequest = MultipartParser::parseRequest($request);
+
+        $this->assertSame(
+            array(
+                'users' => array(
+                    'one' => 'single',
+                    'two' => 'second',
+                    0 => 'first in array',
+                    1 => 'second in array',
+                ),
+                'user' => 'single',
+                'user2' => 'second',
+            ),
+            $parsedRequest->getParsedBody()
+        );
+
+        $files = $parsedRequest->getUploadedFiles();
+
+        $this->assertTrue(isset($files['file']));
+        $this->assertCount(3, $files['files']);
+
+        $this->assertSame('Us er.php', $files['file']->getClientFilename());
+        $this->assertSame('text/php', $files['file']->getClientMediaType());
+        $this->assertSame("<?php echo 'User';\r\n", (string)$files['file']->getStream());
+
+        $this->assertSame('blank.gif', $files['files'][0]->getClientFilename());
+        $this->assertSame('image/gif', $files['files'][0]->getClientMediaType());
+        $this->assertSame($file, (string)$files['files'][0]->getStream());
+
+        $this->assertSame('User.php', $files['files'][1]->getClientFilename());
+        $this->assertSame('text/php', $files['files'][1]->getClientMediaType());
+        $this->assertSame("<?php echo 'User';\r\n\r\n", (string)$files['files'][1]->getStream());
+
+        $this->assertSame('Owner.php', $files['files'][2]->getClientFilename());
+        $this->assertSame('text/php', $files['files'][2]->getClientMediaType());
+        $this->assertSame("<?php echo 'Owner';\r\n\r\n", (string)$files['files'][2]->getStream());
+    }
+}

--- a/tests/Middleware/RequestBodyParserMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyParserMiddlewareTest.php
@@ -133,4 +133,45 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
         $this->assertSame('{"hello":"world"}', (string)$parsedRequest->getBody());
     }
+
+    public function testMultipartFormDataParsing()
+    {
+        $middleware = new RequestBodyParserMiddleware();
+
+        $boundary = "---------------------------12758086162038677464950549563";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[one]\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[two]\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary\r\n";
+
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data',
+        ), $data, 1.1);
+
+        /** @var ServerRequestInterface $parsedRequest */
+        $parsedRequest = $middleware(
+            $request,
+            function (ServerRequestInterface $request) {
+                return $request;
+            }
+        );
+
+        $this->assertSame(
+            array(
+                'users' => array(
+                    'one' => 'single',
+                    'two' => 'second',
+                ),
+            ),
+            $parsedRequest->getParsedBody()
+        );
+        $this->assertSame($data, (string)$parsedRequest->getBody());
+    }
 }


### PR DESCRIPTION
Follow up on #220 adding multipart support for forms and file uploads
Supersedes / Closes #41 
Implements / Closes #105 
Implements / Closes #117 

Todo: 
- [X] Update middleware adding multipart parsing
- [x] Readme