### PR TITLE
Minor internal refactoring to apply server params during request ctor

### DIFF
--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -130,19 +130,6 @@ class RequestHeaderParser extends EventEmitter
         );
         $request = $request->withRequestTarget($target);
 
-        // Add query params
-        $queryString = $request->getUri()->getQuery();
-        if ($queryString !== '') {
-            $queryParams = array();
-            \parse_str($queryString, $queryParams);
-            $request = $request->withQueryParams($queryParams);
-        }
-
-        $cookies = ServerRequest::parseCookie($request->getHeaderLine('Cookie'));
-        if ($cookies !== false) {
-            $request = $request->withCookieParams($cookies);
-        }
-
         // re-apply actual request target from above
         if ($originalTarget !== null) {
             $request = $request->withUri(

--- a/src/Io/ServerRequest.php
+++ b/src/Io/ServerRequest.php
@@ -51,6 +51,13 @@ class ServerRequest extends Request implements ServerRequestInterface
     ) {
         $this->serverParams = $serverParams;
         parent::__construct($method, $uri, $headers, $body, $protocolVersion);
+
+        $query = $this->getUri()->getQuery();
+        if ($query !== '') {
+            \parse_str($query, $this->queryParams);
+        }
+
+        $this->cookies = $this->parseCookie($this->getHeaderLine('Cookie'));
     }
 
     public function getServerParams()
@@ -134,17 +141,16 @@ class ServerRequest extends Request implements ServerRequestInterface
     }
 
     /**
-     * @internal
      * @param string $cookie
-     * @return boolean|mixed[]
+     * @return array
      */
-    public static function parseCookie($cookie)
+    private function parseCookie($cookie)
     {
-        // PSR-7 `getHeaderLine('Cookies')` will return multiple
+        // PSR-7 `getHeaderLine('Cookie')` will return multiple
         // cookie header comma-seperated. Multiple cookie headers
         // are not allowed according to https://tools.ietf.org/html/rfc6265#section-5.4
-        if (\strpos($cookie, ',') !== false) {
-            return false;
+        if ($cookie === '' || \strpos($cookie, ',') !== false) {
+            return array();
         }
 
         $cookieArray = \explode(';', $cookie);


### PR DESCRIPTION
This changeset is in preparation for upcoming refactorings to move
unrelated logic out of the parser class to prepare for persistent HTTP
connections in follow-up PR. This changeset does not affect the public
API and happens to improves performance slightly from around 8800 req/s
to 9000 req/s on my machine (best of 5).

Refs #39 