### PR TITLE
Simplify using middleware request handlers

### DIFF
--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -10,7 +10,6 @@
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use React\EventLoop\Factory;
-use React\Http\MiddlewareRunner;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
@@ -121,12 +120,12 @@ HTML;
 };
 
 // buffer and parse HTTP request body before running our request handler
-$server = new StreamingServer(new MiddlewareRunner(array(
+$server = new StreamingServer(array(
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
     new RequestBodyParserMiddleware(100 * 1024, 1), // 1 file with 100 KiB max, reject upload otherwise
     $handler
-)));
+));
 
 $socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 $server->listen($socket);

--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -1,12 +1,17 @@
 <?php
 
-namespace React\Http;
+namespace React\Http\Io;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise;
 use React\Promise\PromiseInterface;
 
+/**
+ * [Internal] Middleware runner to expose an array of middleware request handlers as a single request handler callable
+ *
+ * @internal
+ */
 final class MiddlewareRunner
 {
     /**

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -27,10 +27,10 @@ use React\Stream\ReadableStreamInterface;
  * than 10 handlers will be invoked at once:
  *
  * ```php
- * $server = new StreamingServer(new MiddlewareRunner([
+ * $server = new StreamingServer(array(
  *     new LimitConcurrentRequestsMiddleware(10),
  *     $handler
- * ]));
+ * ));
  * ```
  *
  * Similarly, this middleware is often used in combination with the
@@ -38,12 +38,12 @@ use React\Stream\ReadableStreamInterface;
  * to limit the total number of requests that can be buffered at once:
  *
  * ```php
- * $server = new StreamingServer(new MiddlewareRunner([
+ * $server = new StreamingServer(array(
  *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
  *     new RequestBodyParserMiddleware(),
- *    $handler
- * ]));
+ *     $handler
+ * ));
  * ```
  *
  * More sophisticated examples include limiting the total number of requests
@@ -51,13 +51,13 @@ use React\Stream\ReadableStreamInterface;
  * processes one request after another without any concurrency:
  *
  * ```php
- * $server = new StreamingServer(new MiddlewareRunner([
+ * $server = new StreamingServer(array(
  *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
  *     new RequestBodyParserMiddleware(),
  *     new LimitConcurrentRequestsMiddleware(1), // only execute 1 handler (no concurrency)
  *     $handler
- * ]));
+ * ));
  * ```
  *
  * @see RequestBodyBufferMiddleware

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -11,6 +11,7 @@ use React\Http\Io\ChunkedEncoder;
 use React\Http\Io\CloseProtectionStream;
 use React\Http\Io\HttpBodyStream;
 use React\Http\Io\LengthLimitedStream;
+use React\Http\Io\MiddlewareRunner;
 use React\Http\Io\RequestHeaderParser;
 use React\Http\Io\ServerRequest;
 use React\Promise\CancellablePromiseInterface;

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -93,16 +93,18 @@ class StreamingServer extends EventEmitter
      * connections in order to then parse incoming data as HTTP.
      * See also [listen()](#listen) for more details.
      *
-     * @param callable $callback
+     * @param callable|callable[] $requestHandler
      * @see self::listen()
      */
-    public function __construct($callback)
+    public function __construct($requestHandler)
     {
-        if (!is_callable($callback)) {
+        if (is_array($requestHandler)) {
+            $requestHandler = new MiddlewareRunner($requestHandler);
+        } elseif (!is_callable($requestHandler)) {
             throw new \InvalidArgumentException();
         }
 
-        $this->callback = $callback;
+        $this->callback = $requestHandler;
     }
 
     /**

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace React\Tests\Http;
+namespace React\Tests\Http\Io;
 
 use Clue\React\Block;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
+use React\Http\Io\MiddlewareRunner;
 use React\Http\Io\ServerRequest;
-use React\Http\MiddlewareRunner;
 use React\Promise;
 use React\Tests\Http\Middleware\ProcessStack;
+use React\Tests\Http\TestCase;
 use RingCentral\Psr7\Response;
 
 final class MiddlewareRunnerTest extends TestCase

--- a/tests/StreamingServerTest.php
+++ b/tests/StreamingServerTest.php
@@ -2,12 +2,11 @@
 
 namespace React\Tests\Http;
 
-use React\Http\MiddlewareRunner;
-use React\Http\StreamingServer;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Response;
-use React\Stream\ThroughStream;
+use React\Http\StreamingServer;
 use React\Promise\Promise;
+use React\Stream\ThroughStream;
 
 class StreamingServerTest extends TestCase
 {
@@ -96,14 +95,14 @@ class StreamingServerTest extends TestCase
         $this->assertSame('127.0.0.1', $serverParams['REMOTE_ADDR']);
     }
 
-    public function testRequestEventWithMiddlewareRunner()
+    public function testRequestEventWithSingleRequestHandlerArray()
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(new MiddlewareRunner(array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
-        })));
+        }));
 
         $this->connection
             ->expects($this->any())

--- a/tests/benchmark-middleware-runner.php
+++ b/tests/benchmark-middleware-runner.php
@@ -1,8 +1,8 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\MiddlewareRunner;
 use React\Http\Io\ServerRequest;
-use React\Http\MiddlewareRunner;
 use React\Http\Response;
 
 const ITERATIONS = 5000;


### PR DESCRIPTION
We now support middleware request handlers by default and no longer require an explicit call to `MiddlewareRunner`. Accordingly, the `MiddlewareRunner` is now internal only.

Builds on top of #215