### PR TITLE
Update Socket to work around sending secure HTTPS responses with PHP < 7.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": ">=5.3.0",
         "ringcentral/psr7": "^1.2",
-        "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6",
+        "react/socket": "^1.0 || ^0.8.3",
+        "react/stream": "^1.0 || ^0.7.1",
         "react/promise": "^2.3 || ^1.2.1",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/promise-stream": "^0.1.1"
@@ -19,7 +19,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.10||^5.0",
-        "react/socket": "^1.0 || ^0.8 || ^0.7",
         "clue/block-react": "^1.1"
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -148,21 +148,12 @@ class Server extends EventEmitter
     public function handleConnection(ConnectionInterface $conn)
     {
         $uriLocal = $conn->getLocalAddress();
-        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // try to detect transport encryption and assume default application scheme
-            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
-        } elseif ($uriLocal !== null) {
+        if ($uriLocal !== null) {
             // local URI known, so translate transport scheme to application scheme
             $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
         }
 
         $uriRemote = $conn->getRemoteAddress();
-        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // actual scheme is not evaluated but required for parsing URI
-            $uriRemote = 'unused://' . $uriRemote;
-        }
 
         $that = $this;
         $parser = new RequestHeaderParser($uriLocal, $uriRemote);
@@ -421,28 +412,5 @@ class Server extends EventEmitter
 
             $connection->end();
         }
-    }
-
-    /**
-     * @param ConnectionInterface $conn
-     * @return bool
-     * @codeCoverageIgnore
-     */
-    private function isConnectionEncrypted(ConnectionInterface $conn)
-    {
-        // Legacy PHP < 7 does not offer any direct access to check crypto parameters
-        // We work around by accessing the context options and assume that only
-        // secure connections *SHOULD* set the "ssl" context options by default.
-        if (PHP_VERSION_ID < 70000) {
-            $context = isset($conn->stream) ? stream_context_get_options($conn->stream) : array();
-
-            return (isset($context['ssl']) && $context['ssl']);
-        }
-
-        // Modern PHP 7+ offers more reliable access to check crypto parameters
-        // by checking stream crypto meta data that is only then made available.
-        $meta = isset($conn->stream) ? stream_get_meta_data($conn->stream) : array();
-
-        return (isset($meta['crypto']) && $meta['crypto']);
     }
 }


### PR DESCRIPTION
PHP < 7.1.4 (and PHP < 7.0.18) suffers from a bug when writing big chunks of data over TLS streams at once. We try to work around this by limiting the write chunk size to 8192 bytes for older PHP versions only. This is only a work-around and has a noticable performance penalty on affected versions. Please update your PHP version.

This also allows us to drop a number of work arounds previously introduced via #167 and #183.

Refs https://github.com/reactphp/socket/issues/105
Refs https://github.com/reactphp/http-client/pull/109