### PR TITLE
Use Psr7 consistently

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -4,7 +4,7 @@ namespace React\Http;
 
 use Evenement\EventEmitter;
 use Exception;
-use RingCentral\Psr7 as g7;
+use RingCentral\Psr7;
 
 /**
  * @event headers
@@ -92,7 +92,7 @@ class RequestHeaderParser extends EventEmitter
         }
 
         // parse request headers into obj implementing RequestInterface
-        $request = g7\parse_request($headers);
+        $request = Psr7\parse_request($headers);
 
         // create new obj implementing ServerRequestInterface by preserving all
         // previous properties and restoring original request-target

--- a/src/Server.php
+++ b/src/Server.php
@@ -8,7 +8,7 @@ use React\Socket\ConnectionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\Promise\Promise;
-use RingCentral\Psr7 as Psr7Implementation;
+use RingCentral\Psr7;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\CancellablePromiseInterface;
 use React\Stream\WritableStreamInterface;
@@ -353,7 +353,7 @@ class Server extends EventEmitter
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling below
         if ($request->getMethod() === 'HEAD' || $code === 100 || ($code > 101 && $code < 200) || $code === 204 || $code === 304) {
-            $response = $response->withBody(Psr7Implementation\stream_for(''));
+            $response = $response->withBody(Psr7\stream_for(''));
         }
 
         // 101 (Switching Protocols) response uses Connection: upgrade header
@@ -388,7 +388,7 @@ class Server extends EventEmitter
     private function handleResponseBody(ResponseInterface $response, ConnectionInterface $connection)
     {
         if (!$response->getBody() instanceof HttpBodyStream) {
-            $connection->write(Psr7Implementation\str($response));
+            $connection->write(Psr7\str($response));
             return $connection->end();
         }
 
@@ -399,7 +399,7 @@ class Server extends EventEmitter
             return $stream->close();
         }
 
-        $connection->write(Psr7Implementation\str($response));
+        $connection->write(Psr7\str($response));
 
         if ($stream->isReadable()) {
             if ($response->getHeaderLine('Transfer-Encoding') === 'chunked') {


### PR DESCRIPTION
This is just a small code cleanup for sake of consistency across the various classes. No functional changes. Split from #235.