### PR TITLE
Fix parsing Cookie request header with comma in its values

### DIFF
--- a/src/Io/ServerRequest.php
+++ b/src/Io/ServerRequest.php
@@ -57,7 +57,13 @@ class ServerRequest extends Request implements ServerRequestInterface
             \parse_str($query, $this->queryParams);
         }
 
-        $this->cookies = $this->parseCookie($this->getHeaderLine('Cookie'));
+        // Multiple cookie headers are not allowed according
+        // to https://tools.ietf.org/html/rfc6265#section-5.4
+        $cookieHeaders = $this->getHeader("Cookie");
+
+        if (count($cookieHeaders) === 1) {
+            $this->cookies = $this->parseCookie($cookieHeaders[0]);
+        }
     }
 
     public function getServerParams()
@@ -146,10 +152,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private function parseCookie($cookie)
     {
-        // PSR-7 `getHeaderLine('Cookie')` will return multiple
-        // cookie header comma-seperated. Multiple cookie headers
-        // are not allowed according to https://tools.ietf.org/html/rfc6265#section-5.4
-        if ($cookie === '' || \strpos($cookie, ',') !== false) {
+        if ($cookie === '') {
             return array();
         }
 

--- a/tests/StreamingServerTest.php
+++ b/tests/StreamingServerTest.php
@@ -2790,6 +2790,25 @@ class StreamingServerTest extends TestCase
         $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $requestValidation->getCookieParams());
     }
 
+    public function testRequestCookieWithCommaValueWillBeAddedToServerRequest() {
+        $requestValidation = null;
+        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+            $requestValidation = $request;
+        });
+
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = "GET / HTTP/1.1\r\n";
+        $data .= "Host: example.com:80\r\n";
+        $data .= "Connection: close\r\n";
+        $data .= "Cookie: test=abc,def; hello=world\r\n";
+        $data .= "\r\n";
+
+        $this->connection->emit('data', array($data));
+        $this->assertEquals(array('test' => 'abc,def', 'hello' => 'world'), $requestValidation->getCookieParams());
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";


### PR DESCRIPTION
Hello,

I encountered an odd issue with the introduction of some cookie consent tool that was on one of my projects. Currently, any cookie containing a comma will break cookie parsing and add no cookies to the request.

This commit fixes the issue and adds an extra test case against the problem.