### PR TITLE
Fix handling invalid or incomplete multipart parts

### DIFF
--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -60,37 +60,15 @@ final class MultipartParser
     {
         $this->buffer = (string)$this->request->getBody();
 
-        $this->determineStartMethod();
+        $contentType = $this->request->getHeaderLine('content-type');
+        if(!preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
+            return $this->request;
+        }
+
+        $this->boundary = $matches[1];
+        $this->parseBuffer();
 
         return $this->request;
-    }
-
-    private function determineStartMethod()
-    {
-        if (!$this->request->hasHeader('content-type')) {
-            $this->findBoundary();
-            return;
-        }
-
-        $contentType = $this->request->getHeaderLine('content-type');
-        preg_match('/boundary="?(.*)"?$/', $contentType, $matches);
-        if (isset($matches[1])) {
-            $this->boundary = $matches[1];
-            $this->parseBuffer();
-            return;
-        }
-
-        $this->findBoundary();
-    }
-
-    private function findBoundary()
-    {
-        if (substr($this->buffer, 0, 3) === '---' && strpos($this->buffer, "\r\n") !== false) {
-            $boundary = substr($this->buffer, 2, strpos($this->buffer, "\r\n"));
-            $boundary = substr($boundary, 0, -2);
-            $this->boundary = $boundary;
-            $this->parseBuffer();
-        }
     }
 
     private function parseBuffer()

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -16,29 +16,9 @@ use RingCentral\Psr7;
 final class MultipartParser
 {
     /**
-     * @var string
-     */
-    protected $buffer = '';
-
-    /**
-     * @var string
-     */
-    protected $boundary;
-
-    /**
      * @var ServerRequestInterface
      */
     protected $request;
-
-    /**
-     * @var HttpBodyStream
-     */
-    protected $body;
-
-    /**
-     * @var callable
-     */
-    protected $onDataCallable;
 
     /**
      * @var int|null
@@ -58,23 +38,21 @@ final class MultipartParser
 
     private function parse()
     {
-        $this->buffer = (string)$this->request->getBody();
-
         $contentType = $this->request->getHeaderLine('content-type');
         if(!preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
             return $this->request;
         }
 
-        $this->boundary = $matches[1];
-        $this->parseBuffer();
+        $this->parseBuffer($matches[1], (string)$this->request->getBody());
 
         return $this->request;
     }
 
-    private function parseBuffer()
+    private function parseBuffer($boundary, $buffer)
     {
-        $chunks = explode('--' . $this->boundary, $this->buffer);
-        $this->buffer = array_pop($chunks);
+        $chunks = explode('--' . $boundary, $buffer);
+        array_pop($chunks);
+
         foreach ($chunks as $chunk) {
             $chunk = $this->stripTrailingEOL($chunk);
             $this->parseChunk($chunk);

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -105,12 +105,13 @@ final class MultipartParser
 
     private function parseChunk($chunk)
     {
-        if ($chunk === '') {
+        $pos = strpos($chunk, "\r\n\r\n");
+        if ($pos === false) {
             return;
         }
 
-        list ($header, $body) = explode("\r\n\r\n", $chunk, 2);
-        $headers = $this->parseHeaders($header);
+        $headers = $this->parseHeaders((string)substr($chunk, 0, $pos));
+        $body = (string)substr($chunk, $pos + 4);
 
         if (!isset($headers['content-disposition'])) {
             return;

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -140,6 +140,7 @@ final class MultipartParser
     {
         $filename = $this->getParameterFromHeader($headers['content-disposition'], 'filename');
         $bodyLength = strlen($body);
+        $contentType = isset($headers['content-type'][0]) ? $headers['content-type'][0] : null;
 
         // no file selected (zero size and empty filename)
         if ($bodyLength === 0 && $filename === '') {
@@ -148,7 +149,7 @@ final class MultipartParser
                 $bodyLength,
                 UPLOAD_ERR_NO_FILE,
                 $filename,
-                $headers['content-type'][0]
+                $contentType
             );
         }
 
@@ -159,7 +160,7 @@ final class MultipartParser
                 $bodyLength,
                 UPLOAD_ERR_FORM_SIZE,
                 $filename,
-                $headers['content-type'][0]
+                $contentType
             );
         }
 
@@ -168,7 +169,7 @@ final class MultipartParser
             $bodyLength,
             UPLOAD_ERR_OK,
             $filename,
-            $headers['content-type'][0]
+            $contentType
         );
     }
 

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -8,6 +8,30 @@ use React\Tests\Http\TestCase;
 
 final class MultipartParserTest extends TestCase
 {
+    public function testDoesNotParseWithoutMultipartFormDataContentType()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"single\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"second\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data',
+        ), $data, 1.1);
+
+        $parsedRequest = MultipartParser::parseRequest($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertEmpty($parsedRequest->getParsedBody());
+    }
+
     public function testPostKey()
     {
         $boundary = "---------------------------5844729766471062541057622570";
@@ -23,7 +47,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -55,7 +79,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -84,7 +108,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -115,7 +139,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -146,7 +170,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -178,7 +202,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -203,7 +227,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -228,7 +252,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -257,7 +281,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -337,7 +361,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -477,7 +501,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -497,7 +521,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -516,7 +540,7 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -539,7 +563,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -573,7 +597,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/mixed; boundary=' . $boundary,
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -606,7 +630,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -639,7 +663,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -676,7 +700,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);
@@ -730,7 +754,7 @@ final class MultipartParserTest extends TestCase
         $data .= "--$boundary--\r\n";
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         $parsedRequest = MultipartParser::parseRequest($request);

--- a/tests/Middleware/RequestBodyParserMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyParserMiddlewareTest.php
@@ -149,7 +149,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
 
         $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data',
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
         /** @var ServerRequestInterface $parsedRequest */


### PR DESCRIPTION
While working on #257, I found a number of issues with parsing invalid multipart parts. This PR adds quite a few tests, removes some now unneeded code and improves code coverage to 100%. This now strictly follows RFC 7578 and RFC 2046.

If you want to review this, I would suggest checking out the individual commits.

Builds on top of #265 and #226