### PR TITLE
Respect max_input_vars and max_input_nesting_level ini settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,12 @@ See also [example #12](examples) for more details.
   
 > PHP's `MAX_FILE_SIZE` hidden field is respected by this middleware.
 
+> This middleware respects the
+  [`max_input_vars`](http://php.net/manual/en/info.configuration.php#ini.max-input-vars)
+  (default `1000`) and
+  [`max_input_nesting_level`](http://php.net/manual/en/info.configuration.php#ini.max-input-nesting-level)
+  (default `64`) ini settings.
+
 #### Third-Party Middleware
 
 A non-exhaustive list of third-party middleware can be found at the [`Middleware`](https://github.com/reactphp/http/wiki/Middleware) wiki page. 

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -25,8 +25,10 @@ final class RequestBodyParserMiddleware
 
     private function parseFormUrlencoded(ServerRequestInterface $request)
     {
+        // parse string into array structure
+        // ignore warnings due to excessive data structures (max_input_vars and max_input_nesting_level)
         $ret = array();
-        parse_str((string)$request->getBody(), $ret);
+        @parse_str((string)$request->getBody(), $ret);
 
         return $request->withParsedBody($ret);
     }

--- a/tests/Middleware/RequestBodyParserMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyParserMiddlewareTest.php
@@ -107,6 +107,76 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $this->assertSame('foo=bar&baz[]=cheese&bar[]=beer&bar[]=wine&market[fish]=salmon&market[meat][]=beef&market[meat][]=chicken&market[]=bazaar', (string)$parsedRequest->getBody());
     }
 
+    public function testFormUrlencodedIgnoresBodyWithExcessiveNesting()
+    {
+        // supported in all Zend PHP versions and HHVM
+        // ini setting does exist everywhere but HHVM: https://3v4l.org/hXLiK
+        // HHVM limits to 64 and returns an empty array structure: https://3v4l.org/j3DK2
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM (limited to depth 64, but keeps empty array structure)');
+        }
+
+        $allowed = (int)ini_get('max_input_nesting_level');
+
+        $middleware = new RequestBodyParserMiddleware();
+        $request = new ServerRequest(
+            'POST',
+            'https://example.com/',
+            array(
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ),
+            'hello' . str_repeat('[]', $allowed + 1) . '=world'
+        );
+
+        /** @var ServerRequestInterface $parsedRequest */
+        $parsedRequest = $middleware(
+            $request,
+            function (ServerRequestInterface $request) {
+                return $request;
+            }
+        );
+
+        $this->assertSame(
+            array(),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
+    public function testFormUrlencodedTruncatesBodyWithExcessiveLength()
+    {
+        // supported as of PHP 5.3.11, no HHVM support: https://3v4l.org/PiqnQ
+        // ini setting already exists in PHP 5.3.9: https://3v4l.org/VF6oV
+        if (defined('HHVM_VERSION') || PHP_VERSION_ID < 50311) {
+            $this->markTestSkipped('Not supported on HHVM and PHP < 5.3.11 (unlimited length)');
+        }
+
+        $allowed = (int)ini_get('max_input_vars');
+
+        $middleware = new RequestBodyParserMiddleware();
+        $request = new ServerRequest(
+            'POST',
+            'https://example.com/',
+            array(
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ),
+            str_repeat('a[]=b&', $allowed + 1)
+        );
+
+        /** @var ServerRequestInterface $parsedRequest */
+        $parsedRequest = $middleware(
+            $request,
+            function (ServerRequestInterface $request) {
+                return $request;
+            }
+        );
+
+        $body = $parsedRequest->getParsedBody();
+
+        $this->assertCount(1, $body);
+        $this->assertTrue(isset($body['a']));
+        $this->assertCount($allowed, $body['a']);
+    }
+
     public function testDoesNotParseJsonByDefault()
     {
         $middleware = new RequestBodyParserMiddleware();


### PR DESCRIPTION
This PR implements support for max_input_vars and max_input_nesting_level ini settings. These are already supported internally by `parse_str()`, so this PR adds according functionality for the multipart parser. These settings can only be controlled through ini settings and offering a way to control these here makes little sense. The main use case for these variables is to prevent DOS attacks due to excessive data structures.

This resolves the first part of #257.