### PR TITLE
Last middleware can invoke next

### DIFF
--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -48,6 +48,10 @@ final class MiddlewareRunner
             return $that->call($request, $position + 1);
         };
 
+        if (!isset($this->middleware[$position])) {
+            return null;
+        }
+
         $handler = $this->middleware[$position];
         return $handler($request, $next);
     }

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -454,4 +454,19 @@ final class MiddlewareRunnerTest extends TestCase
         $this->assertTrue($promise instanceof CancellablePromiseInterface);
         $promise->cancel();
     }
+
+    public function testLastMiddlewareCanInvokeNext()
+    {
+        $middleware = new MiddlewareRunner(array(
+            function (RequestInterface $request, $next) {
+                return $next($request);
+            }
+        ));
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $response = $middleware($request);
+
+        $this->assertNull($response);
+    }
 }


### PR DESCRIPTION
Allows the last middleware in MiddlewareRunner to invoke `$next()`.

Example

```php
$middleware = new MiddlewareRunner(array(
    function (RequestInterface $request, $next) {
        return $next($request);
    }
));
```
 See eg. https://travis-ci.org/jsor-labs/http/jobs/329394945 for a failing test.