### PR TITLE
Raise maximum request header size to 8k to match common implementations

### DIFF
--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -20,7 +20,7 @@ use Exception;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $maxSize = 4096;
+    private $maxSize = 8192;
 
     private $localSocketUri;
     private $remoteSocketUri;
@@ -34,16 +34,9 @@ class RequestHeaderParser extends EventEmitter
     public function feed($data)
     {
         $this->buffer .= $data;
-
         $endOfHeader = strpos($this->buffer, "\r\n\r\n");
 
-        if (false !== $endOfHeader) {
-            $currentHeaderSize = $endOfHeader;
-        } else {
-            $currentHeaderSize = strlen($this->buffer);
-        }
-
-        if ($currentHeaderSize > $this->maxSize) {
+        if ($endOfHeader > $this->maxSize || ($endOfHeader === false && isset($this->buffer[$this->maxSize]))) {
             $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -140,11 +140,11 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame(1, count($parser->listeners('headers')));
         $this->assertSame(1, count($parser->listeners('error')));
 
-        $data = str_repeat('A', 4097);
+        $data = str_repeat('A', 8193);
         $parser->feed($data);
 
         $this->assertInstanceOf('OverflowException', $error);
-        $this->assertSame('Maximum header size of 4096 exceeded.', $error->getMessage());
+        $this->assertSame('Maximum header size of 8192 exceeded.', $error->getMessage());
         $this->assertSame($parser, $passedParser);
         $this->assertSame(0, count($parser->listeners('headers')));
         $this->assertSame(0, count($parser->listeners('error')));
@@ -162,7 +162,7 @@ class RequestHeaderParserTest extends TestCase
         });
 
         $data = $this->createAdvancedPostRequest();
-        $body = str_repeat('A', 4097 - strlen($data));
+        $body = str_repeat('A', 8193 - strlen($data));
         $data .= $body;
 
         $parser->feed($data);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1324,7 +1324,7 @@ class ServerTest extends TestCase
         $this->socket->emit('connection', array($this->connection));
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
-        $data .= str_repeat('A', 4097 - strlen($data)) . "\r\n\r\n";
+        $data .= str_repeat('A', 8193 - strlen($data)) . "\r\n\r\n";
         $this->connection->emit('data', array($data));
 
         $this->assertInstanceOf('OverflowException', $error);


### PR DESCRIPTION
The current maximum request header size is rather small and can easily be reached by using long URIs or long cookie values. This simple PR raises the default maximum request header size from 4k to 8k to match other common implementations, such as Apache, nginx etc. (https://stackoverflow.com/questions/686217/maximum-on-http-header-values or http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers).

This is currently a hard-coded default with no way to change this value as a consumer. There's another open issue #214 to give users more control over this. This PR is created in the hope to spare users from looking into this in the first place.