### PR TITLE
Documentation to recommend Server by default instead of advanced StreamingServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ $loop = React\EventLoop\Factory::create();
 $server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Hello World!\n"
     );
 });
@@ -49,6 +51,28 @@ See also the [examples](examples).
 
 ### Server
 
+The `Server` class is responsible for handling incoming connections and then
+processing each incoming HTTP request.
+
+It buffers and parses the complete incoming HTTP request in memory. Once the
+complete request has been received, it will invoke the request handler.
+
+For each request, it executes the callback function passed to the
+constructor with the respective [request](#request) object and expects
+a respective [response](#response) object in return.
+
+```php
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(
+        200,
+        array(
+            'Content-Type' => 'text/plain'
+        ),
+        "Hello World!\n"
+    );
+});
+```
+
 For most users a server that buffers and parses a requests before handling it over as a 
 PSR-7 request is what they want. The `Server` facade takes care of that, and takes the more 
 advanced configuration out of hand. Under the hood it uses [StreamingServer](#streamingserver) 
@@ -64,8 +88,12 @@ division of half of `memory_limit` by `memory_limit` rounded up.
 
 ### StreamingServer
 
-The `StreamingServer` class is responsible for handling incoming connections and then
+The advanced `StreamingServer` class is responsible for handling incoming connections and then
 processing each incoming HTTP request.
+
+Unlike the [`Server`](#server) class, it does not buffer and parse the incoming
+HTTP request body by default. This means that the request handler will be
+invoked with a streaming request body.
 
 For each request, it executes the callback function passed to the
 constructor with the respective [request](#request) object and expects
@@ -75,7 +103,9 @@ a respective [response](#response) object in return.
 $server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Hello World!\n"
     );
 });
@@ -160,10 +190,11 @@ Check out [request](#request) for more details.
 
 ### Request
 
-An seen above, the `StreamingServer` class is responsible for handling incoming
-connections and then processing each incoming HTTP request.
+As seen above, the [`Server`](#server) and [`StreamingServer`](#streamingserver)
+classes are responsible for handling incoming connections and then processing
+each incoming HTTP request.
 
-The request object will be processed once the request headers have
+The request object will be processed once the request has
 been received by the client.
 This request object implements the
 [PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface)
@@ -172,13 +203,15 @@ which in turn extends the
 and will be passed to the callback function like this.
 
  ```php 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $body = "The method of the request is: " . $request->getMethod();
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         $body
     );
 });
@@ -206,12 +239,14 @@ The following parameters are currently available:
   Set to 'on' if the request used HTTPS, otherwise it won't be set
 
 ```php 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         $body
     );
 });
@@ -223,7 +258,7 @@ The `getQueryParams(): array` method can be used to get the query parameters
 similiar to the `$_GET` variable.
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -235,7 +270,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
 
     return new Response(
         200,
-        array('Content-Type' => 'text/html'),
+        array(
+            'Content-Type' => 'text/html'
+        ),
         $body
     );
 });
@@ -296,7 +333,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
         $request->getBody()->on('end', function () use ($resolve, &$contentLength){
             $response = new Response(
                 200,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "The length of the submitted request body is: " . $contentLength
             );
             $resolve($response);
@@ -306,7 +345,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
         $request->getBody()->on('error', function (\Exception $exception) use ($resolve, &$contentLength) {
             $response = new Response(
                 400,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "An error occured while reading at length: " . $contentLength
             );
             $resolve($response);
@@ -358,14 +399,18 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
 
         return new Response(
             411,
-            array('Content-Type' => 'text/plain'),
+            array(
+                'Content-Type' => 'text/plain'
+            ),
             $body
         );
     }
 
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Request body size: " . $size . " bytes\n"
     );
 });
@@ -404,7 +449,7 @@ The `getCookieParams(): string[]` method can be used to
 get all cookies sent with the current request.
 
 ```php 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -412,7 +457,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
 
         return new Response(
             200,
-            array('Content-Type' => 'text/plain'),
+            array(
+                'Content-Type' => 'text/plain'
+            ),
             $body
         );
     }
@@ -439,9 +486,9 @@ See also [example #5](examples) for more details.
 
 ### Response
 
-The callback function passed to the constructor of the [StreamingServer](#server)
-is responsible for processing the request and returning a response,
-which will be delivered to the client.
+The callback function passed to the constructor of the [`Server`](#server) or
+advanced [`StreamingServer`](#server) is responsible for processing the request
+and returning a response, which will be delivered to the client.
 This function MUST return an instance implementing
 [PSR-7 ResponseInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#33-psrhttpmessageresponseinterface)
 object or a 
@@ -455,10 +502,12 @@ but feel free to use any implemantation of the
 `PSR-7 ResponseInterface` you prefer.
 
 ```php 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Hello World!\n"
     );
 });
@@ -474,12 +523,14 @@ To prevent this you SHOULD use a
 This example shows how such a long-term action could look like:
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(
                 200,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "Hello world"
             );
             $resolve($response);
@@ -507,7 +558,7 @@ Note that other implementations of the `PSR-7 ResponseInterface` likely
 only support strings.
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
@@ -519,7 +570,13 @@ $server = new StreamingServer(function (ServerRequestInterface $request) use ($l
         $stream->emit('end');
     });
 
-    return new Response(200, array('Content-Type' => 'text/plain'), $stream);
+    return new Response(
+        200,
+        array(
+            'Content-Type' => 'text/plain'
+        ),
+        $stream
+    );
 });
 ```
 
@@ -550,7 +607,7 @@ If you know the length of your stream body, you MAY specify it like this instead
 
 ```php
 $stream = new ThroughStream()
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+$server = new Server(function (ServerRequestInterface $request) use ($stream) {
     return new Response(
         200,
         array(
@@ -635,8 +692,13 @@ A `Date` header will be automatically added with the system date and time if non
 You can add a custom `Date` header yourself like this:
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) {
-    return new Response(200, array('Date' => date('D, d M Y H:i:s T')));
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(
+        200,
+        array(
+            'Date' => date('D, d M Y H:i:s T')
+        )
+    );
 });
 ```
 
@@ -644,8 +706,13 @@ If you don't have a appropriate clock to rely on, you should
 unset this header with an empty string:
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) {
-    return new Response(200, array('Date' => ''));
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(
+        200,
+        array(
+            'Date' => ''
+        )
+    );
 });
 ```
 
@@ -653,8 +720,13 @@ Note that it will automatically assume a `X-Powered-By: react/alpha` header
 unless your specify a custom `X-Powered-By` header yourself:
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) {
-    return new Response(200, array('X-Powered-By' => 'PHP 3'));
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(
+        200,
+        array(
+            'X-Powered-By' => 'PHP 3'
+        )
+    );
 });
 ```
 
@@ -662,8 +734,13 @@ If you do not want to send this header at all, you can use an empty string as
 value like this:
 
 ```php
-$server = new StreamingServer(function (ServerRequestInterface $request) {
-    return new Response(200, array('X-Powered-By' => ''));
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Response(
+        200,
+        array(
+            'X-Powered-By' => ''
+        )
+    );
 });
 ```
 

--- a/examples/01-hello-world.php
+++ b/examples/01-hello-world.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(

--- a/examples/02-count-visitors.php
+++ b/examples/02-count-visitors.php
@@ -3,17 +3,19 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
 $counter = 0;
-$server = new StreamingServer(function (ServerRequestInterface $request) use (&$counter) {
+$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Welcome number " . ++$counter . "!\n"
     );
 });

--- a/examples/03-client-ip.php
+++ b/examples/03-client-ip.php
@@ -3,18 +3,20 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         $body
     );
 });

--- a/examples/04-query-parameter.php
+++ b/examples/04-query-parameter.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -21,7 +21,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
 
     return new Response(
         200,
-        array('Content-Type' => 'text/html'),
+        array(
+            'Content-Type' => 'text/html'
+        ),
         $body
     );
 });

--- a/examples/05-cookie-handling.php
+++ b/examples/05-cookie-handling.php
@@ -3,13 +3,13 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -17,7 +17,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
 
         return new Response(
             200,
-            array('Content-Type' => 'text/plain'),
+            array(
+                'Content-Type' => 'text/plain'
+            ),
             $body
         );
     }

--- a/examples/06-sleep.php
+++ b/examples/06-sleep.php
@@ -3,19 +3,21 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($request, $loop) {
         $loop->addTimer(1.5, function() use ($loop, $resolve) {
             $response = new Response(
                 200,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "Hello world"
             );
             $resolve($response);

--- a/examples/07-error-handling.php
+++ b/examples/07-error-handling.php
@@ -3,7 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 
 $count = 0;
-$server = new StreamingServer(function (ServerRequestInterface $request) use (&$count) {
+$server = new Server(function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 
@@ -21,7 +21,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) use (&$
 
         $response = new Response(
             200,
-            array('Content-Type' => 'text/plain'),
+            array(
+                'Content-Type' => 'text/plain'
+            ),
             "Hello World!\n"
         );
 

--- a/examples/08-stream-response.php
+++ b/examples/08-stream-response.php
@@ -3,14 +3,16 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer($loop,function (ServerRequestInterface $request) use ($loop) {
+// Note how this example still uses `Server` instead of `StreamingServer`.
+// The `StreamingServer` is only required for streaming *incoming* requests.
+$server = new Server($loop,function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }
@@ -28,7 +30,9 @@ $server = new StreamingServer($loop,function (ServerRequestInterface $request) u
 
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         $stream
     );
 });

--- a/examples/09-stream-request.php
+++ b/examples/09-stream-request.php
@@ -10,6 +10,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
+// Note how this example uses the advanced `StreamingServer` to allow streaming
+// the incoming HTTP request. This very simple example merely counts the size
+// of the streaming body, it does not otherwise buffer its contents in memory.
 $server = new StreamingServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) use ($request) {
         $contentLength = 0;
@@ -20,7 +23,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
         $request->getBody()->on('end', function () use ($resolve, &$contentLength){
             $response = new Response(
                 200,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "The length of the submitted request body is: " . $contentLength
             );
             $resolve($response);
@@ -30,7 +35,9 @@ $server = new StreamingServer(function (ServerRequestInterface $request) {
         $request->getBody()->on('error', function (\Exception $exception) use ($resolve, &$contentLength) {
             $response = new Response(
                 400,
-                array('Content-Type' => 'text/plain'),
+                array(
+                    'Content-Type' => 'text/plain'
+                ),
                 "An error occured while reading at length: " . $contentLength
             );
             $resolve($response);

--- a/examples/11-hello-world-https.php
+++ b/examples/11-hello-world-https.php
@@ -3,16 +3,18 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         "Hello world!\n"
     );
 });

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -114,12 +114,15 @@ HTML;
 
     return new Response(
         200,
-        array('Content-Type' => 'text/html; charset=UTF-8'),
+        array(
+            'Content-Type' => 'text/html; charset=UTF-8'
+        ),
         $html
     );
 };
 
-// buffer and parse HTTP request body before running our request handler
+// Note how this example explicitly uses the advanced `StreamingServer` to apply
+// custom request buffering limits below before running our request handler.
 $server = new StreamingServer(array(
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise

--- a/examples/21-http-proxy.php
+++ b/examples/21-http-proxy.php
@@ -3,18 +3,24 @@
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (RequestInterface $request) {
+// Note how this example uses the `Server` instead of `StreamingServer`.
+// This means that this proxy buffers the whole request before "processing" it.
+// As such, this is store-and-forward proxy. This could also use the advanced
+// `StreamingServer` to forward the incoming request as it comes in.
+$server = new Server(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,
-            array('Content-Type' => 'text/plain'),
+            array(
+                'Content-Type' => 'text/plain'
+            ),
             'This is a plain HTTP proxy'
         );
     }
@@ -32,7 +38,9 @@ $server = new StreamingServer(function (RequestInterface $request) {
     // and forward the incoming response to the original client request
     return new Response(
         200,
-        array('Content-Type' => 'text/plain'),
+        array(
+            'Content-Type' => 'text/plain'
+        ),
         Psr7\str($outgoing)
     );
 });

--- a/examples/31-upgrade-echo.php
+++ b/examples/31-upgrade-echo.php
@@ -20,16 +20,25 @@ $ telnet localhost 1080
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
+// Note how this example uses the `Server` instead of `StreamingServer`.
+// The initial incoming request does not contain a body and we upgrade to a
+// stream object below.
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
-        return new Response(426, array('Upgrade' => 'echo'), '"Upgrade: echo" required');
+        return new Response(
+            426,
+            array(
+                'Upgrade' => 'echo'
+            ),
+            '"Upgrade: echo" required'
+        );
     }
 
     // simply return a duplex ThroughStream here

--- a/examples/32-upgrade-chat.php
+++ b/examples/32-upgrade-chat.php
@@ -22,7 +22,7 @@ Hint: try this with multiple connections :)
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
 
@@ -35,9 +35,18 @@ $loop = Factory::create();
 // this means that any Upgraded data will simply be sent back to the client
 $chat = new ThroughStream();
 
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop, $chat) {
+// Note how this example uses the `Server` instead of `StreamingServer`.
+// The initial incoming request does not contain a body and we upgrade to a
+// stream object below.
+$server = new Server(function (ServerRequestInterface $request) use ($loop, $chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
-        return new Response(426, array('Upgrade' => 'chat'), '"Upgrade: chat" required');
+        return new Response(
+            426,
+            array(
+                'Upgrade' => 'chat'
+            ),
+            '"Upgrade: chat" required'
+        );
     }
 
     // user stream forwards chat data and accepts incoming data

--- a/examples/99-benchmark-download.php
+++ b/examples/99-benchmark-download.php
@@ -10,7 +10,7 @@ use Evenement\EventEmitter;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 
@@ -86,12 +86,16 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-$server = new StreamingServer(function (ServerRequestInterface $request) use ($loop) {
+// Note how this example still uses `Server` instead of `StreamingServer`.
+// The `StreamingServer` is only required for streaming *incoming* requests.
+$server = new Server(function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
                 200,
-                array('Content-Type' => 'text/html'),
+                array(
+                    'Content-Type' => 'text/html'
+                ),
                 '<html><a href="1g.bin">1g.bin</a><br/><a href="10g.bin">10g.bin</a></html>'
             );
         case '/1g.bin':
@@ -108,7 +112,10 @@ $server = new StreamingServer(function (ServerRequestInterface $request) use ($l
 
     return new Response(
         200,
-        array('Content-Type' => 'application/octet-data', 'Content-Length' => $stream->getSize()),
+        array(
+            'Content-Type' => 'application/octet-data',
+            'Content-Length' => $stream->getSize()
+        ),
         $stream
     );
 });


### PR DESCRIPTION
This PR adds some documentation to recommend `Server` by default instead of the advanced `StreamingServer`. I've tried to keep changes to a minimum to ease review.

There's still potential for a follow-up PR to eventually improve the README structure :+1: 

Builds on top of #266 and #271