### PR TITLE
Improve performance by prefixing all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/Io/ChunkedDecoder.php
+++ b/src/Io/ChunkedDecoder.php
@@ -97,7 +97,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
         while ($this->buffer !== '') {
             if (!$this->headerCompleted) {
-                $positionCrlf = strpos($this->buffer, static::CRLF);
+                $positionCrlf = \strpos($this->buffer, static::CRLF);
 
                 if ($positionCrlf === false) {
                     // Header shouldn't be bigger than 1024 bytes
@@ -107,43 +107,43 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                     return;
                 }
 
-                $header = strtolower((string)substr($this->buffer, 0, $positionCrlf));
+                $header = \strtolower((string)\substr($this->buffer, 0, $positionCrlf));
                 $hexValue = $header;
 
-                if (strpos($header, ';') !== false) {
-                    $array = explode(';', $header);
+                if (\strpos($header, ';') !== false) {
+                    $array = \explode(';', $header);
                     $hexValue = $array[0];
                 }
 
                 if ($hexValue !== '') {
-                    $hexValue = ltrim($hexValue, "0");
+                    $hexValue = \ltrim($hexValue, "0");
                     if ($hexValue === '') {
                         $hexValue = "0";
                     }
                 }
 
-                $this->chunkSize = hexdec($hexValue);
-                if (dechex($this->chunkSize) !== $hexValue) {
+                $this->chunkSize = \hexdec($hexValue);
+                if (\dechex($this->chunkSize) !== $hexValue) {
                     $this->handleError(new Exception($hexValue . ' is not a valid hexadecimal number'));
                     return;
                 }
 
-                $this->buffer = (string)substr($this->buffer, $positionCrlf + 2);
+                $this->buffer = (string)\substr($this->buffer, $positionCrlf + 2);
                 $this->headerCompleted = true;
                 if ($this->buffer === '') {
                     return;
                 }
             }
 
-            $chunk = (string)substr($this->buffer, 0, $this->chunkSize - $this->transferredSize);
+            $chunk = (string)\substr($this->buffer, 0, $this->chunkSize - $this->transferredSize);
 
             if ($chunk !== '') {
-                $this->transferredSize += strlen($chunk);
+                $this->transferredSize += \strlen($chunk);
                 $this->emit('data', array($chunk));
-                $this->buffer = (string)substr($this->buffer, strlen($chunk));
+                $this->buffer = (string)\substr($this->buffer, \strlen($chunk));
             }
 
-            $positionCrlf = strpos($this->buffer, static::CRLF);
+            $positionCrlf = \strpos($this->buffer, static::CRLF);
 
             if ($positionCrlf === 0) {
                 if ($this->chunkSize === 0) {
@@ -154,16 +154,16 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                 $this->chunkSize = 0;
                 $this->headerCompleted = false;
                 $this->transferredSize = 0;
-                $this->buffer = (string)substr($this->buffer, 2);
+                $this->buffer = (string)\substr($this->buffer, 2);
             }
 
-            if ($positionCrlf !== 0 && $this->chunkSize === $this->transferredSize && strlen($this->buffer) > 2) {
+            if ($positionCrlf !== 0 && $this->chunkSize === $this->transferredSize && \strlen($this->buffer) > 2) {
                 // the first 2 characters are not CLRF, send error event
                 $this->handleError(new Exception('Chunk does not end with a CLRF'));
                 return;
             }
 
-            if ($positionCrlf !== 0 && strlen($this->buffer) < 2) {
+            if ($positionCrlf !== 0 && \strlen($this->buffer) < 2) {
                 // No CLRF found, wait for additional data which could be a CLRF
                 return;
             }

--- a/src/Io/ChunkedEncoder.php
+++ b/src/Io/ChunkedEncoder.php
@@ -101,7 +101,7 @@ class ChunkedEncoder extends EventEmitter implements ReadableStreamInterface
      */
     private function createChunk($data)
     {
-        $byteSize = dechex(strlen($data));
+        $byteSize = \dechex(\strlen($data));
         $chunkBeginning = $byteSize . "\r\n";
 
         return $chunkBeginning . $data . "\r\n";

--- a/src/Io/IniUtil.php
+++ b/src/Io/IniUtil.php
@@ -15,14 +15,14 @@ final class IniUtil
      */
     public static function iniSizeToBytes($size)
     {
-        if (is_numeric($size)) {
+        if (\is_numeric($size)) {
             return (int)$size;
         }
 
-        $suffix = strtoupper(substr($size, -1));
-        $strippedSize = substr($size, 0, -1);
+        $suffix = \strtoupper(\substr($size, -1));
+        $strippedSize = \substr($size, 0, -1);
 
-        if (!is_numeric($strippedSize)) {
+        if (!\is_numeric($strippedSize)) {
             throw new \InvalidArgumentException("$size is not a valid ini size");
         }
 

--- a/src/Io/LengthLimitedStream.php
+++ b/src/Io/LengthLimitedStream.php
@@ -72,13 +72,13 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
     /** @internal */
     public function handleData($data)
     {
-        if (($this->transferredLength + strlen($data)) > $this->maxLength) {
+        if (($this->transferredLength + \strlen($data)) > $this->maxLength) {
             // Only emit data until the value of 'Content-Length' is reached, the rest will be ignored
-            $data = (string)substr($data, 0, $this->maxLength - $this->transferredLength);
+            $data = (string)\substr($data, 0, $this->maxLength - $this->transferredLength);
         }
 
         if ($data !== '') {
-            $this->transferredLength += strlen($data);
+            $this->transferredLength += \strlen($data);
             $this->emit('data', array($data));
         }
 

--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -23,7 +23,7 @@ final class MiddlewareRunner
      */
     public function __construct(array $middleware)
     {
-        $this->middleware = array_values($middleware);
+        $this->middleware = \array_values($middleware);
     }
 
     /**

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -73,27 +73,27 @@ final class MultipartParser
      */
     public function __construct($uploadMaxFilesize = null, $maxFileUploads = null)
     {
-        $var = ini_get('max_input_vars');
+        $var = \ini_get('max_input_vars');
         if ($var !== false) {
             $this->maxInputVars = (int)$var;
         }
-        $var = ini_get('max_input_nesting_level');
+        $var = \ini_get('max_input_nesting_level');
         if ($var !== false) {
             $this->maxInputNestingLevel = (int)$var;
         }
 
         if ($uploadMaxFilesize === null) {
-            $uploadMaxFilesize = ini_get('upload_max_filesize');
+            $uploadMaxFilesize = \ini_get('upload_max_filesize');
         }
 
         $this->uploadMaxFilesize = IniUtil::iniSizeToBytes($uploadMaxFilesize);
-        $this->maxFileUploads = $maxFileUploads === null ? (ini_get('file_uploads') === '' ? 0 : (int)ini_get('max_file_uploads')) : (int)$maxFileUploads;
+        $this->maxFileUploads = $maxFileUploads === null ? (\ini_get('file_uploads') === '' ? 0 : (int)\ini_get('max_file_uploads')) : (int)$maxFileUploads;
     }
 
     public function parse(ServerRequestInterface $request)
     {
         $contentType = $request->getHeaderLine('content-type');
-        if(!preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
+        if(!\preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
             return $request;
         }
 
@@ -112,35 +112,35 @@ final class MultipartParser
 
     private function parseBody($boundary, $buffer)
     {
-        $len = strlen($boundary);
+        $len = \strlen($boundary);
 
         // ignore everything before initial boundary (SHOULD be empty)
-        $start = strpos($buffer, $boundary . "\r\n");
+        $start = \strpos($buffer, $boundary . "\r\n");
 
         while ($start !== false) {
             // search following boundary (preceded by newline)
             // ignore last if not followed by boundary (SHOULD end with "--")
             $start += $len + 2;
-            $end = strpos($buffer, "\r\n" . $boundary, $start);
+            $end = \strpos($buffer, "\r\n" . $boundary, $start);
             if ($end === false) {
                 break;
             }
 
             // parse one part and continue searching for next
-            $this->parsePart(substr($buffer, $start, $end - $start));
+            $this->parsePart(\substr($buffer, $start, $end - $start));
             $start = $end;
         }
     }
 
     private function parsePart($chunk)
     {
-        $pos = strpos($chunk, "\r\n\r\n");
+        $pos = \strpos($chunk, "\r\n\r\n");
         if ($pos === false) {
             return;
         }
 
         $headers = $this->parseHeaders((string)substr($chunk, 0, $pos));
-        $body = (string)substr($chunk, $pos + 4);
+        $body = (string)\substr($chunk, $pos + 4);
 
         if (!isset($headers['content-disposition'])) {
             return;
@@ -180,7 +180,7 @@ final class MultipartParser
 
     private function parseUploadedFile($filename, $contentType, $contents)
     {
-        $size = strlen($contents);
+        $size = \strlen($contents);
 
         // no file selected (zero size and empty filename)
         if ($size === 0 && $filename === '') {
@@ -192,7 +192,7 @@ final class MultipartParser
             return new UploadedFile(
                 Psr7\stream_for(),
                 $size,
-                UPLOAD_ERR_NO_FILE,
+                \UPLOAD_ERR_NO_FILE,
                 $filename,
                 $contentType
             );
@@ -208,7 +208,7 @@ final class MultipartParser
             return new UploadedFile(
                 Psr7\stream_for(),
                 $size,
-                UPLOAD_ERR_INI_SIZE,
+                \UPLOAD_ERR_INI_SIZE,
                 $filename,
                 $contentType
             );
@@ -219,7 +219,7 @@ final class MultipartParser
             return new UploadedFile(
                 Psr7\stream_for(),
                 $size,
-                UPLOAD_ERR_FORM_SIZE,
+                \UPLOAD_ERR_FORM_SIZE,
                 $filename,
                 $contentType
             );
@@ -228,7 +228,7 @@ final class MultipartParser
         return new UploadedFile(
             Psr7\stream_for($contents),
             $size,
-            UPLOAD_ERR_OK,
+            \UPLOAD_ERR_OK,
             $filename,
             $contentType
         );
@@ -247,7 +247,7 @@ final class MultipartParser
             $value
         ));
 
-        if (strtoupper($name) === 'MAX_FILE_SIZE') {
+        if (\strtoupper($name) === 'MAX_FILE_SIZE') {
             $this->maxFileSize = (int)$value;
 
             if ($this->maxFileSize === 0) {
@@ -260,15 +260,15 @@ final class MultipartParser
     {
         $headers = array();
 
-        foreach (explode("\r\n", trim($header)) as $line) {
-            $parts = explode(':', $line, 2);
+        foreach (\explode("\r\n", \trim($header)) as $line) {
+            $parts = \explode(':', $line, 2);
             if (!isset($parts[1])) {
                 continue;
             }
 
-            $key = strtolower(trim($parts[0]));
-            $values = explode(';', $parts[1]);
-            $values = array_map('trim', $values);
+            $key = \strtolower(trim($parts[0]));
+            $values = \explode(';', $parts[1]);
+            $values = \array_map('trim', $values);
             $headers[$key] = $values;
         }
 
@@ -278,7 +278,7 @@ final class MultipartParser
     private function getParameterFromHeader(array $header, $parameter)
     {
         foreach ($header as $part) {
-            if (preg_match('/' . $parameter . '="?(.*)"$/', $part, $matches)) {
+            if (\preg_match('/' . $parameter . '="?(.*)"$/', $part, $matches)) {
                 return $matches[1];
             }
         }
@@ -288,8 +288,8 @@ final class MultipartParser
 
     private function extractPost($postFields, $key, $value)
     {
-        $chunks = explode('[', $key);
-        if (count($chunks) == 1) {
+        $chunks = \explode('[', $key);
+        if (\count($chunks) == 1) {
             $postFields[$key] = $value;
             return $postFields;
         }
@@ -299,23 +299,23 @@ final class MultipartParser
             return $postFields;
         }
 
-        $chunkKey = rtrim($chunks[0], ']');
+        $chunkKey = \rtrim($chunks[0], ']');
         $parent = &$postFields;
         for ($i = 1; isset($chunks[$i]); $i++) {
             $previousChunkKey = $chunkKey;
 
             if ($previousChunkKey === '') {
                 $parent[] = array();
-                end($parent);
-                $parent = &$parent[key($parent)];
+                \end($parent);
+                $parent = &$parent[\key($parent)];
             } else {
-                if (!isset($parent[$previousChunkKey]) || !is_array($parent[$previousChunkKey])) {
+                if (!isset($parent[$previousChunkKey]) || !\is_array($parent[$previousChunkKey])) {
                     $parent[$previousChunkKey] = array();
                 }
                 $parent = &$parent[$previousChunkKey];
             }
 
-            $chunkKey = rtrim($chunks[$i], ']');
+            $chunkKey = \rtrim($chunks[$i], ']');
         }
 
         if ($chunkKey === '') {

--- a/src/Io/ServerRequest.php
+++ b/src/Io/ServerRequest.php
@@ -113,7 +113,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     public function getAttribute($name, $default = null)
     {
-        if (!array_key_exists($name, $this->attributes)) {
+        if (!\array_key_exists($name, $this->attributes)) {
             return $default;
         }
         return $this->attributes[$name];
@@ -143,20 +143,20 @@ class ServerRequest extends Request implements ServerRequestInterface
         // PSR-7 `getHeaderLine('Cookies')` will return multiple
         // cookie header comma-seperated. Multiple cookie headers
         // are not allowed according to https://tools.ietf.org/html/rfc6265#section-5.4
-        if (strpos($cookie, ',') !== false) {
+        if (\strpos($cookie, ',') !== false) {
             return false;
         }
 
-        $cookieArray = explode(';', $cookie);
+        $cookieArray = \explode(';', $cookie);
         $result = array();
 
         foreach ($cookieArray as $pair) {
-            $pair = trim($pair);
-            $nameValuePair = explode('=', $pair, 2);
+            $pair = \trim($pair);
+            $nameValuePair = \explode('=', $pair, 2);
 
-            if (count($nameValuePair) === 2) {
-                $key = urldecode($nameValuePair[0]);
-                $value = urldecode($nameValuePair[1]);
+            if (\count($nameValuePair) === 2) {
+                $key = \urldecode($nameValuePair[0]);
+                $value = \urldecode($nameValuePair[1]);
                 $result[$key] = $value;
             }
         }

--- a/src/Io/UploadedFile.php
+++ b/src/Io/UploadedFile.php
@@ -57,15 +57,15 @@ final class UploadedFile implements UploadedFileInterface
         $this->stream = $stream;
         $this->size = $size;
 
-        if (!is_int($error) || !in_array($error, array(
-            UPLOAD_ERR_OK,
-            UPLOAD_ERR_INI_SIZE,
-            UPLOAD_ERR_FORM_SIZE,
-            UPLOAD_ERR_PARTIAL,
-            UPLOAD_ERR_NO_FILE,
-            UPLOAD_ERR_NO_TMP_DIR,
-            UPLOAD_ERR_CANT_WRITE,
-            UPLOAD_ERR_EXTENSION,
+        if (!\is_int($error) || !\in_array($error, array(
+            \UPLOAD_ERR_OK,
+            \UPLOAD_ERR_INI_SIZE,
+            \UPLOAD_ERR_FORM_SIZE,
+            \UPLOAD_ERR_PARTIAL,
+            \UPLOAD_ERR_NO_FILE,
+            \UPLOAD_ERR_NO_TMP_DIR,
+            \UPLOAD_ERR_CANT_WRITE,
+            \UPLOAD_ERR_EXTENSION,
         ))) {
             throw new InvalidArgumentException(
                 'Invalid error code, must be an UPLOAD_ERR_* constant'
@@ -81,7 +81,7 @@ final class UploadedFile implements UploadedFileInterface
      */
     public function getStream()
     {
-        if ($this->error !== UPLOAD_ERR_OK) {
+        if ($this->error !== \UPLOAD_ERR_OK) {
             throw new RuntimeException('Cannot retrieve stream due to upload error');
         }
 

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -129,8 +129,8 @@ final class LimitConcurrentRequestsMiddleware
         // get next queue position
         $queue =& $this->queue;
         $queue[] = null;
-        end($queue);
-        $id = key($queue);
+        \end($queue);
+        $id = \key($queue);
 
         $deferred = new Deferred(function ($_, $reject) use (&$queue, $id) {
             // queued promise cancelled before its next handler is invoked
@@ -200,7 +200,7 @@ final class LimitConcurrentRequestsMiddleware
             return;
         }
 
-        $first = reset($this->queue);
+        $first = \reset($this->queue);
         unset($this->queue[key($this->queue)]);
 
         $first->resolve();

--- a/src/Middleware/RequestBodyBufferMiddleware.php
+++ b/src/Middleware/RequestBodyBufferMiddleware.php
@@ -23,7 +23,7 @@ final class RequestBodyBufferMiddleware
     public function __construct($sizeLimit = null)
     {
         if ($sizeLimit === null) {
-            $sizeLimit = ini_get('post_max_size');
+            $sizeLimit = \ini_get('post_max_size');
         }
 
         $this->sizeLimit = IniUtil::iniSizeToBytes($sizeLimit);
@@ -51,7 +51,7 @@ final class RequestBodyBufferMiddleware
         }
 
         return Stream\buffer($body, $sizeLimit)->then(function ($buffer) use ($request, $stack) {
-            $stream = new BufferStream(strlen($buffer));
+            $stream = new BufferStream(\strlen($buffer));
             $stream->write($buffer);
             $request = $request->withBody($stream);
 

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -20,8 +20,8 @@ final class RequestBodyParserMiddleware
 
     public function __invoke(ServerRequestInterface $request, $next)
     {
-        $type = strtolower($request->getHeaderLine('Content-Type'));
-        list ($type) = explode(';', $type);
+        $type = \strtolower($request->getHeaderLine('Content-Type'));
+        list ($type) = \explode(';', $type);
 
         if ($type === 'application/x-www-form-urlencoded') {
             return $next($this->parseFormUrlencoded($request));
@@ -39,7 +39,7 @@ final class RequestBodyParserMiddleware
         // parse string into array structure
         // ignore warnings due to excessive data structures (max_input_vars and max_input_nesting_level)
         $ret = array();
-        @parse_str((string)$request->getBody(), $ret);
+        @\parse_str((string)$request->getBody(), $ret);
 
         return $request->withParsedBody($ret);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -50,7 +50,7 @@ final class Server extends EventEmitter
      */
     public function __construct($requestHandler)
     {
-        if (!is_callable($requestHandler) && !is_array($requestHandler)) {
+        if (!\is_callable($requestHandler) && !\is_array($requestHandler)) {
             throw new \InvalidArgumentException('Invalid request handler given');
         }
 
@@ -62,15 +62,15 @@ final class Server extends EventEmitter
         // @link http://php.net/manual/en/ini.core.php#ini.enable-post-data-reading
         // @link http://php.net/manual/en/function.ini-get.php#refsect1-function.ini-get-notes
         // @link https://3v4l.org/qJtsa
-        $enablePostDataReading = ini_get('enable_post_data_reading');
+        $enablePostDataReading = \ini_get('enable_post_data_reading');
         if ($enablePostDataReading !== '') {
             $middleware[] = new RequestBodyParserMiddleware();
         }
 
-        if (is_callable($requestHandler)) {
+        if (\is_callable($requestHandler)) {
             $middleware[] = $requestHandler;
         } else {
-            $middleware = array_merge($middleware, $requestHandler);
+            $middleware = \array_merge($middleware, $requestHandler);
         }
 
         $this->streamingServer = new StreamingServer($middleware);
@@ -95,12 +95,12 @@ final class Server extends EventEmitter
      */
     private function getConcurrentRequestsLimit()
     {
-        if (ini_get('memory_limit') == -1) {
+        if (\ini_get('memory_limit') == -1) {
             return self::MAXIMUM_CONCURRENT_REQUESTS;
         }
 
-        $availableMemory = IniUtil::iniSizeToBytes(ini_get('memory_limit')) / 4;
-        $concurrentRequests = ceil($availableMemory / IniUtil::iniSizeToBytes(ini_get('post_max_size')));
+        $availableMemory = IniUtil::iniSizeToBytes(\ini_get('memory_limit')) / 4;
+        $concurrentRequests = \ceil($availableMemory / IniUtil::iniSizeToBytes(\ini_get('post_max_size')));
 
         if ($concurrentRequests >= self::MAXIMUM_CONCURRENT_REQUESTS) {
             return self::MAXIMUM_CONCURRENT_REQUESTS;

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -98,9 +98,9 @@ final class StreamingServer extends EventEmitter
      */
     public function __construct($requestHandler)
     {
-        if (!is_callable($requestHandler) && !is_array($requestHandler)) {
+        if (!\is_callable($requestHandler) && !\is_array($requestHandler)) {
             throw new \InvalidArgumentException('Invalid request handler given');
-        } elseif (!is_callable($requestHandler)) {
+        } elseif (!\is_callable($requestHandler)) {
             $requestHandler = new MiddlewareRunner($requestHandler);
         }
 
@@ -160,7 +160,7 @@ final class StreamingServer extends EventEmitter
         $uriLocal = $conn->getLocalAddress();
         if ($uriLocal !== null) {
             // local URI known, so translate transport scheme to application scheme
-            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
+            $uriLocal = \strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
         }
 
         $uriRemote = $conn->getRemoteAddress();
@@ -200,7 +200,7 @@ final class StreamingServer extends EventEmitter
         $contentLength = 0;
         $stream = new CloseProtectionStream($conn);
         if ($request->hasHeader('Transfer-Encoding')) {
-            if (strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
+            if (\strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
                 $this->emit('error', array(new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding')));
                 return $this->writeError($conn, 501, $request);
             }
@@ -229,7 +229,7 @@ final class StreamingServer extends EventEmitter
 
         $request = $request->withBody(new HttpBodyStream($stream, $contentLength));
 
-        if ($request->getProtocolVersion() !== '1.0' && '100-continue' === strtolower($request->getHeaderLine('Expect'))) {
+        if ($request->getProtocolVersion() !== '1.0' && '100-continue' === \strtolower($request->getHeaderLine('Expect'))) {
             $conn->write("HTTP/1.1 100 Continue\r\n\r\n");
         }
 
@@ -273,7 +273,7 @@ final class StreamingServer extends EventEmitter
             function ($response) use ($that, $conn, $request) {
                 if (!$response instanceof ResponseInterface) {
                     $message = 'The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but resolved with "%s" instead.';
-                    $message = sprintf($message, is_object($response) ? get_class($response) : gettype($response));
+                    $message = \sprintf($message, \is_object($response) ? \get_class($response) : \gettype($response));
                     $exception = new \RuntimeException($message);
 
                     $that->emit('error', array($exception));
@@ -283,7 +283,7 @@ final class StreamingServer extends EventEmitter
             },
             function ($error) use ($that, $conn, $request) {
                 $message = 'The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but rejected with "%s" instead.';
-                $message = sprintf($message, is_object($error) ? get_class($error) : gettype($error));
+                $message = \sprintf($message, \is_object($error) ? \get_class($error) : \gettype($error));
 
                 $previous = null;
 


### PR DESCRIPTION
Requests/second went up by about 100 (1666req/s up from 1562req/s) when testing this change with wrk on a box.