### PR TITLE
Fix Server to skip SERVER_ADDR params for Unix domain sockets (UDS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ $server = new Server(function (ServerRequestInterface $request) {
 
 See also [example #3](examples).
 
+> Advanced: Note that address parameters will not be set if you're listening on
+  a Unix domain socket (UDS) path as this protocol lacks the concept of
+  host/port.
+
 #### Query parameters
 
 The `getQueryParams(): array` method can be used to get the query parameters

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -97,16 +97,23 @@ class RequestHeaderParser extends EventEmitter
             'REQUEST_TIME_FLOAT' => microtime(true)
         );
 
+        // apply REMOTE_ADDR and REMOTE_PORT if source address is known
+        // address should always be known, unless this is over Unix domain sockets (UDS)
         if ($this->remoteSocketUri !== null) {
             $remoteAddress = parse_url($this->remoteSocketUri);
             $serverParams['REMOTE_ADDR'] = $remoteAddress['host'];
             $serverParams['REMOTE_PORT'] = $remoteAddress['port'];
         }
 
+        // apply SERVER_ADDR and SERVER_PORT if server address is known
+        // address should always be known, even for Unix domain sockets (UDS)
+        // but skip UDS as it doesn't have a concept of host/port.s
         if ($this->localSocketUri !== null) {
             $localAddress = parse_url($this->localSocketUri);
-            $serverParams['SERVER_ADDR'] = $localAddress['host'];
-            $serverParams['SERVER_PORT'] = $localAddress['port'];
+            if (isset($localAddress['host'], $localAddress['port'])) {
+                $serverParams['SERVER_ADDR'] = $localAddress['host'];
+                $serverParams['SERVER_PORT'] = $localAddress['port'];
+            }
             if (isset($localAddress['scheme']) && $localAddress['scheme'] === 'https') {
                 $serverParams['HTTPS'] = 'on';
             }

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -408,6 +408,33 @@ class RequestHeaderParserTest extends TestCase
         $this->assertEquals('8001', $serverParams['REMOTE_PORT']);
     }
 
+    public function testServerParamsWillNotSetRemoteAddressForUnixDomainSockets()
+    {
+        $request = null;
+
+        $parser = new RequestHeaderParser(
+            'unix://./server.sock',
+            null
+        );
+
+        $parser->on('headers', function ($parsedRequest) use (&$request) {
+            $request = $parsedRequest;
+        });
+
+        $parser->feed("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n");
+        $serverParams = $request->getServerParams();
+
+        $this->assertArrayNotHasKey('HTTPS', $serverParams);
+        $this->assertNotEmpty($serverParams['REQUEST_TIME']);
+        $this->assertNotEmpty($serverParams['REQUEST_TIME_FLOAT']);
+
+        $this->assertArrayNotHasKey('SERVER_ADDR', $serverParams);
+        $this->assertArrayNotHasKey('SERVER_PORT', $serverParams);
+
+        $this->assertArrayNotHasKey('REMOTE_ADDR', $serverParams);
+        $this->assertArrayNotHasKey('REMOTE_PORT', $serverParams);
+    }
+
     public function testServerParamsWontBeSetOnMissingUrls()
     {
         $request = null;


### PR DESCRIPTION
Refs #234