### PR TITLE
Pass request header parser through factory

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -12,7 +12,7 @@ use RingCentral\Psr7 as g7;
  *
  * @internal
  */
-class RequestHeaderParser extends EventEmitter
+class RequestHeaderParser extends EventEmitter implements RequestHeaderParserInterface
 {
     private $buffer = '';
     private $maxSize = 4096;

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -23,7 +23,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
      * @param ConnectionInterface $conn
      * @return string
      */
-    private function getUriLocal(ConnectionInterface $conn)
+    protected function getUriLocal(ConnectionInterface $conn)
     {
         $uriLocal = $conn->getLocalAddress();
         if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
@@ -42,7 +42,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
      * @param ConnectionInterface $conn
      * @return string
      */
-    private function getUriRemote(ConnectionInterface $conn)
+    protected function getUriRemote(ConnectionInterface $conn)
     {
         $uriRemote = $conn->getRemoteAddress();
         if ($uriRemote !== null && strpos($uriRemote, '://') === false) {

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -32,7 +32,7 @@ class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
             $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
         } elseif ($uriLocal !== null) {
             // local URI known, so translate transport scheme to application scheme
-            $uriLocal = strtr($uriLocal, ['tcp://' => 'http://', 'tls://' => 'https://']);
+            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
         }
 
         return $uriLocal;

--- a/src/RequestHeaderParserFactory.php
+++ b/src/RequestHeaderParserFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace React\Http;
+
+use React\Socket\ConnectionInterface;
+
+class RequestHeaderParserFactory implements RequestHeaderParserFactoryInterface
+{
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return RequestHeaderParserInterface
+     */
+    public function create(ConnectionInterface $conn)
+    {
+        $uriLocal = $this->getUriLocal($conn);
+        $uriRemote = $this->getUriRemote($conn);
+
+        return new RequestHeaderParser($uriLocal, $uriRemote);
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriLocal(ConnectionInterface $conn)
+    {
+        $uriLocal = $conn->getLocalAddress();
+        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // try to detect transport encryption and assume default application scheme
+            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
+        } elseif ($uriLocal !== null) {
+            // local URI known, so translate transport scheme to application scheme
+            $uriLocal = strtr($uriLocal, ['tcp://' => 'http://', 'tls://' => 'https://']);
+        }
+
+        return $uriLocal;
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriRemote(ConnectionInterface $conn)
+    {
+        $uriRemote = $conn->getRemoteAddress();
+        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
+            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+            // actual scheme is not evaluated but required for parsing URI
+            $uriRemote = 'unused://' . $uriRemote;
+        }
+
+        return $uriRemote;
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    private function isConnectionEncrypted(ConnectionInterface $conn)
+    {
+        // Legacy PHP < 7 does not offer any direct access to check crypto parameters
+        // We work around by accessing the context options and assume that only
+        // secure connections *SHOULD* set the "ssl" context options by default.
+        if (PHP_VERSION_ID < 70000) {
+            $context = isset($conn->stream) ? stream_context_get_options($conn->stream) : array();
+
+            return (isset($context['ssl']) && $context['ssl']);
+        }
+
+        // Modern PHP 7+ offers more reliable access to check crypto parameters
+        // by checking stream crypto meta data that is only then made available.
+        $meta = isset($conn->stream) ? stream_get_meta_data($conn->stream) : array();
+
+        return (isset($meta['crypto']) && $meta['crypto']);
+    }
+
+}

--- a/src/RequestHeaderParserFactoryInterface.php
+++ b/src/RequestHeaderParserFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Http;
+
+use React\Socket\ConnectionInterface;
+
+interface RequestHeaderParserFactoryInterface
+{
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return mixed
+     */
+    public function create(ConnectionInterface $conn);
+}

--- a/src/RequestHeaderParserFactoryInterface.php
+++ b/src/RequestHeaderParserFactoryInterface.php
@@ -9,7 +9,7 @@ interface RequestHeaderParserFactoryInterface
 
     /**
      * @param ConnectionInterface $conn
-     * @return mixed
+     * @return RequestHeaderParserInterface
      */
     public function create(ConnectionInterface $conn);
 }

--- a/src/RequestHeaderParserInterface.php
+++ b/src/RequestHeaderParserInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace React\Http;
+
+interface RequestHeaderParserInterface
+{
+
+    /**
+     * Feed the RequestHeaderParser with a data chunk from the connection
+     * @param string $data
+     * @return mixed
+     */
+    public function feed($data);
+}

--- a/src/RequestHeaderParserInterface.php
+++ b/src/RequestHeaderParserInterface.php
@@ -2,13 +2,15 @@
 
 namespace React\Http;
 
-interface RequestHeaderParserInterface
+use Evenement\EventEmitterInterface;
+
+interface RequestHeaderParserInterface extends EventEmitterInterface
 {
 
     /**
      * Feed the RequestHeaderParser with a data chunk from the connection
      * @param string $data
-     * @return mixed
+     * @return void
      */
     public function feed($data);
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -91,29 +91,17 @@ class Server extends EventEmitter
      * See also [listen()](#listen) for more details.
      *
      * @param callable $callback
+     * @param RequestHeaderParserFactoryInterface $factory
      * @see self::listen()
      */
-    public function __construct($callback)
+    public function __construct($callback, RequestHeaderParserFactoryInterface $factory = null)
     {
         if (!is_callable($callback)) {
             throw new \InvalidArgumentException();
         }
 
         $this->callback = $callback;
-        $this->factory = new RequestHeaderParserFactory();
-    }
-
-    /**
-     * Adds the ability to overwrite the default RequestHeaderParser
-     *
-     * @param RequestHeaderParserFactoryInterface $factory
-     * @return $this
-     */
-    public function setRequestHeaderParserFactory(RequestHeaderParserFactoryInterface $factory)
-    {
-        $this->factory = $factory;
-
-        return $this;
+        $this->factory = $factory ? $factory : new RequestHeaderParserFactory();
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -78,6 +78,11 @@ class Server extends EventEmitter
     private $callback;
 
     /**
+     * @var RequestHeaderParserFactoryInterface
+     */
+    private $factory;
+
+    /**
      * Creates an HTTP server that invokes the given callback for each incoming HTTP request
      *
      * In order to process any connections, the server needs to be attached to an
@@ -95,6 +100,20 @@ class Server extends EventEmitter
         }
 
         $this->callback = $callback;
+        $this->factory = new RequestHeaderParserFactory();
+    }
+
+    /**
+     * Adds the ability to overwrite the default RequestHeaderParser
+     *
+     * @param RequestHeaderParserFactoryInterface $factory
+     * @return $this
+     */
+    public function setRequestHeaderParserFactory(RequestHeaderParserFactoryInterface $factory)
+    {
+        $this->factory = $factory;
+
+        return $this;
     }
 
     /**
@@ -147,25 +166,8 @@ class Server extends EventEmitter
     /** @internal */
     public function handleConnection(ConnectionInterface $conn)
     {
-        $uriLocal = $conn->getLocalAddress();
-        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // try to detect transport encryption and assume default application scheme
-            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
-        } elseif ($uriLocal !== null) {
-            // local URI known, so translate transport scheme to application scheme
-            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
-        }
-
-        $uriRemote = $conn->getRemoteAddress();
-        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // actual scheme is not evaluated but required for parsing URI
-            $uriRemote = 'unused://' . $uriRemote;
-        }
-
         $that = $this;
-        $parser = new RequestHeaderParser($uriLocal, $uriRemote);
+        $parser = $this->factory->create($conn);
 
         $listener = array($parser, 'feed');
         $parser->on('headers', function (RequestInterface $request, $bodyBuffer) use ($conn, $listener, $that) {
@@ -421,28 +423,5 @@ class Server extends EventEmitter
 
             $connection->end();
         }
-    }
-
-    /**
-     * @param ConnectionInterface $conn
-     * @return bool
-     * @codeCoverageIgnore
-     */
-    private function isConnectionEncrypted(ConnectionInterface $conn)
-    {
-        // Legacy PHP < 7 does not offer any direct access to check crypto parameters
-        // We work around by accessing the context options and assume that only
-        // secure connections *SHOULD* set the "ssl" context options by default.
-        if (PHP_VERSION_ID < 70000) {
-            $context = isset($conn->stream) ? stream_context_get_options($conn->stream) : array();
-
-            return (isset($context['ssl']) && $context['ssl']);
-        }
-
-        // Modern PHP 7+ offers more reliable access to check crypto parameters
-        // by checking stream crypto meta data that is only then made available.
-        $meta = isset($conn->stream) ? stream_get_meta_data($conn->stream) : array();
-
-        return (isset($meta['crypto']) && $meta['crypto']);
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1258,6 +1258,7 @@ class ServerTest extends TestCase
 
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
+        $defaultMaxHeaderSize = 4096;
         $error = null;
         $server = new Server($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
@@ -1281,7 +1282,7 @@ class ServerTest extends TestCase
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
-        $data .= str_repeat('A', 4097 - strlen($data)) . "\r\n\r\n";
+        $data .= str_repeat('A', $defaultMaxHeaderSize + 1 - strlen($data)) . "\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertInstanceOf('OverflowException', $error);


### PR DESCRIPTION
Split-off from #217 and extension to #40. This PR adds the ability to pass a custom RequestHeaderParser to the server. 

* Adds option to pass a `RequestHeaderParserFactoryInterface` (someone up for a shorter name?)
* If none is passed, we take the default one shipped by the server
* If one is passed, it's taking the custom one

As soon as #241 gets merged we could also extend this factory with a custom parameter to enrich the `RequestHeaderParser` with for a custom `maxSize`. This could then complete #214. 