### PR TITLE
Renamed Server to StreamingServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Event-driven, streaming plaintext HTTP and secure HTTPS server for [ReactPHP](ht
 
 * [Quickstart example](#quickstart-example)
 * [Usage](#usage)
-  * [Server](#server)
+  * [StreamingServer](#streamingserver)
   * [Request](#request)
   * [Response](#response)
   * [Middleware](#middleware)
@@ -27,7 +27,7 @@ This is an HTTP server which responds with `Hello World` to every request.
 ```php
 $loop = React\EventLoop\Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -45,9 +45,9 @@ See also the [examples](examples).
 
 ## Usage
 
-### Server
+### StreamingServer
 
-The `Server` class is responsible for handling incoming connections and then
+The `StreamingServer` class is responsible for handling incoming connections and then
 processing each incoming HTTP request.
 
 For each request, it executes the callback function passed to the
@@ -55,7 +55,7 @@ constructor with the respective [request](#request) object and expects
 a respective [response](#response) object in return.
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -73,7 +73,7 @@ You can attach this to a
 in order to start a plaintext HTTP server like this:
 
 ```php
-$server = new Server($handler);
+$server = new StreamingServer($handler);
 
 $socket = new React\Socket\Server(8080, $loop);
 $server->listen($socket);
@@ -86,7 +86,7 @@ Similarly, you can also attach this to a
 in order to start a secure HTTPS server like this:
 
 ```php
-$server = new Server($handler);
+$server = new StreamingServer($handler);
 
 $socket = new React\Socket\Server(8080, $loop);
 $socket = new React\Socket\SecureServer($socket, $loop, array(
@@ -110,7 +110,7 @@ examples above.
 See also [request](#request) and [response](#response)
 for more details (e.g. the request data body).
 
-The `Server` supports both HTTP/1.1 and HTTP/1.0 request messages.
+The `StreamingServer` supports both HTTP/1.1 and HTTP/1.0 request messages.
 If a client sends an invalid request message, uses an invalid HTTP protocol
 version or sends an invalid `Transfer-Encoding` in the request header, it will
 emit an `error` event, send an HTTP error response to the client and
@@ -125,7 +125,7 @@ $server->on('error', function (Exception $e) {
 The server will also emit an `error` event if you return an invalid
 type in the callback function or have a unhandled `Exception` or `Throwable`.
 If your callback function throws an `Exception` or `Throwable`,
-the `Server` will emit a `RuntimeException` and add the thrown exception
+the `StreamingServer` will emit a `RuntimeException` and add the thrown exception
 as previous:
 
 ```php
@@ -143,7 +143,7 @@ Check out [request](#request) for more details.
 
 ### Request
 
-An seen above, the `Server` class is responsible for handling incoming
+An seen above, the `StreamingServer` class is responsible for handling incoming
 connections and then processing each incoming HTTP request.
 
 The request object will be processed once the request headers have
@@ -155,7 +155,7 @@ which in turn extends the
 and will be passed to the callback function like this.
 
  ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $body = "The method of the request is: " . $request->getMethod();
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
@@ -189,7 +189,7 @@ The following parameters are currently available:
   Set to 'on' if the request used HTTPS, otherwise it won't be set
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
@@ -206,7 +206,7 @@ The `getQueryParams(): array` method can be used to get the query parameters
 similiar to the `$_GET` variable.
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -269,7 +269,7 @@ The `ReactPHP ReadableStreamInterface` gives you access to the incoming
 request body as the individual chunks arrive:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
         $request->getBody()->on('data', function ($data) use (&$contentLength) {
@@ -333,7 +333,7 @@ Note that this value may be `null` if the request body size is unknown in
 advance because the request message uses chunked transfer encoding.
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $size = $request->getBody()->getSize();
     if ($size === null) {
         $body = 'The request does not contain an explicit length.';
@@ -387,7 +387,7 @@ The `getCookieParams(): string[]` method can be used to
 get all cookies sent with the current request.
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -422,7 +422,7 @@ See also [example #5](examples) for more details.
 
 ### Response
 
-The callback function passed to the constructor of the [Server](#server)
+The callback function passed to the constructor of the [StreamingServer](#server)
 is responsible for processing the request and returning a response,
 which will be delivered to the client.
 This function MUST return an instance implementing
@@ -438,7 +438,7 @@ but feel free to use any implemantation of the
 `PSR-7 ResponseInterface` you prefer.
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),
@@ -457,7 +457,7 @@ To prevent this you SHOULD use a
 This example shows how such a long-term action could look like:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(
@@ -490,7 +490,7 @@ Note that other implementations of the `PSR-7 ResponseInterface` likely
 only support strings.
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
@@ -533,7 +533,7 @@ If you know the length of your stream body, you MAY specify it like this instead
 
 ```php
 $stream = new ThroughStream()
-$server = new Server(function (ServerRequestInterface $request) use ($stream) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
     return new Response(
         200,
         array(
@@ -549,8 +549,8 @@ An invalid return value or an unhandled `Exception` or `Throwable` in the code
 of the callback function, will result in an `500 Internal Server Error` message.
 Make sure to catch `Exceptions` or `Throwables` to create own response messages.
 
-After the return in the callback function the response will be processed by the `Server`.
-The `Server` will add the protocol version of the request, so you don't have to.
+After the return in the callback function the response will be processed by the `StreamingServer`.
+The `StreamingServer` will add the protocol version of the request, so you don't have to.
 
 Any response to a `HEAD` request and any response with a `1xx` (Informational),
 `204` (No Content) or `304` (Not Modified) status code will *not* include a
@@ -618,7 +618,7 @@ A `Date` header will be automatically added with the system date and time if non
 You can add a custom `Date` header yourself like this:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(200, array('Date' => date('D, d M Y H:i:s T')));
 });
 ```
@@ -627,7 +627,7 @@ If you don't have a appropriate clock to rely on, you should
 unset this header with an empty string:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(200, array('Date' => ''));
 });
 ```
@@ -636,7 +636,7 @@ Note that it will automatically assume a `X-Powered-By: react/alpha` header
 unless your specify a custom `X-Powered-By` header yourself:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(200, array('X-Powered-By' => 'PHP 3'));
 });
 ```
@@ -645,7 +645,7 @@ If you do not want to send this header at all, you can use an empty string as
 value like this:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(200, array('X-Powered-By' => ''));
 });
 ```
@@ -670,7 +670,7 @@ The following example adds a middleware that adds the current time to the reques
 header (`Request-Time`) and middleware that always returns a 200 code without a body: 
 
 ```php
-$server = new Server(new MiddlewareRunner([
+$server = new StreamingServer(new MiddlewareRunner([
     function (ServerRequestInterface $request, callable $next) {
         $request = $request->withHeader('Request-Time', time());
         return $next($request);
@@ -767,7 +767,7 @@ $handler = function (ServerRequestInterface $request) {
     );
 };
 
-$server = new Server(new MiddlewareRunner([
+$server = new StreamingServer(new MiddlewareRunner([
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
     new RequestBodyParserMiddleware(),
     $handler

--- a/examples/01-hello-world.php
+++ b/examples/01-hello-world.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(

--- a/examples/02-count-visitors.php
+++ b/examples/02-count-visitors.php
@@ -3,14 +3,14 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
 $counter = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),

--- a/examples/03-client-ip.php
+++ b/examples/03-client-ip.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(

--- a/examples/04-query-parameter.php
+++ b/examples/04-query-parameter.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';

--- a/examples/05-cookie-handling.php
+++ b/examples/05-cookie-handling.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {

--- a/examples/06-sleep.php
+++ b/examples/06-sleep.php
@@ -3,14 +3,14 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(

--- a/examples/07-error-handling.php
+++ b/examples/07-error-handling.php
@@ -3,7 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 
 $count = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$count) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 

--- a/examples/08-stream-response.php
+++ b/examples/08-stream-response.php
@@ -3,14 +3,14 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server($loop,function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer($loop,function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }

--- a/examples/09-stream-request.php
+++ b/examples/09-stream-request.php
@@ -3,14 +3,14 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
         $request->getBody()->on('data', function ($data) use (&$contentLength) {

--- a/examples/11-hello-world-https.php
+++ b/examples/11-hello-world-https.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array('Content-Type' => 'text/plain'),

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -14,7 +14,7 @@ use React\Http\MiddlewareRunner;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -118,7 +118,7 @@ HTML;
 };
 
 // buffer and parse HTTP request body before running our request handler
-$server = new Server(new MiddlewareRunner(array(
+$server = new StreamingServer(new MiddlewareRunner(array(
     new RequestBodyBufferMiddleware(100000), // 100 KB max
     new RequestBodyParserMiddleware(),
     $handler

--- a/examples/21-http-proxy.php
+++ b/examples/21-http-proxy.php
@@ -3,14 +3,14 @@
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (RequestInterface $request) {
+$server = new StreamingServer(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,

--- a/examples/22-connect-proxy.php
+++ b/examples/22-connect-proxy.php
@@ -3,7 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
@@ -12,7 +12,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $connector = new Connector($loop);
 
-$server = new Server(function (ServerRequestInterface $request) use ($connector) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,

--- a/examples/31-upgrade-echo.php
+++ b/examples/31-upgrade-echo.php
@@ -20,14 +20,14 @@ $ telnet localhost 1080
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(426, array('Upgrade' => 'echo'), '"Upgrade: echo" required');
     }

--- a/examples/32-upgrade-chat.php
+++ b/examples/32-upgrade-chat.php
@@ -22,7 +22,7 @@ Hint: try this with multiple connections :)
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
 
@@ -35,7 +35,7 @@ $loop = Factory::create();
 // this means that any Upgraded data will simply be sent back to the client
 $chat = new ThroughStream();
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop, $chat) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop, $chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(426, array('Upgrade' => 'chat'), '"Upgrade: chat" required');
     }

--- a/examples/99-benchmark-download.php
+++ b/examples/99-benchmark-download.php
@@ -10,7 +10,7 @@ use Evenement\EventEmitter;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 
@@ -86,7 +86,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -30,7 +30,7 @@ use RingCentral\Psr7 as Psr7Implementation;
  * a respective [response](#response) object in return.
  *
  * ```php
- * $server = new Server(function (ServerRequestInterface $request) {
+ * $server = new StreamingServer(function (ServerRequestInterface $request) {
  *     return new Response(
  *         200,
  *         array('Content-Type' => 'text/plain'),
@@ -81,7 +81,7 @@ use RingCentral\Psr7 as Psr7Implementation;
  * @see Response
  * @see self::listen()
  */
-class Server extends EventEmitter
+class StreamingServer extends EventEmitter
 {
     private $callback;
 
@@ -120,7 +120,7 @@ class Server extends EventEmitter
      * in order to start a plaintext HTTP server like this:
      *
      * ```php
-     * $server = new Server($handler);
+     * $server = new StreamingServer($handler);
      *
      * $socket = new React\Socket\Server(8080, $loop);
      * $server->listen($socket);
@@ -133,7 +133,7 @@ class Server extends EventEmitter
      * in order to start a secure HTTPS server like this:
      *
      * ```php
-     * $server = new Server($handler);
+     * $server = new StreamingServer($handler);
      *
      * $socket = new React\Socket\Server(8080, $loop);
      * $socket = new React\Socket\SecureServer($socket, $loop, array(

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -5,7 +5,7 @@ namespace React\Tests\Http;
 use React\Http\MiddlewareRunner;
 use React\Socket\Server as Socket;
 use React\EventLoop\Factory;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use Psr\Http\Message\RequestInterface;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
@@ -23,7 +23,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -49,7 +49,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(new MiddlewareRunner(array(function (RequestInterface $request) {
+        $server = new StreamingServer(new MiddlewareRunner(array(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         })));
 
@@ -75,7 +75,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(new MiddlewareRunner(array(
+        $server = new StreamingServer(new MiddlewareRunner(array(
             function () {
                 return new Response(404);
             },
@@ -102,7 +102,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -128,7 +128,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -160,7 +160,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -192,7 +192,7 @@ class FunctionalServerTest extends TestCase
 
         $loop = Factory::create();
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -236,7 +236,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -270,7 +270,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -300,7 +300,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -339,7 +339,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -378,7 +378,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -408,7 +408,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -447,7 +447,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri() . 'x' . $request->getHeaderLine('Host'));
         });
 
@@ -475,7 +475,7 @@ class FunctionalServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server(function (RequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -504,7 +504,7 @@ class FunctionalServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server(function (RequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -537,7 +537,7 @@ class FunctionalServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server(function (RequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -572,7 +572,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -609,7 +609,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -646,7 +646,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new StreamingServer(function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -687,7 +687,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new StreamingServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
             $stream->close();
 

--- a/tests/StreamingServerTest.php
+++ b/tests/StreamingServerTest.php
@@ -3,13 +3,13 @@
 namespace React\Tests\Http;
 
 use React\Http\MiddlewareRunner;
-use React\Http\Server;
+use React\Http\StreamingServer;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Response;
 use React\Stream\ThroughStream;
 use React\Promise\Promise;
 
-class ServerTest extends TestCase
+class StreamingServerTest extends TestCase
 {
     private $connection;
     private $socket;
@@ -42,7 +42,7 @@ class ServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -54,7 +54,7 @@ class ServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new Server($this->expectCallableOnce());
+        $server = new StreamingServer($this->expectCallableOnce());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -67,7 +67,7 @@ class ServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -100,7 +100,7 @@ class ServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new Server(new MiddlewareRunner(array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(new MiddlewareRunner(array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         })));
@@ -132,7 +132,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -154,7 +154,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -176,7 +176,7 @@ class ServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -198,7 +198,7 @@ class ServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -218,7 +218,7 @@ class ServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -231,7 +231,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -253,7 +253,7 @@ class ServerTest extends TestCase
     public function testRequestConnectWithoutHostWillBeAdded()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -275,7 +275,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -297,7 +297,7 @@ class ServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBeOverwritten()
     {
         $requestAssertion = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -318,7 +318,7 @@ class ServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -330,7 +330,7 @@ class ServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -344,7 +344,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -370,7 +370,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -392,7 +392,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -414,7 +414,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -436,7 +436,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -458,7 +458,7 @@ class ServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -478,7 +478,7 @@ class ServerTest extends TestCase
 
     public function testRequestPauseWillbeForwardedToConnection()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->pause();
         });
 
@@ -498,7 +498,7 @@ class ServerTest extends TestCase
 
     public function testRequestResumeWillbeForwardedToConnection()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->resume();
         });
 
@@ -513,7 +513,7 @@ class ServerTest extends TestCase
 
     public function testRequestCloseWillPauseConnection()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
         });
 
@@ -528,7 +528,7 @@ class ServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();
         });
@@ -544,7 +544,7 @@ class ServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
         });
@@ -563,7 +563,7 @@ class ServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
         });
 
@@ -578,7 +578,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -598,7 +598,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new Server(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -619,7 +619,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsPoweredByHeader()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -649,7 +649,7 @@ class ServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -679,7 +679,7 @@ class ServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -711,7 +711,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -746,7 +746,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -784,7 +784,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -820,7 +820,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -875,7 +875,7 @@ class ServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -893,7 +893,7 @@ class ServerTest extends TestCase
 
     public function testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -929,7 +929,7 @@ class ServerTest extends TestCase
 
     public function testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -964,7 +964,7 @@ class ServerTest extends TestCase
 
     public function testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 101,
                 array(
@@ -1004,7 +1004,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
                 array(
@@ -1045,7 +1045,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1083,7 +1083,7 @@ class ServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1102,7 +1102,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1135,7 +1135,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1169,7 +1169,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1201,7 +1201,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 204,
                 array(),
@@ -1234,7 +1234,7 @@ class ServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1268,7 +1268,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1302,7 +1302,7 @@ class ServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1336,7 +1336,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1373,7 +1373,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1401,7 +1401,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1432,7 +1432,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1461,7 +1461,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1488,7 +1488,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1516,7 +1516,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1539,7 +1539,7 @@ class ServerTest extends TestCase
     public function testRequestWithMalformedHostWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1572,7 +1572,7 @@ class ServerTest extends TestCase
     public function testRequestWithInvalidHostUriComponentsWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1609,7 +1609,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1640,7 +1640,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1672,7 +1672,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1698,7 +1698,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1725,7 +1725,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1756,7 +1756,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1793,7 +1793,7 @@ class ServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1826,7 +1826,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidNonIntegerContentLengthWillEmitServerErrorAndSendResponse()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1863,7 +1863,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidHeadRequestWithInvalidNonIntegerContentLengthWillEmitServerErrorAndSendResponseWithoutBody()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1900,7 +1900,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidMultipleContentLengthWillEmitErrorOnServer()
     {
         $error = null;
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1937,7 +1937,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server(function ($request) use ($errorEvent){
+        $server = new StreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1963,7 +1963,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server(function ($request) use ($errorEvent){
+        $server = new StreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1986,7 +1986,7 @@ class ServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server(function ($request) use ($errorEvent){
+        $server = new StreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2010,7 +2010,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server(function ($request) use ($errorEvent){
+        $server = new StreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2033,7 +2033,7 @@ class ServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new Server(function ($request) use ($errorEvent){
+        $server = new StreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2061,7 +2061,7 @@ class ServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = new StreamingServer(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -2086,7 +2086,7 @@ class ServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -2105,7 +2105,7 @@ class ServerTest extends TestCase
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
     {
         $stream = new ThroughStream();
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -2139,7 +2139,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2177,7 +2177,7 @@ class ServerTest extends TestCase
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
     {
         $stream = new ThroughStream();
-        $server = new Server(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(
@@ -2214,7 +2214,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDate()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2244,7 +2244,7 @@ class ServerTest extends TestCase
 
     public function testResponseWIthCustomDateHeaderOverwritesDefault()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
@@ -2277,7 +2277,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Date' => '')
@@ -2310,7 +2310,7 @@ class ServerTest extends TestCase
 
     public function testResponseCanContainMultipleCookieHeaders()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2350,7 +2350,7 @@ class ServerTest extends TestCase
     {
         $error = null;
 
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($exception) use (&$error) {
             $error = $exception;
         });
@@ -2387,7 +2387,7 @@ class ServerTest extends TestCase
     {
         $error = null;
 
-        $server = new Server($this->expectCallableNever());
+        $server = new StreamingServer($this->expectCallableNever());
         $server->on('error', function ($exception) use (&$error) {
             $error = $exception;
         });
@@ -2420,7 +2420,7 @@ class ServerTest extends TestCase
 
     public function testReponseWithExpectContinueRequestContainsContinueWithLaterResponse()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2452,7 +2452,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2485,14 +2485,14 @@ class ServerTest extends TestCase
      */
     public function testInvalidCallbackFunctionLeadsToException()
     {
-        $server = new Server('invalid');
+        $server = new StreamingServer('invalid');
     }
 
     public function testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding()
     {
         $input = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array(),
@@ -2531,7 +2531,7 @@ class ServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new Server(function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array('Content-Length' => 5),
@@ -2569,7 +2569,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithResponsePromise()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2597,7 +2597,7 @@ class ServerTest extends TestCase
 
     public function testResponseReturnInvalidTypeWillResultInError()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2631,7 +2631,7 @@ class ServerTest extends TestCase
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2659,7 +2659,7 @@ class ServerTest extends TestCase
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2690,7 +2690,7 @@ class ServerTest extends TestCase
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2721,7 +2721,7 @@ class ServerTest extends TestCase
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Transfer-Encoding' => 'chunked'),
@@ -2757,7 +2757,7 @@ class ServerTest extends TestCase
 
     public function testResponseWillBeHandled()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2785,7 +2785,7 @@ class ServerTest extends TestCase
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2823,7 +2823,7 @@ class ServerTest extends TestCase
      */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             throw new \Error('hello');
         });
 
@@ -2866,7 +2866,7 @@ class ServerTest extends TestCase
 
     public function testResponseRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2903,7 +2903,7 @@ class ServerTest extends TestCase
     public function testRequestServerRequestParams()
     {
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2937,7 +2937,7 @@ class ServerTest extends TestCase
     public function testRequestQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2957,7 +2957,7 @@ class ServerTest extends TestCase
     public function testRequestCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2978,7 +2978,7 @@ class ServerTest extends TestCase
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2999,7 +2999,7 @@ class ServerTest extends TestCase
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new Server(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 


### PR DESCRIPTION
This simple PR renames the `Server` class to `StreamingServer`.

A follow-up PR will introduce a new `Server` class which acts as a facade for the existing server classes. In other words, the follow-up PR will restore compatibility with consumer code so this does in fact not result in a BC break for most users.

Refs #259
Supersedes / closes #260 