### PR TITLE
Internal optimization to let StreamingServer wrap Server's middleware list

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -3,7 +3,6 @@
 namespace React\Http;
 
 use React\Http\Io\IniUtil;
-use React\Http\Io\MiddlewareRunner;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
@@ -66,7 +65,7 @@ final class Server
         }
         $middleware[] = $callback;
 
-        $this->streamingServer = new StreamingServer(new MiddlewareRunner($middleware));
+        $this->streamingServer = new StreamingServer($middleware);
     }
 
     /**


### PR DESCRIPTION
With #277 in it doesn't make sense to me letting `Server` wrap the middleware in a `MiddlewareRunner` we it can delegate that task to `StreamingServer`.