### PR TITLE
Reject requests that contain both Content-Length and Transfer-Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,14 +411,14 @@ message boundaries.
 This value may be `0` if the request message does not contain a request body
 (such as a simple `GET` request).
 Note that this value may be `null` if the request body size is unknown in
-advance because the request message uses chunked transfer encoding.
+advance because the request message uses `Transfer-Encoding: chunked`.
 
 ```php 
 $server = new StreamingServer(function (ServerRequestInterface $request) {
     $size = $request->getBody()->getSize();
     if ($size === null) {
         $body = 'The request does not contain an explicit length.';
-        $body .= 'This server does not accept chunked transfer encoding.';
+        $body .= 'This example does not accept chunked transfer encoding.';
 
         return new Response(
             411,


### PR DESCRIPTION
A request message that contains both a `Content-Length` and `Transfer-Encoding` header should not happen in practice. As per https://tools.ietf.org/html/rfc7230#section-3.3.3 this ought to be handled as an error.

> If a message is received with both a Transfer-Encoding and a
 Content-Length header field, the Transfer-Encoding overrides the
 Content-Length.  Such a message might indicate an attempt to
 perform request smuggling (Section 9.5) or response splitting
 (Section 9.4) and ought to be handled as an error."

Refs #137
Build on top of #316