### PR TITLE
Add internal IniUtil helper class to convert ini size settings to bytes

### DIFF
--- a/src/Io/IniUtil.php
+++ b/src/Io/IniUtil.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace React\Http\Io;
+
+/**
+ * @internal
+ */
+final class IniUtil
+{
+    /**
+     * Convert a ini like size to a numeric size in bytes.
+     *
+     * @param string $iniSetting
+     * @return int
+     */
+    public static function iniSizeToBytes($size)
+    {
+        if (is_numeric($size)) {
+            return $size;
+        }
+
+        $suffix = strtoupper(substr($size, -1));
+        $strippedSize = substr($size, 0, -1);
+
+        if (!is_numeric($strippedSize)) {
+            throw new \InvalidArgumentException('"' . $size . '" is not a valid ini size');
+        }
+
+        if ($strippedSize <= 0) {
+            throw new \InvalidArgumentException('Expect "' . $size . '" to be higher isn\'t zero or lower');
+        }
+
+        if ($suffix === 'K') {
+            return $strippedSize * 1024;
+        }
+        if ($suffix === 'M') {
+            return $strippedSize * 1024 * 1024;
+        }
+        if ($suffix === 'G') {
+            return $strippedSize * 1024 * 1024 * 1024;
+        }
+        if ($suffix === 'T') {
+            return $strippedSize * 1024  * 1024 * 1024 * 1024;
+        }
+
+        return $size;
+    }
+}

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -82,7 +82,11 @@ final class MultipartParser
             $this->maxInputNestingLevel = (int)$var;
         }
 
-        $this->uploadMaxFilesize = $uploadMaxFilesize === null ? $this->iniUploadMaxFilesize() : (int)$uploadMaxFilesize;
+        if ($uploadMaxFilesize === null) {
+            $uploadMaxFilesize = IniUtil::iniSizeToBytes(ini_get('upload_max_filesize'));
+        }
+
+        $this->uploadMaxFilesize = (int)$uploadMaxFilesize;
         $this->maxFileUploads = $maxFileUploads === null ? (ini_get('file_uploads') === '' ? 0 : (int)ini_get('max_file_uploads')) : (int)$maxFileUploads;
     }
 
@@ -321,29 +325,5 @@ final class MultipartParser
         }
 
         return $postFields;
-    }
-
-    /**
-     * Gets upload_max_filesize from PHP's configuration expressed in bytes
-     *
-     * @return int
-     * @link http://php.net/manual/en/ini.core.php#ini.upload-max-filesize
-     * @codeCoverageIgnore
-     */
-    private function iniUploadMaxFilesize()
-    {
-        $size = ini_get('upload_max_filesize');
-        $suffix = strtoupper(substr($size, -1));
-        if ($suffix === 'K') {
-            return substr($size, 0, -1) * 1024;
-        }
-        if ($suffix === 'M') {
-            return substr($size, 0, -1) * 1024 * 1024;
-        }
-        if ($suffix === 'G') {
-            return substr($size, 0, -1) * 1024 * 1024 * 1024;
-        }
-
-        return $size;
     }
 }

--- a/src/Middleware/RequestBodyBufferMiddleware.php
+++ b/src/Middleware/RequestBodyBufferMiddleware.php
@@ -4,6 +4,7 @@ namespace React\Http\Middleware;
 
 use OverflowException;
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\IniUtil;
 use React\Promise\Stream;
 use React\Stream\ReadableStreamInterface;
 use RingCentral\Psr7\BufferStream;
@@ -21,7 +22,7 @@ final class RequestBodyBufferMiddleware
     public function __construct($sizeLimit = null)
     {
         if ($sizeLimit === null) {
-            $sizeLimit = $this->iniMaxPostSize();
+            $sizeLimit = IniUtil::iniSizeToBytes(ini_get('post_max_size'));
         }
 
         $this->sizeLimit = $sizeLimit;
@@ -65,29 +66,5 @@ final class RequestBodyBufferMiddleware
 
             throw $error;
         });
-    }
-
-    /**
-     * Gets post_max_size from PHP's configuration expressed in bytes
-     *
-     * @return int
-     * @link http://php.net/manual/en/ini.core.php#ini.post-max-size
-     * @codeCoverageIgnore
-     */
-    private function iniMaxPostSize()
-    {
-        $size = ini_get('post_max_size');
-        $suffix = strtoupper(substr($size, -1));
-        if ($suffix === 'K') {
-            return substr($size, 0, -1) * 1024;
-        }
-        if ($suffix === 'M') {
-            return substr($size, 0, -1) * 1024 * 1024;
-        }
-        if ($suffix === 'G') {
-            return substr($size, 0, -1) * 1024  * 1024 * 1024;
-        }
-
-        return $size;
     }
 }

--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use React\Http\Io\IniUtil;
+use React\Tests\Http\TestCase;
+
+class IniUtilTest extends TestCase
+{
+    public function provideIniSizes()
+    {
+        return array(
+            array(
+                '1',
+                1,
+            ),
+            array(
+                '10',
+                10,
+            ),
+            array(
+                '1024',
+                1024,
+            ),
+            array(
+                '1K',
+                1024,
+            ),
+            array(
+                '1.5M',
+                1572864,
+            ),
+            array(
+                '64M',
+                67108864,
+            ),
+            array(
+                '8G',
+                8589934592,
+            ),
+            array(
+                '1T',
+                1099511627776,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideIniSizes
+     */
+    public function testIniSizeToBytes($input, $output)
+    {
+        $this->assertEquals($output, IniUtil::iniSizeToBytes($input));
+    }
+
+    public function provideInvalidInputIniSizeToBytes()
+    {
+        return array(
+            array('-1G'),
+            array('0G'),
+            array(null),
+            array('foo'),
+            array('fooK'),
+            array('1ooL'),
+            array('1ooL'),
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidInputIniSizeToBytes
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidInputIniSizeToBytes($input)
+    {
+        IniUtil::iniSizeToBytes($input);
+    }
+}


### PR DESCRIPTION
Created Util::iniSizeToBytes() helper so we don't have to copy the same internal method everywhere. A follow up PR can take care of #275. This will also be used in #271.