### PR TITLE
Small code improvements

### DIFF
--- a/src/Io/ChunkedDecoder.php
+++ b/src/Io/ChunkedDecoder.php
@@ -79,12 +79,12 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
     public function handleEnd()
     {
         if (!$this->closed) {
-            $this->handleError(new \Exception('Unexpected end event'));
+            $this->handleError(new Exception('Unexpected end event'));
         }
     }
 
     /** @internal */
-    public function handleError(\Exception $e)
+    public function handleError(Exception $e)
     {
         $this->emit('error', array($e));
         $this->close();
@@ -102,7 +102,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                 if ($positionCrlf === false) {
                     // Header shouldn't be bigger than 1024 bytes
                     if (isset($this->buffer[static::MAX_CHUNK_HEADER_SIZE])) {
-                        $this->handleError(new \Exception('Chunk header size inclusive extension bigger than' . static::MAX_CHUNK_HEADER_SIZE. ' bytes'));
+                        $this->handleError(new Exception('Chunk header size inclusive extension bigger than' . static::MAX_CHUNK_HEADER_SIZE. ' bytes'));
                     }
                     return;
                 }
@@ -124,7 +124,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
                 $this->chunkSize = hexdec($hexValue);
                 if (dechex($this->chunkSize) !== $hexValue) {
-                    $this->handleError(new \Exception($hexValue . ' is not a valid hexadecimal number'));
+                    $this->handleError(new Exception($hexValue . ' is not a valid hexadecimal number'));
                     return;
                 }
 
@@ -159,7 +159,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
             if ($positionCrlf !== 0 && $this->chunkSize === $this->transferredSize && strlen($this->buffer) > 2) {
                 // the first 2 characters are not CLRF, send error event
-                $this->handleError(new \Exception('Chunk does not end with a CLRF'));
+                $this->handleError(new Exception('Chunk does not end with a CLRF'));
                 return;
             }
 

--- a/src/Io/CloseProtectionStream.php
+++ b/src/Io/CloseProtectionStream.php
@@ -17,7 +17,7 @@ use React\Stream\WritableStreamInterface;
  * */
 class CloseProtectionStream extends EventEmitter implements ReadableStreamInterface
 {
-    private $connection;
+    private $input;
     private $closed = false;
 
     /**

--- a/src/Io/LengthLimitedStream.php
+++ b/src/Io/LengthLimitedStream.php
@@ -19,7 +19,6 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
 {
     private $stream;
     private $closed = false;
-    private $encoder;
     private $transferredLength = 0;
     private $maxLength;
 

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -190,7 +190,7 @@ final class MultipartParser
             }
 
             return new UploadedFile(
-                Psr7\stream_for(''),
+                Psr7\stream_for(),
                 $size,
                 UPLOAD_ERR_NO_FILE,
                 $filename,
@@ -206,7 +206,7 @@ final class MultipartParser
         // file exceeds "upload_max_filesize" ini setting
         if ($size > $this->uploadMaxFilesize) {
             return new UploadedFile(
-                Psr7\stream_for(''),
+                Psr7\stream_for(),
                 $size,
                 UPLOAD_ERR_INI_SIZE,
                 $filename,
@@ -217,7 +217,7 @@ final class MultipartParser
         // file exceeds MAX_FILE_SIZE value
         if ($this->maxFileSize !== null && $size > $this->maxFileSize) {
             return new UploadedFile(
-                Psr7\stream_for(''),
+                Psr7\stream_for(),
                 $size,
                 UPLOAD_ERR_FORM_SIZE,
                 $filename,

--- a/src/Io/ServerRequest.php
+++ b/src/Io/ServerRequest.php
@@ -3,6 +3,8 @@
 namespace React\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use RingCentral\Psr7\Request;
 
 /**
@@ -37,7 +39,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      * @param string $protocolVersion HTTP protocol version.
      * @param array server-side parameters
      *
-     * @throws InvalidArgumentException for an invalid URI
+     * @throws \InvalidArgumentException for an invalid URI
      */
     public function __construct(
         $method,

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -214,7 +214,7 @@ final class StreamingServer extends EventEmitter
             $string = $request->getHeaderLine('Content-Length');
 
             $contentLength = (int)$string;
-            if ((string)$contentLength !== (string)$string) {
+            if ((string)$contentLength !== $string) {
                 // Content-Length value is not an integer or not a single integer
                 $this->emit('error', array(new \InvalidArgumentException('The value of `Content-Length` is not valid')));
                 return $this->writeError($conn, 400, $request);
@@ -355,7 +355,7 @@ final class StreamingServer extends EventEmitter
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling below
         if ($request->getMethod() === 'HEAD' || $code === 100 || ($code > 101 && $code < 200) || $code === 204 || $code === 304) {
-            $response = $response->withBody(Psr7Implementation\stream_for(''));
+            $response = $response->withBody(Psr7Implementation\stream_for());
         }
 
         // 101 (Switching Protocols) response uses Connection: upgrade header


### PR DESCRIPTION
This PR provides some small code improvement:

- removes unused private properties
- removes redundant fully-specified class name
- removes arguments that are identical to their default values
- adds missed class imports
- removes unnecessary type casting