### PR TITLE
Avoid promise wrapping for middleware next request handlers and add documentation for consuming response from next request handler

### DIFF
--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -4,7 +4,6 @@ namespace React\Http\Io;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use React\Promise;
 use React\Promise\PromiseInterface;
 
 /**
@@ -29,12 +28,13 @@ final class MiddlewareRunner
 
     /**
      * @param ServerRequestInterface $request
-     * @return PromiseInterface<ResponseInterface>
+     * @return ResponseInterface|PromiseInterface<ResponseInterface>
+     * @throws Exception
      */
     public function __invoke(ServerRequestInterface $request)
     {
         if (count($this->middleware) === 0) {
-            return Promise\reject(new \RuntimeException('No middleware to run'));
+            throw new \RuntimeException('No middleware to run');
         }
 
         return $this->call($request, 0);
@@ -49,14 +49,6 @@ final class MiddlewareRunner
         };
 
         $handler = $this->middleware[$position];
-        try {
-            return Promise\resolve($handler($request, $next));
-        } catch (\Exception $error) {
-            // request handler callback throws an Exception
-            return Promise\reject($error);
-        } catch (\Throwable $error) { // @codeCoverageIgnoreStart
-            // request handler callback throws a PHP7+ Error
-            return Promise\reject($error); // @codeCoverageIgnoreEnd
-        }
+        return $handler($request, $next);
     }
 }


### PR DESCRIPTION
This PR avoids wrapping the return value from the next request handler in another promise. The request handler will either return a promise or a value that can be consumed directly. When running example 99 with included benchmarking instructions, this simple change improves performance from ~2600 req/s to ~2700 req/s on my local machine. Also, running the (very synthetic) `tests/benchmark-middleware-runner.php` improved from ~2s to ~1.7s on my local machine.

There's potential for a BC break here, but given the lack of documentation for the old behavior and its surprising semantics (see #287), I do not consider this to be a BC break. Instead, this PR now adds documentation for consuming the response from the next middleware request handler function to avoid any future BC breaks.

Builds on top of #293
Supersedes / closes #287