### PR TITLE
Add verify_peer SSL context

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ $server = new StreamingServer($handler);
 $socket = new React\Socket\Server(8080, $loop);
 $socket = new React\Socket\SecureServer($socket, $loop, array(
     'local_cert' => __DIR__ . '/localhost.pem'
+    'verify_peer' => false,         // Used to authenticate the identity of the remote peer (client)
+    'verify_peer_name' => false     // Used to authenticate the identity of the remote peer (client)
 ));
 
 $server->listen($socket);

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $server = new StreamingServer($handler);
 
 $socket = new React\Socket\Server(8080, $loop);
 $socket = new React\Socket\SecureServer($socket, $loop, array(
-    'local_cert' => __DIR__ . '/localhost.pem'
+    'local_cert' => __DIR__ . '/localhost.pem',
     'verify_peer' => false,         // Used to authenticate the identity of the remote peer (client)
     'verify_peer_name' => false     // Used to authenticate the identity of the remote peer (client)
 ));

--- a/examples/11-hello-world-https.php
+++ b/examples/11-hello-world-https.php
@@ -21,7 +21,9 @@ $server = new Server(function (ServerRequestInterface $request) {
 
 $socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 $socket = new \React\Socket\SecureServer($socket, $loop, array(
-    'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
+    'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem',
+    'verify_peer' => false,         // Used to authenticate the identity of the remote peer (client)
+    'verify_peer_name' => false     // Used to authenticate the identity of the remote peer (client)
 ));
 $server->listen($socket);
 

--- a/src/StreamingServer.php
+++ b/src/StreamingServer.php
@@ -139,7 +139,9 @@ final class StreamingServer extends EventEmitter
      *
      * $socket = new React\Socket\Server(8080, $loop);
      * $socket = new React\Socket\SecureServer($socket, $loop, array(
-     *     'local_cert' => __DIR__ . '/localhost.pem'
+     *     'local_cert' => __DIR__ . '/localhost.pem',
+     *     'verify_peer' => false,         // Used to authenticate the identity of the remote peer (client)
+     *     'verify_peer_name' => false     // Used to authenticate the identity of the remote peer (client)
      * ));
      *
      * $server->listen($socket);


### PR DESCRIPTION
For standard HTTPS server, it is necessary to disable peer verification, which is only used when client are authenticated by client certificates. HTTPS is used only server certificates.