### PR TITLE
Avoid unneeded warning when decoding invalid data on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,31 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm # ignore errors, see below
-
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-# also test lowest dependencies on PHP 7
 matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
     - php: 7.0
       env:
         - DEPENDENCIES=lowest
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm
   allow_failures:
     - php: hhvm
-
-sudo: false
 
 install:
   - composer install --no-interaction
   - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest -n; fi
-  
+
 script:
   - ./vendor/bin/phpunit --coverage-text
   - if [ "$DEPENDENCIES" = "lowest" ]; then php -n tests/benchmark-middleware-runner.php; fi

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>

--- a/src/Io/ChunkedDecoder.php
+++ b/src/Io/ChunkedDecoder.php
@@ -122,7 +122,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                     }
                 }
 
-                $this->chunkSize = \hexdec($hexValue);
+                $this->chunkSize = @\hexdec($hexValue);
                 if (\dechex($this->chunkSize) !== $hexValue) {
                     $this->handleError(new Exception($hexValue . ' is not a valid hexadecimal number'));
                     return;


### PR DESCRIPTION
Supersedes / Closes #356
Refs: https://github.com/reactphp/http-client/pull/150