### PR TITLE
Fix parsing multipart chunks with nested field names

### DIFF
--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -250,29 +250,27 @@ final class MultipartParser
             return $postFields;
         }
 
-        $chunkKey = $chunks[0];
-        if (!isset($postFields[$chunkKey])) {
-            $postFields[$chunkKey] = array();
-        }
-
+        $chunkKey = rtrim($chunks[0], ']');
         $parent = &$postFields;
         for ($i = 1; $i < count($chunks); $i++) {
             $previousChunkKey = $chunkKey;
-            if (!isset($parent[$previousChunkKey])) {
+            if ($previousChunkKey !== '' && !isset($parent[$previousChunkKey])) {
                 $parent[$previousChunkKey] = array();
             }
-            $parent = &$parent[$previousChunkKey];
-            $chunkKey = $chunks[$i];
 
-            if ($chunkKey == ']') {
-                $parent[] = $value;
-                return $postFields;
+            if ($previousChunkKey === '') {
+                $parent = &$parent[0];
+            } else {
+                $parent = &$parent[$previousChunkKey];
             }
 
-            $chunkKey = rtrim($chunkKey, ']');
+            $chunkKey = rtrim($chunks[$i], ']');
             if ($i == count($chunks) - 1) {
-                $parent[$chunkKey] = $value;
-                return $postFields;
+                if ($chunkKey === '') {
+                    $parent[] = $value;
+                } else {
+                    $parent[$chunkKey] = $value;
+                }
             }
         }
 

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -116,36 +116,29 @@ final class MultipartParser
             return;
         }
 
-        if ($this->headerStartsWith($headers['content-disposition'], 'filename')) {
-            $this->parseFile($headers, $body);
+        if (!$this->headerContainsParameter($headers['content-disposition'], 'name')) {
             return;
         }
 
-        if ($this->headerStartsWith($headers['content-disposition'], 'name')) {
+        if ($this->headerContainsParameter($headers['content-disposition'], 'filename')) {
+            $this->parseFile($headers, $body);
+        } else {
             $this->parsePost($headers, $body);
-            return;
         }
     }
 
     private function parseFile($headers, $body)
     {
-        if (
-            !$this->headerContains($headers['content-disposition'], 'name=') ||
-            !$this->headerContains($headers['content-disposition'], 'filename=')
-        ) {
-            return;
-        }
-
         $this->request = $this->request->withUploadedFiles($this->extractPost(
             $this->request->getUploadedFiles(),
-            $this->getFieldFromHeader($headers['content-disposition'], 'name'),
+            $this->getParameterFromHeader($headers['content-disposition'], 'name'),
             $this->parseUploadedFile($headers, $body)
         ));
     }
 
     private function parseUploadedFile($headers, $body)
     {
-        $filename = $this->getFieldFromHeader($headers['content-disposition'], 'filename');
+        $filename = $this->getParameterFromHeader($headers['content-disposition'], 'filename');
         $bodyLength = strlen($body);
 
         // no file selected (zero size and empty filename)
@@ -217,10 +210,10 @@ final class MultipartParser
         return $headers;
     }
 
-    private function headerStartsWith(array $header, $needle)
+    private function headerContainsParameter(array $header, $parameter)
     {
         foreach ($header as $part) {
-            if (strpos($part, $needle) === 0) {
+            if (strpos($part, $parameter . '=') === 0) {
                 return true;
             }
         }
@@ -228,22 +221,11 @@ final class MultipartParser
         return false;
     }
 
-    private function headerContains(array $header, $needle)
+    private function getParameterFromHeader(array $header, $parameter)
     {
         foreach ($header as $part) {
-            if (strpos($part, $needle) !== false) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function getFieldFromHeader(array $header, $field)
-    {
-        foreach ($header as $part) {
-            if (strpos($part, $field) === 0) {
-                preg_match('/' . $field . '="?(.*)"$/', $part, $matches);
+            if (strpos($part, $parameter) === 0) {
+                preg_match('/' . $parameter . '="?(.*)"$/', $part, $matches);
                 return $matches[1];
             }
         }

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -252,26 +252,27 @@ final class MultipartParser
 
         $chunkKey = rtrim($chunks[0], ']');
         $parent = &$postFields;
-        for ($i = 1; $i < count($chunks); $i++) {
+        for ($i = 1; isset($chunks[$i]); $i++) {
             $previousChunkKey = $chunkKey;
-            if ($previousChunkKey !== '' && !isset($parent[$previousChunkKey])) {
-                $parent[$previousChunkKey] = array();
-            }
 
             if ($previousChunkKey === '') {
-                $parent = &$parent[0];
+                $parent[] = array();
+                end($parent);
+                $parent = &$parent[key($parent)];
             } else {
+                if (!isset($parent[$previousChunkKey]) || !is_array($parent[$previousChunkKey])) {
+                    $parent[$previousChunkKey] = array();
+                }
                 $parent = &$parent[$previousChunkKey];
             }
 
             $chunkKey = rtrim($chunks[$i], ']');
-            if ($i == count($chunks) - 1) {
-                if ($chunkKey === '') {
-                    $parent[] = $value;
-                } else {
-                    $parent[$chunkKey] = $value;
-                }
-            }
+        }
+
+        if ($chunkKey === '') {
+            $parent[] = $value;
+        } else {
+            $parent[$chunkKey] = $value;
         }
 
         return $postFields;

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -51,7 +51,6 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-
         $request = new ServerRequest('POST', 'http://example.com/', array(
             'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
         ), $data, 1.1);
@@ -77,7 +76,6 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-
         $request = new ServerRequest('POST', 'http://example.com/', array(
             'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
         ), $data, 1.1);
@@ -88,6 +86,64 @@ final class MultipartParserTest extends TestCase
         $this->assertSame(
             array(
                 '' => 'value'
+            ),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
+    public function testNestedPostKeyAssoc()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"a[b][c]\"\r\n";
+        $data .= "\r\n";
+        $data .= "value\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+        ), $data, 1.1);
+
+        $parsedRequest = MultipartParser::parseRequest($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertSame(
+            array(
+                'a' => array(
+                    'b' => array(
+                        'c' => 'value'
+                    )
+                )
+            ),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
+    public function testNestedPostKeyVector()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"a[][]\"\r\n";
+        $data .= "\r\n";
+        $data .= "value\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+        ), $data, 1.1);
+
+        $parsedRequest = MultipartParser::parseRequest($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertSame(
+            array(
+                'a' => array(
+                    array(
+                        'value'
+                    )
+                )
             ),
             $parsedRequest->getParsedBody()
         );


### PR DESCRIPTION
While working on #257, I found a number of issues with parsing the "name" field for multipart chunks. This adds quite a few tests, removes some now unneeded code and significantly improves code coverage.

Builds on top of #226