### PR TITLE
Add TLS client certificate to SERVER_PARAMS

### DIFF
--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -166,6 +166,19 @@ class RequestHeaderParser extends EventEmitter
         if (isset($localParts['scheme']) && $localParts['scheme'] === 'tls') {
             $scheme = 'https://';
             $serverParams['HTTPS'] = 'on';
+            
+            // Try and get the SSL info from the stream
+            $sslOptions = stream_context_get_options($conn->stream);
+            
+            // If there appears to be a client cert and it can be exported, add it to the server params
+            if(!empty($sslOptions['ssl']['peer_certificate'])) {
+                $cert = false;
+                // SSL_CLIENT_CERT
+                openssl_x509_export($sslOptions['ssl']['peer_certificate'], $cert);
+                if($cert){
+                    $serverParams['SSL_CLIENT_CERT'] = $cert;
+                }
+            }
         } else {
             $scheme = 'http://';
         }


### PR DESCRIPTION
related to #324 

Attempt to extract a client certificate from the request and add it to server params as SSL_CLIENT_CERT (as per apache).

Allows Middleware to get at the client cert, which I need in my instance for mutual TLS based auth.

Needs verify_peer and capture_peer_cert to be enabled as ssl options e.g.
`
$socket = new React\Socket\SecureServer(
    $socket,
    $loop,
    [
        'local_cert' => $localCert,
        'local_pk' => $localKey,
        'allow_self_signed' => true,
        'verify_peer' => true,
        'capture_peer_cert' => true,
    ]
);
`