### PR TITLE
Improve test suite to be less fragile

### DIFF
--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -80,6 +80,14 @@ final class MiddlewareRunnerTest extends TestCase
      */
     public function testProcessStack(array $middlewares, $expectedCallCount)
     {
+        // the ProcessStack middleware instances are stateful, so reset these
+        // before running the test, to not fail with --repeat=100
+        foreach ($middlewares as $middleware) {
+            if ($middleware instanceof ProcessStack) {
+                $middleware->reset();
+            }
+        }
+
         $request = new ServerRequest('GET', 'https://example.com/');
         $middlewareStack = new MiddlewareRunner($middlewares);
 

--- a/tests/Middleware/ProcessStack.php
+++ b/tests/Middleware/ProcessStack.php
@@ -25,4 +25,9 @@ final class ProcessStack
     {
         return $this->callCount;
     }
+
+    public function reset()
+    {
+        $this->callCount = 0;
+    }
 }


### PR DESCRIPTION
This simple PR improves the test suite to use less fragile assumptions for the functional tests and also resets test doubles between test runs to ensure the test suite supports running with `--repeat=100`.

Also, the old test suite did report an error when using `ext-event`, both locally and when run on Travis. Note that this project currently only tests against the "default loop", so this wasn't reported here, but actually as part of https://github.com/reactphp/react/pull/396#issuecomment-353783972. Accordingly, it's worth considering running against multiple loop implementations, but I'll try to leave this discussion separated from this PR.

The updated test suite avoids assumptions about the loop tick behavior and the number of tests runs and thus makes these tests less fragile.

Refs https://github.com/reactphp/event-loop/pull/144