### PR TITLE
Respect ini settings for file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,8 @@ $handler = function (ServerRequestInterface $request) {
     if ($avatar instanceof UploadedFileInterface) {
         if ($avatar->getError() === UPLOAD_ERR_OK) {
             $uploaded = $avatar->getSize() . ' bytes';
+        } elseif ($avatar->getError() === UPLOAD_ERR_INI_SIZE) {
+            $uploaded = 'file too large';
         } else {
             $uploaded = 'with error';
         }
@@ -798,6 +800,8 @@ See also [example #12](examples) for more details.
 > PHP's `MAX_FILE_SIZE` hidden field is respected by this middleware.
 
 > This middleware respects the
+  [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)
+  (default `2M`),
   [`max_input_vars`](http://php.net/manual/en/info.configuration.php#ini.max-input-vars)
   (default `1000`) and
   [`max_input_nesting_level`](http://php.net/manual/en/info.configuration.php#ini.max-input-nesting-level)

--- a/README.md
+++ b/README.md
@@ -834,6 +834,13 @@ new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
   [`max_input_nesting_level`](http://php.net/manual/en/info.configuration.php#ini.max-input-nesting-level)
   (default `64`) ini settings.
 
+> Note that this middleware ignores the
+  [`enable_post_data_reading`](http://php.net/manual/en/ini.core.php#ini.enable-post-data-reading)
+  (default `1`) ini setting because it makes little sense to respect here and
+  is left up to higher-level implementations.
+  If you want to respect this setting, you have to check its value and
+  effectively avoid using this middleware entirely.
+
 #### Third-Party Middleware
 
 A non-exhaustive list of third-party middleware can be found at the [`Middleware`](https://github.com/reactphp/http/wiki/Middleware) wiki page. 

--- a/README.md
+++ b/README.md
@@ -796,6 +796,18 @@ constructor like this:
 new RequestBodyParserMiddleware(8 * 1024 * 1024); // 8 MiB limit per file
 ```
 
+By default, this middleware respects the
+[`max_file_uploads`](http://php.net/manual/en/ini.core.php#ini.max-file-uploads)
+(default `20`) ini setting.
+If you upload more files in a single request, additional files will be ignored
+and the `getUploadedFiles()` method returns a truncated array. 
+You can control the maximum number of file uploads per request by explicitly
+passing the second parameter to the constructor like this:
+
+```php
+new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
+```
+
 > Note that this middleware handler simply parses everything that is already
   buffered in the request body.
   It is imperative that the request body is buffered by a prior middleware

--- a/README.md
+++ b/README.md
@@ -797,8 +797,11 @@ new RequestBodyParserMiddleware(8 * 1024 * 1024); // 8 MiB limit per file
 ```
 
 By default, this middleware respects the
+[`file_uploads`](http://php.net/manual/en/ini.core.php#ini.file-uploads)
+(default `1`) and
 [`max_file_uploads`](http://php.net/manual/en/ini.core.php#ini.max-file-uploads)
-(default `20`) ini setting.
+(default `20`) ini settings.
+These settings control if any and how many files can be uploaded in a single request.
 If you upload more files in a single request, additional files will be ignored
 and the `getUploadedFiles()` method returns a truncated array.
 Note that upload fields left blank on submission do not count towards this limit.

--- a/README.md
+++ b/README.md
@@ -784,6 +784,18 @@ $server = new StreamingServer(new MiddlewareRunner([
 
 See also [example #12](examples) for more details.
 
+By default, this middleware respects the
+[`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)
+(default `2M`) ini setting.
+Files that exceed this limit will be rejected with an `UPLOAD_ERR_INI_SIZE` error.
+You can control the maximum filesize for each individual file upload by
+explicitly passing the maximum filesize in bytes as the first parameter to the
+constructor like this:
+
+```php
+new RequestBodyParserMiddleware(8 * 1024 * 1024); // 8 MiB limit per file
+```
+
 > Note that this middleware handler simply parses everything that is already
   buffered in the request body.
   It is imperative that the request body is buffered by a prior middleware
@@ -798,10 +810,9 @@ See also [example #12](examples) for more details.
   more details.
   
 > PHP's `MAX_FILE_SIZE` hidden field is respected by this middleware.
+  Files that exceed this limit will be rejected with an `UPLOAD_ERR_FORM_SIZE` error.
 
 > This middleware respects the
-  [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)
-  (default `2M`),
   [`max_input_vars`](http://php.net/manual/en/info.configuration.php#ini.max-input-vars)
   (default `1000`) and
   [`max_input_nesting_level`](http://php.net/manual/en/info.configuration.php#ini.max-input-nesting-level)

--- a/README.md
+++ b/README.md
@@ -800,7 +800,8 @@ By default, this middleware respects the
 [`max_file_uploads`](http://php.net/manual/en/ini.core.php#ini.max-file-uploads)
 (default `20`) ini setting.
 If you upload more files in a single request, additional files will be ignored
-and the `getUploadedFiles()` method returns a truncated array. 
+and the `getUploadedFiles()` method returns a truncated array.
+Note that upload fields left blank on submission do not count towards this limit.
 You can control the maximum number of file uploads per request by explicitly
 passing the second parameter to the constructor like this:
 

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -121,8 +121,8 @@ HTML;
 
 // buffer and parse HTTP request body before running our request handler
 $server = new StreamingServer(new MiddlewareRunner(array(
-    new RequestBodyBufferMiddleware(100000), // 100 KB max, ignore body otherwise
-    new RequestBodyParserMiddleware(),
+    new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
+    new RequestBodyParserMiddleware(100 * 1024), // 100 KiB max, reject upload otherwise
     $handler
 )));
 

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -122,7 +122,7 @@ HTML;
 // buffer and parse HTTP request body before running our request handler
 $server = new StreamingServer(new MiddlewareRunner(array(
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
-    new RequestBodyParserMiddleware(100 * 1024), // 100 KiB max, reject upload otherwise
+    new RequestBodyParserMiddleware(100 * 1024, 1), // 1 file with 100 KiB max, reject upload otherwise
     $handler
 )));
 

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -42,6 +42,8 @@ $handler = function (ServerRequestInterface $request) {
                 // contents via `(string)$file->getStream()` instead.
                 // Here, we simply use an inline image to send back to client:
                 $avatar = '<img src="data:'. $file->getClientMediaType() . ';base64,' . base64_encode($file->getStream()) . '" /> (' . $file->getSize() . ' bytes)';
+            } elseif ($file->getError() === UPLOAD_ERR_INI_SIZE) {
+                $avatar = 'upload exceeds file size limit';
             } else {
                 // Real applications should probably check the error number and
                 // should print some human-friendly text

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -56,7 +56,10 @@ final class MultipartParser
 
     private $postCount = 0;
 
-    public function __construct()
+    /**
+     * @param int|null $uploadMaxFilesize
+     */
+    public function __construct($uploadMaxFilesize = null)
     {
         $var = ini_get('max_input_vars');
         if ($var !== false) {
@@ -67,7 +70,7 @@ final class MultipartParser
             $this->maxInputNestingLevel = (int)$var;
         }
 
-        $this->uploadMaxFilesize = $this->iniUploadMaxFilesize();
+        $this->uploadMaxFilesize = $uploadMaxFilesize === null ? $this->iniUploadMaxFilesize() : (int)$uploadMaxFilesize;
     }
 
     public function parse(ServerRequestInterface $request)

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -57,6 +57,8 @@ final class MultipartParser
     /**
      * ini setting "max_file_uploads"
      *
+     * Additionally, setting "file_uploads = off" effectively sets this to zero.
+     *
      * @var int
      */
     private $maxFileUploads;
@@ -81,7 +83,7 @@ final class MultipartParser
         }
 
         $this->uploadMaxFilesize = $uploadMaxFilesize === null ? $this->iniUploadMaxFilesize() : (int)$uploadMaxFilesize;
-        $this->maxFileUploads = $maxFileUploads === null ? (int)ini_get('max_file_uploads') : (int)$maxFileUploads;
+        $this->maxFileUploads = $maxFileUploads === null ? (ini_get('file_uploads') === '' ? 0 : (int)ini_get('max_file_uploads')) : (int)$maxFileUploads;
     }
 
     public function parse(ServerRequestInterface $request)

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -63,6 +63,7 @@ final class MultipartParser
 
     private $postCount = 0;
     private $filesCount = 0;
+    private $emptyCount = 0;
 
     /**
      * @param int|null $uploadMaxFilesize
@@ -97,6 +98,7 @@ final class MultipartParser
         $this->request = null;
         $this->postCount = 0;
         $this->filesCount = 0;
+        $this->emptyCount = 0;
         $this->maxFileSize = null;
 
         return $request;
@@ -176,6 +178,11 @@ final class MultipartParser
 
         // no file selected (zero size and empty filename)
         if ($size === 0 && $filename === '') {
+            // ignore excessive number of empty file uploads
+            if (++$this->emptyCount + $this->filesCount > $this->maxInputVars) {
+                return;
+            }
+
             return new UploadedFile(
                 Psr7\stream_for(''),
                 $size,

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -172,11 +172,6 @@ final class MultipartParser
 
     private function parseUploadedFile($filename, $contentType, $contents)
     {
-        // ignore excessive number of file uploads
-        if (++$this->filesCount > $this->maxFileUploads) {
-            return;
-        }
-
         $size = strlen($contents);
 
         // no file selected (zero size and empty filename)
@@ -188,6 +183,11 @@ final class MultipartParser
                 $filename,
                 $contentType
             );
+        }
+
+        // ignore excessive number of file uploads
+        if (++$this->filesCount > $this->maxFileUploads) {
+            return;
         }
 
         // file exceeds "upload_max_filesize" ini setting

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -9,9 +9,12 @@ final class RequestBodyParserMiddleware
 {
     private $multipart;
 
-    public function __construct()
+    /**
+     * @param int|null $uploadMaxFilesize
+     */
+    public function __construct($uploadMaxFilesize = null)
     {
-        $this->multipart = new MultipartParser();
+        $this->multipart = new MultipartParser($uploadMaxFilesize);
     }
 
     public function __invoke(ServerRequestInterface $request, $next)

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -11,10 +11,11 @@ final class RequestBodyParserMiddleware
 
     /**
      * @param int|null $uploadMaxFilesize
+     * @param int|null $maxFileUploads
      */
-    public function __construct($uploadMaxFilesize = null)
+    public function __construct($uploadMaxFilesize = null, $maxFileUploads = null)
     {
-        $this->multipart = new MultipartParser($uploadMaxFilesize);
+        $this->multipart = new MultipartParser($uploadMaxFilesize, $maxFileUploads);
     }
 
     public function __invoke(ServerRequestInterface $request, $next)

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -7,6 +7,13 @@ use React\Http\Io\MultipartParser;
 
 final class RequestBodyParserMiddleware
 {
+    private $multipart;
+
+    public function __construct()
+    {
+        $this->multipart = new MultipartParser();
+    }
+
     public function __invoke(ServerRequestInterface $request, $next)
     {
         $type = strtolower($request->getHeaderLine('Content-Type'));
@@ -17,7 +24,7 @@ final class RequestBodyParserMiddleware
         }
 
         if ($type === 'multipart/form-data') {
-            return $next(MultipartParser::parseRequest($request));
+            return $next($this->multipart->parse($request));
         }
 
         return $next($request);

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -26,7 +26,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data',
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -50,7 +51,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -82,7 +84,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -111,7 +114,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -142,7 +146,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -173,7 +178,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -205,7 +211,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -230,7 +237,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -255,7 +263,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -284,7 +293,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -364,7 +374,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertSame(
             array(
@@ -418,7 +429,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -443,7 +455,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -462,7 +475,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -479,7 +493,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -499,7 +514,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -519,7 +535,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -539,7 +556,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertEmpty($parsedRequest->getParsedBody());
@@ -558,7 +576,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
@@ -581,7 +600,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 
@@ -615,7 +635,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 
@@ -648,7 +669,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 
@@ -681,7 +703,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 
@@ -718,7 +741,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 
@@ -772,7 +796,8 @@ final class MultipartParserTest extends TestCase
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
         ), $data, 1.1);
 
-        $parsedRequest = MultipartParser::parseRequest($request);
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
 
         $files = $parsedRequest->getUploadedFiles();
 

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -754,6 +754,42 @@ final class MultipartParserTest extends TestCase
         $this->assertSame(UPLOAD_ERR_NO_FILE, $file->getError());
     }
 
+    public function testUploadTooManyFilesReturnsTruncatedList()
+    {
+        $boundary = "---------------------------12758086162038677464950549563";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"first\"; filename=\"first\"\r\n";
+        $data .= "Content-type: text/plain\r\n";
+        $data .= "\r\n";
+        $data .= "hello\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"second\"; filename=\"second\"\r\n";
+        $data .= "Content-type: text/plain\r\n";
+        $data .= "\r\n";
+        $data .= "world\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
+        ), $data, 1.1);
+
+        $parser = new MultipartParser(100, 1);
+        $parsedRequest = $parser->parse($request);
+
+        $files = $parsedRequest->getUploadedFiles();
+
+        $this->assertCount(1, $files);
+        $this->assertTrue(isset($files['first']));
+
+        $file = $files['first'];
+        $this->assertSame('first', $file->getClientFilename());
+        $this->assertSame('text/plain', $file->getClientMediaType());
+        $this->assertSame(5, $file->getSize());
+        $this->assertSame(UPLOAD_ERR_OK, $file->getError());
+        $this->assertSame('hello', (string)$file->getStream());
+    }
+
     public function testPostMaxFileSize()
     {
         $boundary = "---------------------------12758086162038677464950549563";


### PR DESCRIPTION
This PR ensures that the `RequestBodyParserMiddleware` respects all relevant ini settings for file uploads. In other words, this middleware will now respect the following ini settings:

```
file_uploads		On
max_file_uploads	20
upload_max_filesize	2M
```

Additionally, two parameters have been added to explicitly configure these settings like this:

```php
// allow up to 20 files with 2 MiB each
new RequestBodyParserMiddleware(2 * 1024 * 1024, 20);
```

I realize that this PR is not exactly trivial. If you want to review this, I would suggest checking out the individual commits.

Builds on top of #268
Resolves / closes #257