### PR TITLE
Add max size to request header parser

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -15,16 +15,20 @@ use RingCentral\Psr7 as g7;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $bufferMaxSize;
+    private $maxSize;
 
     private $localSocketUri;
     private $remoteSocketUri;
 
-    public function __construct($localSocketUri = null, $remoteSocketUri = null, $bufferMaxSize = null)
+    public function __construct($localSocketUri = null, $remoteSocketUri = null, $maxSize = 4096)
     {
+        if (!is_integer($maxSize)) {
+          throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
+        }
+
         $this->localSocketUri = $localSocketUri;
         $this->remoteSocketUri = $remoteSocketUri;
-        $this->bufferMaxSize = is_integer($bufferMaxSize) ? $bufferMaxSize : 4096;
+        $this->maxSize = $maxSize;
     }
 
     public function feed($data)
@@ -39,8 +43,8 @@ class RequestHeaderParser extends EventEmitter
             $currentHeaderSize = strlen($this->buffer);
         }
 
-        if ($currentHeaderSize > $this->bufferMaxSize) {
-            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->bufferMaxSize} exceeded.", 431), $this));
+        if ($currentHeaderSize > $this->maxSize) {
+            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;
         }

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -15,15 +15,16 @@ use RingCentral\Psr7 as g7;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $maxSize = 4096;
+    private $bufferMaxSize;
 
     private $localSocketUri;
     private $remoteSocketUri;
 
-    public function __construct($localSocketUri = null, $remoteSocketUri = null)
+    public function __construct($localSocketUri = null, $remoteSocketUri = null, $bufferMaxSize = null)
     {
         $this->localSocketUri = $localSocketUri;
         $this->remoteSocketUri = $remoteSocketUri;
+        $this->bufferMaxSize = is_integer($bufferMaxSize) ? $bufferMaxSize : 4096;
     }
 
     public function feed($data)
@@ -38,8 +39,8 @@ class RequestHeaderParser extends EventEmitter
             $currentHeaderSize = strlen($this->buffer);
         }
 
-        if ($currentHeaderSize > $this->maxSize) {
-            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
+        if ($currentHeaderSize > $this->bufferMaxSize) {
+            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->bufferMaxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;
         }

--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -23,7 +23,7 @@ class RequestHeaderParser extends EventEmitter
     public function __construct($localSocketUri = null, $remoteSocketUri = null, $maxSize = 4096)
     {
         if (!is_integer($maxSize)) {
-          throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
+            throw new \InvalidArgumentException('Invalid type for maxSize provided. Expected an integer value.');
         }
 
         $this->localSocketUri = $localSocketUri;

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -9,8 +9,7 @@ class RequestHeaderParserTest extends TestCase
 
     public function testMaxSizeParameterShouldFailOnWrongType()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid type for maxSize provided. Expected an integer value.');
+        $this->setExpectedException('InvalidArgumentException', 'Invalid type for maxSize provided. Expected an integer value.');
 
         new RequestHeaderParser(null, null, 'abc');
     }

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -6,6 +6,15 @@ use React\Http\RequestHeaderParser;
 
 class RequestHeaderParserTest extends TestCase
 {
+
+    public function testMaxSizeParameterShouldFailOnWrongType()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid type for maxSize provided. Expected an integer value.');
+
+        new RequestHeaderParser(null, null, 'abc');
+    }
+
     public function testSplitShouldHappenOnDoubleCrlf()
     {
         $parser = new RequestHeaderParser();
@@ -124,34 +133,11 @@ class RequestHeaderParserTest extends TestCase
         $this->assertEquals('example.com', $request->getHeaderLine('Host'));
     }
 
-    public function testBufferSizeParameterShouldFallbackOnWrongValue()
-    {
-        $error = null;
-        $passedParser = null;
-        $defaultValue = 4096;
-
-        $parser = new RequestHeaderParser(null, null, 'x-y-z');
-        $parser->on('headers', $this->expectCallableNever());
-        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
-            $error = $message;
-            $passedParser = $parser;
-        });
-
-        $this->assertSame(1, count($parser->listeners('headers')));
-        $this->assertSame(1, count($parser->listeners('error')));
-
-        $data = str_repeat('A', 4097);
-        $parser->feed($data);
-
-        $this->assertInstanceOf('OverflowException', $error);
-        $this->assertSame('Maximum header size of ' . $defaultValue . ' exceeded.', $error->getMessage());
-    }
-
     public function testCustomBufferSizeOverflowShouldEmitError()
     {
       $error = null;
       $passedParser = null;
-      $newCustomBufferSize = 1014 * 16;
+      $newCustomBufferSize = 1024 * 16;
 
       $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
       $parser->on('headers', $this->expectCallableNever());

--- a/tests/RequestHeaderParserTest.php
+++ b/tests/RequestHeaderParserTest.php
@@ -134,25 +134,25 @@ class RequestHeaderParserTest extends TestCase
 
     public function testCustomBufferSizeOverflowShouldEmitError()
     {
-      $error = null;
-      $passedParser = null;
-      $newCustomBufferSize = 1024 * 16;
+        $error = null;
+        $passedParser = null;
+        $newCustomBufferSize = 1024 * 16;
 
-      $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
-      $parser->on('headers', $this->expectCallableNever());
-      $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
-        $error = $message;
-        $passedParser = $parser;
-      });
+        $parser = new RequestHeaderParser(null, null, $newCustomBufferSize);
+        $parser->on('headers', $this->expectCallableNever());
+        $parser->on('error', function ($message, $parser) use (&$error, &$passedParser) {
+            $error = $message;
+            $passedParser = $parser;
+        });
 
-      $this->assertSame(1, count($parser->listeners('headers')));
-      $this->assertSame(1, count($parser->listeners('error')));
+        $this->assertSame(1, count($parser->listeners('headers')));
+        $this->assertSame(1, count($parser->listeners('error')));
 
-      $data = str_repeat('A', $newCustomBufferSize + 1);
-      $parser->feed($data);
+        $data = str_repeat('A', $newCustomBufferSize + 1);
+        $parser->feed($data);
 
-      $this->assertInstanceOf('OverflowException', $error);
-      $this->assertSame('Maximum header size of ' . $newCustomBufferSize . ' exceeded.', $error->getMessage());
+        $this->assertInstanceOf('OverflowException', $error);
+        $this->assertSame('Maximum header size of ' . $newCustomBufferSize . ' exceeded.', $error->getMessage());
     }
 
     public function testHeaderOverflowShouldEmitError()


### PR DESCRIPTION
Split-off from #217 in order to solve #214. This PR adds a customisable maximum request-header size. 