### PR TITLE
Change parser to use single regular expression to match all headers

### DIFF
--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -5,7 +5,6 @@ namespace React\Http\Io;
 use Evenement\EventEmitter;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Socket\ConnectionInterface;
-use RingCentral\Psr7 as g7;
 use Exception;
 
 /**
@@ -56,7 +55,7 @@ class RequestHeaderParser extends EventEmitter
 
             try {
                 $request = $that->parseRequest(
-                    (string)\substr($buffer, 0, $endOfHeader),
+                    (string)\substr($buffer, 0, $endOfHeader + 2),
                     $conn->getRemoteAddress(),
                     $conn->getLocalAddress()
                 );
@@ -124,32 +123,36 @@ class RequestHeaderParser extends EventEmitter
     {
         // additional, stricter safe-guard for request line
         // because request parser doesn't properly cope with invalid ones
-        if (!\preg_match('#^[^ ]+ [^ ]+ HTTP/\d\.\d#m', $headers)) {
+        $start = array();
+        if (!\preg_match('#^(?<method>[^ ]+) (?<target>[^ ]+) HTTP/(?<version>\d\.\d)#m', $headers, $start)) {
             throw new \InvalidArgumentException('Unable to parse invalid request-line');
         }
 
-        // parser does not support asterisk-form and authority-form
-        // remember original target and temporarily replace and re-apply below
-        $originalTarget = null;
-        if (\strncmp($headers, 'OPTIONS * ', 10) === 0) {
-            $originalTarget = '*';
-            $headers = 'OPTIONS / ' . \substr($headers, 10);
-        } elseif (\strncmp($headers, 'CONNECT ', 8) === 0) {
-            $parts = \explode(' ', $headers, 3);
-            $uri = \parse_url('tcp://' . $parts[1]);
-
-            // check this is a valid authority-form request-target (host:port)
-            if (isset($uri['scheme'], $uri['host'], $uri['port']) && count($uri) === 3) {
-                $originalTarget = $parts[1];
-                $parts[1] = 'http://' . $parts[1] . '/';
-                $headers = implode(' ', $parts);
-            } else {
-                throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target');
-            }
+        // only support HTTP/1.1 and HTTP/1.0 requests
+        if ($start['version'] !== '1.1' && $start['version'] !== '1.0') {
+            throw new \InvalidArgumentException('Received request with invalid protocol version', 505);
         }
 
-        // parse request headers into obj implementing RequestInterface
-        $request = g7\parse_request($headers);
+        // match all request header fields into array, thanks to @kelunik for checking the HTTP specs and coming up with this regex
+        $matches = array();
+        $n = \preg_match_all('/^([^()<>@,;:\\\"\/\[\]?={}\x01-\x20\x7F]++):[\x20\x09]*+((?:[\x20\x09]*+[\x21-\x7E\x80-\xFF]++)*+)[\x20\x09]*+[\r]?+\n/m', $headers, $matches, \PREG_SET_ORDER);
+
+        // check number of valid header fields matches number of lines + request line
+        if (\substr_count($headers, "\n") !== $n + 1) {
+            throw new \InvalidArgumentException('Unable to parse invalid request header fields');
+        }
+
+        // format all header fields into associative array
+        $host = null;
+        $fields = array();
+        foreach ($matches as $match) {
+            $fields[$match[1]][] = $match[2];
+
+            // match `Host` request header
+            if ($host === null && \strtolower($match[1]) === 'host') {
+                $host = $match[2];
+            }
+        }
 
         // create new obj implementing ServerRequestInterface by preserving all
         // previous properties and restoring original request-target
@@ -157,6 +160,48 @@ class RequestHeaderParser extends EventEmitter
             'REQUEST_TIME' => \time(),
             'REQUEST_TIME_FLOAT' => \microtime(true)
         );
+
+        // scheme is `http` unless TLS is used
+        $localParts = \parse_url($localSocketUri);
+        if (isset($localParts['scheme']) && $localParts['scheme'] === 'tls') {
+            $scheme = 'https://';
+            $serverParams['HTTPS'] = 'on';
+        } else {
+            $scheme = 'http://';
+        }
+
+        // default host if unset comes from local socket address or defaults to localhost
+        if ($host === null) {
+            $host = isset($localParts['host'], $localParts['port']) ? $localParts['host'] . ':' . $localParts['port'] : '127.0.0.1';
+        }
+
+        if ($start['method'] === 'OPTIONS' && $start['target'] === '*') {
+            // support asterisk-form for `OPTIONS *` request line only
+            $uri = $scheme . $host;
+        } elseif ($start['method'] === 'CONNECT') {
+            $parts = \parse_url('tcp://' . $start['target']);
+
+            // check this is a valid authority-form request-target (host:port)
+            if (!isset($parts['scheme'], $parts['host'], $parts['port']) || \count($parts) !== 3) {
+                throw new \InvalidArgumentException('CONNECT method MUST use authority-form request target');
+            }
+            $uri = $scheme . $start['target'];
+        } else {
+            // support absolute-form or origin-form for proxy requests
+            if ($start['target'][0] === '/') {
+                $uri = $scheme . $host . $start['target'];
+            } else {
+                // ensure absolute-form request-target contains a valid URI
+                $parts = \parse_url($start['target']);
+
+                // make sure value contains valid host component (IP or hostname), but no fragment
+                if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'http' || isset($parts['fragment'])) {
+                    throw new \InvalidArgumentException('Invalid absolute-form request-target');
+                }
+
+                $uri = $start['target'];
+            }
+        }
 
         // apply REMOTE_ADDR and REMOTE_PORT if source address is known
         // address should always be known, unless this is over Unix domain sockets (UDS)
@@ -169,51 +214,23 @@ class RequestHeaderParser extends EventEmitter
         // apply SERVER_ADDR and SERVER_PORT if server address is known
         // address should always be known, even for Unix domain sockets (UDS)
         // but skip UDS as it doesn't have a concept of host/port.
-        if ($localSocketUri !== null) {
-            $localAddress = \parse_url($localSocketUri);
-            if (isset($localAddress['host'], $localAddress['port'])) {
-                $serverParams['SERVER_ADDR'] = $localAddress['host'];
-                $serverParams['SERVER_PORT'] = $localAddress['port'];
-            }
-            if (isset($localAddress['scheme']) && $localAddress['scheme'] === 'tls') {
-                $serverParams['HTTPS'] = 'on';
-            }
+        if ($localSocketUri !== null && isset($localParts['host'], $localParts['port'])) {
+            $serverParams['SERVER_ADDR'] = $localParts['host'];
+            $serverParams['SERVER_PORT'] = $localParts['port'];
         }
 
-        $target = $request->getRequestTarget();
         $request = new ServerRequest(
-            $request->getMethod(),
-            $request->getUri(),
-            $request->getHeaders(),
-            $request->getBody(),
-            $request->getProtocolVersion(),
+            $start['method'],
+            $uri,
+            $fields,
+            null,
+            $start['version'],
             $serverParams
         );
-        $request = $request->withRequestTarget($target);
 
-        // re-apply actual request target from above
-        if ($originalTarget !== null) {
-            $request = $request->withUri(
-                $request->getUri()->withPath(''),
-                true
-            )->withRequestTarget($originalTarget);
-        }
-
-        // only support HTTP/1.1 and HTTP/1.0 requests
-        $protocolVersion = $request->getProtocolVersion();
-        if ($protocolVersion !== '1.1' && $protocolVersion !== '1.0') {
-            throw new \InvalidArgumentException('Received request with invalid protocol version', 505);
-        }
-
-        // ensure absolute-form request-target contains a valid URI
-        $requestTarget = $request->getRequestTarget();
-        if (\strpos($requestTarget, '://') !== false && \substr($requestTarget, 0, 1) !== '/') {
-            $parts = \parse_url($requestTarget);
-
-            // make sure value contains valid host component (IP or hostname), but no fragment
-            if (!isset($parts['scheme'], $parts['host']) || $parts['scheme'] !== 'http' || isset($parts['fragment'])) {
-                throw new \InvalidArgumentException('Invalid absolute-form request-target');
-            }
+        // only assign request target if it is not in origin-form (happy path for most normal requests)
+        if ($start['target'][0] !== '/') {
+            $request = $request->withRequestTarget($start['target']);
         }
 
         // Optional Host header value MUST be valid (host and optional port)
@@ -250,44 +267,6 @@ class RequestHeaderParser extends EventEmitter
                 // Content-Length value is not an integer or not a single integer
                 throw new \InvalidArgumentException('The value of `Content-Length` is not valid', 400);
             }
-        }
-
-        // set URI components from socket address if not already filled via Host header
-        if ($request->getUri()->getHost() === '') {
-            $parts = \parse_url($localSocketUri);
-            if (!isset($parts['host'], $parts['port'])) {
-                $parts = array('host' => '127.0.0.1', 'port' => 80);
-            }
-
-            $request = $request->withUri(
-                $request->getUri()->withScheme('http')->withHost($parts['host'])->withPort($parts['port']),
-                true
-            );
-        }
-
-        // Do not assume this is HTTPS when this happens to be port 443
-        // detecting HTTPS is left up to the socket layer (TLS detection)
-        if ($request->getUri()->getScheme() === 'https') {
-            $request = $request->withUri(
-                $request->getUri()->withScheme('http')->withPort(443),
-                true
-            );
-        }
-
-        // Update request URI to "https" scheme if the connection is encrypted
-        $parts = \parse_url($localSocketUri);
-        if (isset($parts['scheme']) && $parts['scheme'] === 'tls') {
-            // The request URI may omit default ports here, so try to parse port
-            // from Host header field (if possible)
-            $port = $request->getUri()->getPort();
-            if ($port === null) {
-                $port = \parse_url('tcp://' . $request->getHeaderLine('Host'), PHP_URL_PORT); // @codeCoverageIgnore
-            }
-
-            $request = $request->withUri(
-                $request->getUri()->withScheme('https')->withPort($port),
-                true
-            );
         }
 
         // always sanitize Host header because it contains critical routing information


### PR DESCRIPTION
This changeset was originally worked on in preparation for upcoming refactorings to rearrange some unrelated logic inside the request parser class to prepare for persistent HTTP connections in follow-up PR. This changeset does not affect the public API and happens to improve performance noticeably from around 9500 req/s to 11000 req/s on my machine (best of 5).

Builds on top of #349
Resolves #302, thanks @kelunik for bringing this up!