### PR TITLE
Forward compatibility with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7",
-        "clue/block-react": "^1.1"
+        "clue/block-react": "^1.1",
+        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.10||^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "clue/block-react": "^1.1"
     }
 }

--- a/tests/MiddlewareRunnerTest.php
+++ b/tests/MiddlewareRunnerTest.php
@@ -13,9 +13,12 @@ use Clue\React\Block;
 
 final class MiddlewareRunnerTest extends TestCase
 {
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage No middleware to run
+     */
     public function testDefaultResponse()
     {
-        $this->setExpectedException('\RuntimeException');
         $request = new ServerRequest('GET', 'https://example.com/');
         $middlewares = array();
         $middlewareStack = new MiddlewareRunner($middlewares);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace React\Tests\Http;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
     protected function expectCallableExactly($amount)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.