### PR TITLE
Return internal server error for unexpected exceptions

### DIFF
--- a/src/ChunkedDecoder.php
+++ b/src/ChunkedDecoder.php
@@ -95,7 +95,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                 if ($positionCrlf === false) {
                     // Header shouldn't be bigger than 1024 bytes
                     if (isset($this->buffer[static::MAX_CHUNK_HEADER_SIZE])) {
-                        $this->handleError(new \Exception('Chunk header size inclusive extension bigger than' . static::MAX_CHUNK_HEADER_SIZE. ' bytes'));
+                        $this->handleError(new \Exception('Chunk header size inclusive extension bigger than' . static::MAX_CHUNK_HEADER_SIZE. ' bytes', 400));
                     }
                     return;
                 }
@@ -117,7 +117,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
                 $this->chunkSize = hexdec($hexValue);
                 if (dechex($this->chunkSize) !== $hexValue) {
-                    $this->handleError(new \Exception($hexValue . ' is not a valid hexadecimal number'));
+                    $this->handleError(new \Exception($hexValue . ' is not a valid hexadecimal number', 400));
                     return;
                 }
 
@@ -152,7 +152,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
             if ($positionCrlf !== 0 && $this->chunkSize === $this->transferredSize && strlen($this->buffer) > 2) {
                 // the first 2 characters are not CLRF, send error event
-                $this->handleError(new \Exception('Chunk does not end with a CLRF'));
+                $this->handleError(new \Exception('Chunk does not end with a CLRF', 400));
                 return;
             }
 

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -66,7 +66,7 @@ class RequestHeaderParser extends EventEmitter
         // additional, stricter safe-guard for request line
         // because request parser doesn't properly cope with invalid ones
         if (!preg_match('#^[^ ]+ [^ ]+ HTTP/\d\.\d#m', $headers)) {
-            throw new \InvalidArgumentException('Unable to parse invalid request-line');
+            throw new \InvalidArgumentException('Unable to parse invalid request-line', 400);
         }
 
         $lines = explode("\r\n", $headers);
@@ -87,7 +87,7 @@ class RequestHeaderParser extends EventEmitter
                 $parts[1] = 'http://' . $parts[1] . '/';
                 $headers = implode(' ', $parts);
             } else {
-                throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target');
+                throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target', 400);
             }
         }
 
@@ -159,7 +159,7 @@ class RequestHeaderParser extends EventEmitter
 
             // make sure value contains valid host component (IP or hostname), but no fragment
             if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'http' || isset($parts['fragment'])) {
-                throw new \InvalidArgumentException('Invalid absolute-form request-target');
+                throw new \InvalidArgumentException('Invalid absolute-form request-target', 400);
             }
         }
 
@@ -175,7 +175,7 @@ class RequestHeaderParser extends EventEmitter
             // make sure value does not contain any other URI component
             unset($parts['scheme'], $parts['host'], $parts['port']);
             if ($parts === false || $parts) {
-                throw new \InvalidArgumentException('Invalid Host header value');
+                throw new \InvalidArgumentException('Invalid Host header value', 400);
             }
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -186,7 +186,7 @@ class Server extends EventEmitter
 
             $that->writeError(
                 $conn,
-                $e->getCode() !== 0 ? $e->getCode() : 400
+                $e->getCode() ?: 500
             );
         });
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -186,7 +186,7 @@ class Server extends EventEmitter
 
             $that->writeError(
                 $conn,
-                $e->getCode() ?: 500
+                $e->getCode() !== 0 ? $e->getCode() : 500
             );
         });
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -198,7 +198,7 @@ class Server extends EventEmitter
         $stream = new CloseProtectionStream($conn);
         if ($request->hasHeader('Transfer-Encoding')) {
             if (strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
-                $this->emit('error', array(new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding')));
+                $this->emit('error', array(new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', 400)));
                 return $this->writeError($conn, 501, $request);
             }
 
@@ -214,7 +214,7 @@ class Server extends EventEmitter
             $contentLength = (int)$string;
             if ((string)$contentLength !== (string)$string) {
                 // Content-Length value is not an integer or not a single integer
-                $this->emit('error', array(new \InvalidArgumentException('The value of `Content-Length` is not valid')));
+                $this->emit('error', array(new \InvalidArgumentException('The value of `Content-Length` is not valid', 400)));
                 return $this->writeError($conn, 400, $request);
             }
 


### PR DESCRIPTION
Debugging improvement for https://github.com/reactphp/http/issues/231

Alle exceptions are treated as HTTP 500 unless they explicitly provide an error code.