### PR TITLE
Do not pass $next handler to final request handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,9 +850,13 @@ $server = new Server(array(
 ));
 ```
 
+> Note how the middleware request handler and the final request handler have a
+  very simple (and similar) interface. The only difference is that the final
+  request handler does not receive a `$next` handler.
+
 Similarly, you can use the result of the `$next` middleware request handler
 function to modify the outgoing response.
-Note that as per the above documentation, the `$next` method may return a
+Note that as per the above documentation, the `$next` function may return a
 `ResponseInterface` directly or one wrapped in a promise for deferred
 resolution.
 In order to simplify handling both paths, you can simply wrap this in a
@@ -1002,7 +1006,7 @@ Usage:
 $server = new StreamingServer(array(
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
-    function (ServerRequestInterface $request, callable $next) {
+    function (ServerRequestInterface $request) {
         // The body from $request->getBody() is now fully available without the need to stream it 
         return new Response(200);
     },

--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -29,7 +29,7 @@ final class MiddlewareRunner
     /**
      * @param ServerRequestInterface $request
      * @return ResponseInterface|PromiseInterface<ResponseInterface>
-     * @throws Exception
+     * @throws \Exception
      */
     public function __invoke(ServerRequestInterface $request)
     {
@@ -43,11 +43,18 @@ final class MiddlewareRunner
     /** @internal */
     public function call(ServerRequestInterface $request, $position)
     {
+        // final request handler will be invoked without a next handler
+        if (!isset($this->middleware[$position + 1])) {
+            $handler = $this->middleware[$position];
+            return $handler($request);
+        }
+
         $that = $this;
         $next = function (ServerRequestInterface $request) use ($that, $position) {
             return $that->call($request, $position + 1);
         };
 
+        // invoke middleware request handler with next handler
         $handler = $this->middleware[$position];
         return $handler($request, $next);
     }


### PR DESCRIPTION
The last handler in a "handler array" is in fact a "final handler" and by definition not a "middleware handler". As such, all but the last entry should receive a `$next` handler. This is in line with how a "normal request handler" also doesn't receive a `$next` handler.

Builds on top of the work done by @jsor in #300.
Supersedes / closes #300