### PR TITLE
Add the event loop as required constructor argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This is an HTTP server which responds with `Hello World!` to every request.
 ```php
 $loop = React\EventLoop\Factory::create();
 
-$server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Response(
         200,
         array(
@@ -714,7 +714,7 @@ the constructor and will be invoked with the respective [request](#server-reques
 object and expects a [response](#response) object in return:
 
 ```php
-$server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Response(
         200,
         array(
@@ -742,7 +742,7 @@ chapter. In its most simple form, you can attach this to a
 to start a plaintext HTTP server like this:
 
 ```php
-$server = new React\Http\Server($handler);
+$server = new React\Http\Server($loop, $handler);
 
 $socket = new React\Socket\Server('0.0.0.0:8080', $loop);
 $server->listen($socket);
@@ -803,7 +803,7 @@ to explicitly configure the total number of requests that can be handled at
 once like this:
 
 ```php
-$server = new React\Http\Server(array(
+$server = new React\Http\Server($loop, array(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -822,7 +822,7 @@ also use a streaming approach where only small chunks of data have to be kept
 in memory:
 
 ```php
-$server = new React\Http\Server(array(
+$server = new React\Http\Server($loop, array(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     $handler
 ));
@@ -851,7 +851,7 @@ messages. In its most common form, you can attach this to a
 order to start a plaintext HTTP server like this:
 
 ```php
-$server = new React\Http\Server($handler);
+$server = new React\Http\Server($loop, $handler);
 
 $socket = new React\Socket\Server('0.0.0.0:8080', $loop);
 $server->listen($socket);
@@ -877,7 +877,7 @@ using a secure TLS listen address, a certificate file and optional
 `passphrase` like this:
 
 ```php
-$server = new React\Http\Server($handler);
+$server = new React\Http\Server($loop, $handler);
 
 $socket = new React\Socket\Server('tls://0.0.0.0:8443', $loop, array(
     'local_cert' => __DIR__ . '/localhost.pem'
@@ -902,7 +902,7 @@ which in turn extends the
 and will be passed to the callback function like this.
 
  ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $body = "The method of the request is: " . $request->getMethod();
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
@@ -945,7 +945,7 @@ The following parameters are currently available:
   Set to 'on' if the request used HTTPS, otherwise it won't be set
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
@@ -970,7 +970,7 @@ The `getQueryParams(): array` method can be used to get the query parameters
 similiar to the `$_GET` variable.
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -1024,7 +1024,7 @@ By default, this method will only return parsed data for requests using
 request headers (commonly used for `POST` requests for HTML form submission data).
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $name = $request->getParsedBody()['name'] ?? 'anonymous';
 
     return new Response(
@@ -1048,7 +1048,7 @@ an XML (`Content-Type: application/xml`) request body (which is commonly used fo
 `POST`, `PUT` or `PATCH` requests in JSON-based or RESTful/RESTish APIs).
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $data = json_decode((string)$request->getBody());
     $name = $data->name ?? 'anonymous';
 
@@ -1071,7 +1071,7 @@ This array will only be filled when using the `Content-Type: multipart/form-data
 request header (commonly used for `POST` requests for HTML file uploads).
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $files = $request->getUploadedFiles();
     $name = isset($files['avatar']) ? $files['avatar']->getClientFilename() : 'nothing';
 
@@ -1141,7 +1141,7 @@ The ReactPHP `ReadableStreamInterface` gives you access to the incoming
 request body as the individual chunks arrive:
 
 ```php
-$server = new React\Http\Server(array(
+$server = new React\Http\Server($loop, array(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $body = $request->getBody();
@@ -1214,7 +1214,7 @@ This method operates on the streaming request body, i.e. the request body size
 may be unknown (`null`) when using `Transfer-Encoding: chunked` for HTTP/1.1 requests.
 
 ```php 
-$server = new React\Http\Server(array(
+$server = new React\Http\Server($loop, array(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $size = $request->getBody()->getSize();
@@ -1287,7 +1287,7 @@ The `getCookieParams(): string[]` method can be used to
 get all cookies sent with the current request.
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -1359,7 +1359,7 @@ but feel free to use any implemantation of the
 `PSR-7 ResponseInterface` you prefer.
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1382,7 +1382,7 @@ To prevent this you SHOULD use a
 This example shows how such a long-term action could look like:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($loop) {
         $loop->addTimer(1.5, function() use ($resolve) {
             $response = new Response(
@@ -1419,7 +1419,7 @@ Note that other implementations of the `PSR-7 ResponseInterface` likely
 only support strings.
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
@@ -1510,7 +1510,7 @@ added automatically. This is the most common use case, for example when using
 a `string` response body like this:
 
 ```php 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1529,7 +1529,7 @@ response messages will contain the plain response body. If you know the length
 of your streaming response body, you MAY want to specify it explicitly like this:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $loop->addTimer(2.0, function () use ($stream) {
@@ -1608,7 +1608,7 @@ A `Date` header will be automatically added with the system date and time if non
 You can add a custom `Date` header yourself like this:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1622,7 +1622,7 @@ If you don't have a appropriate clock to rely on, you should
 unset this header with an empty string:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1636,7 +1636,7 @@ Note that it will automatically assume a `X-Powered-By: react/alpha` header
 unless your specify a custom `X-Powered-By` header yourself:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1650,7 +1650,7 @@ If you do not want to send this header at all, you can use an empty string as
 value like this:
 
 ```php
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -1723,7 +1723,7 @@ The following example adds a middleware request handler that adds the current ti
 header (`Request-Time`) and a final request handler that always returns a 200 code without a body: 
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     function (ServerRequestInterface $request, callable $next) {
         $request = $request->withHeader('Request-Time', time());
         return $next($request);
@@ -1747,7 +1747,7 @@ In order to simplify handling both paths, you can simply wrap this in a
 [`Promise\resolve()`](https://reactphp.org/promise/#resolve) call like this:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     function (ServerRequestInterface $request, callable $next) {
         $promise = React\Promise\resolve($next($request));
         return $promise->then(function (ResponseInterface $response) {
@@ -1769,7 +1769,7 @@ handling logic (or logging etc.) by wrapping this in a
 [`Promise`](https://reactphp.org/promise/#promise) like this:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     function (ServerRequestInterface $request, callable $next) {
         $promise = new React\Promise\Promise(function ($resolve) use ($next, $request) {
             $resolve($next($request));
@@ -2404,7 +2404,7 @@ The following example shows how this middleware can be used to ensure no more
 than 10 handlers will be invoked at once:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     new LimitConcurrentRequestsMiddleware(10),
     $handler
 ));
@@ -2415,7 +2415,7 @@ Similarly, this middleware is often used in combination with the
 to limit the total number of requests that can be buffered at once:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -2429,7 +2429,7 @@ that can be buffered at once and then ensure the actual request handler only
 processes one request after another without any concurrency:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -2482,7 +2482,7 @@ the total number of concurrent requests.
 Usage:
 
 ```php
-$server = new Server(array(
+$server = new Server($loop, array(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
@@ -2542,7 +2542,7 @@ $handler = function (ServerRequestInterface $request) {
     );
 };
 
-$server = new Server(array(
+$server = new Server($loop, array(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
     new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 
 $counter = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
+$server = new Server($loop, function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array(

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($loop) {
         $loop->addTimer(1.5, function() use ($resolve) {
             $response = new Response(

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 
 $count = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$count) {
+$server = new Server($loop, function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -15,7 +15,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
             415, // Unsupported Media Type

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$server = new Server(function (ServerRequestInterface $request) {
+$server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -124,7 +124,7 @@ HTML;
 
 // Note how this example explicitly uses the advanced `StreamingRequestMiddleware` to apply
 // custom request buffering limits below before running our request handler.
-$server = new Server(array(
+$server = new Server($loop, array(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -17,7 +17,7 @@ $loop = Factory::create();
 // This means that this proxy buffers the whole request before "processing" it.
 // As such, this is store-and-forward proxy. This could also use the advanced
 // `StreamingRequestMiddleware` to forward the incoming request as it comes in.
-$server = new Server(function (RequestInterface $request) {
+$server = new Server($loop, function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -19,7 +19,7 @@ $connector = new Connector($loop);
 // Unlike the plain HTTP proxy, the CONNECT method does not contain a body
 // and we establish an end-to-end connection over the stream object, so this
 // doesn't have to store any payload data in memory at all.
-$server = new Server(function (ServerRequestInterface $request) use ($connector) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -30,7 +30,7 @@ $loop = Factory::create();
 // Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             426,

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -38,7 +38,7 @@ $chat = new ThroughStream();
 // Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
-$server = new Server(function (ServerRequestInterface $request) use ($loop, $chat) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop, $chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             426,

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -87,7 +87,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-$server = new Server(function (ServerRequestInterface $request) use ($loop) {
+$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -5,6 +5,7 @@ namespace React\Http\Io;
 use Evenement\EventEmitter;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\LoopInterface;
 use React\Http\Response;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
@@ -83,6 +84,7 @@ final class StreamingServer extends EventEmitter
 {
     private $callback;
     private $parser;
+    private $loop;
 
     /**
      * Creates an HTTP server that invokes the given callback for each incoming HTTP request
@@ -92,11 +94,14 @@ final class StreamingServer extends EventEmitter
      * connections in order to then parse incoming data as HTTP.
      * See also [listen()](#listen) for more details.
      *
+     * @param LoopInterface $loop
      * @param callable|callable[] $requestHandler
      * @see self::listen()
      */
-    public function __construct($requestHandler)
+    public function __construct(LoopInterface $loop, $requestHandler)
     {
+        $this->loop = $loop;
+
         if (!\is_callable($requestHandler) && !\is_array($requestHandler)) {
             throw new \InvalidArgumentException('Invalid request handler given');
         } elseif (!\is_callable($requestHandler)) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -3,6 +3,7 @@
 namespace React\Http;
 
 use Evenement\EventEmitter;
+use React\EventLoop\LoopInterface;
 use React\Http\Io\IniUtil;
 use React\Http\Io\StreamingServer;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
@@ -164,10 +165,11 @@ final class Server extends EventEmitter
      * connections in order to then parse incoming data as HTTP.
      * See also [listen()](#listen) for more details.
      *
+     * @param LoopInterface $loop
      * @param callable|callable[] $requestHandler
      * @see self::listen()
      */
-    public function __construct($requestHandler)
+    public function __construct(LoopInterface $loop, $requestHandler)
     {
         if (!\is_callable($requestHandler) && !\is_array($requestHandler)) {
             throw new \InvalidArgumentException('Invalid request handler given');
@@ -204,7 +206,7 @@ final class Server extends EventEmitter
             $middleware = \array_merge($middleware, $requestHandler);
         }
 
-        $this->streamingServer = new StreamingServer($middleware);
+        $this->streamingServer = new StreamingServer($loop, $middleware);
 
         $that = $this;
         $this->streamingServer->on('error', function ($error) use ($that) {

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -32,7 +32,7 @@ class FunctionalBrowserTest extends TestCase
         $this->loop = $loop = Factory::create();
         $this->browser = new Browser($this->loop);
 
-        $server = new Server(array(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) use ($loop) {
+        $server = new Server($this->loop, array(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) use ($loop) {
             $path = $request->getUri()->getPath();
 
             $headers = array();
@@ -527,7 +527,7 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testPostStreamWillStartSendingRequestEvenWhenBodyDoesNotEmitData()
     {
-        $server = new Server(array(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
+        $server = new Server($this->loop, array(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
             return new Response(200);
         }));
         $socket = new \React\Socket\Server(0, $this->loop);
@@ -554,7 +554,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsHttp11ByDefault()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new Server($this->loop, function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -574,7 +574,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsExplicitHttp10Request()
     {
-        $server = new Server(function (ServerRequestInterface $request) {
+        $server = new Server($this->loop, function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),

--- a/tests/FunctionalServerTest.php
+++ b/tests/FunctionalServerTest.php
@@ -26,7 +26,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -52,7 +52,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(array(
+        $server = new Server($loop, array(
             function () {
                 return new Response(404);
             },
@@ -79,7 +79,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -105,7 +105,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -137,7 +137,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -169,7 +169,7 @@ class FunctionalServerTest extends TestCase
 
         $loop = Factory::create();
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -213,7 +213,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -247,7 +247,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -277,7 +277,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -316,7 +316,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -355,7 +355,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -385,7 +385,7 @@ class FunctionalServerTest extends TestCase
         }
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -424,7 +424,7 @@ class FunctionalServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri() . 'x' . $request->getHeaderLine('Host'));
         });
 
@@ -452,7 +452,7 @@ class FunctionalServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new Server(function (RequestInterface $request) use ($stream) {
+        $server = new Server($loop, function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -479,7 +479,7 @@ class FunctionalServerTest extends TestCase
         $connector = new Connector($loop);
 
         $once = $this->expectCallableOnce();
-        $server = new Server(array(
+        $server = new Server($loop, array(
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($once) {
                 $request->getBody()->on('close', $once);
@@ -509,7 +509,7 @@ class FunctionalServerTest extends TestCase
 
         $stream = new ThroughStream();
 
-        $server = new Server(array(
+        $server = new Server($loop, array(
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($stream) {
                 return new Response(200, array(), $stream);
@@ -542,7 +542,7 @@ class FunctionalServerTest extends TestCase
 
         $stream = new ThroughStream();
 
-        $server = new Server(function (RequestInterface $request) use ($stream) {
+        $server = new Server($loop, function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -570,7 +570,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new Server($loop, function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -607,7 +607,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new Server($loop, function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -645,7 +645,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new Server($loop, function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -682,7 +682,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) use ($loop) {
+        $server = new Server($loop, function (RequestInterface $request) use ($loop) {
             $stream = new ThroughStream();
 
             $loop->addTimer(0.1, function () use ($stream) {
@@ -723,7 +723,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(function (RequestInterface $request) {
+        $server = new Server($loop, function (RequestInterface $request) {
             $stream = new ThroughStream();
             $stream->close();
 
@@ -757,7 +757,7 @@ class FunctionalServerTest extends TestCase
         $loop = Factory::create();
         $connector = new Connector($loop);
 
-        $server = new Server(array(
+        $server = new Server($loop, array(
             new LimitConcurrentRequestsMiddleware(5),
             new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
             function (ServerRequestInterface $request, $next) use ($loop) {

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Io\StreamingServer;
+use React\EventLoop\Factory;
 use React\Http\Response;
 use React\Promise\Promise;
 use React\Stream\ThroughStream;
@@ -46,7 +47,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -58,7 +59,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new StreamingServer($this->expectCallableOnce());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableOnce());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -73,7 +74,7 @@ class StreamingServerTest extends TestCase
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
-        $server = new StreamingServer(array($this, 'helperCallableOnce'));
+        $server = new StreamingServer(Factory::create(), array($this, 'helperCallableOnce'));
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -93,7 +94,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -126,7 +127,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), array(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         }));
@@ -158,7 +159,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -180,7 +181,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -202,7 +203,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -224,7 +225,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -244,7 +245,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -257,7 +258,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -279,7 +280,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectWithoutHostWillBeAdded()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -301,7 +302,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -323,7 +324,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBeOverwritten()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -344,7 +345,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -356,7 +357,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -370,7 +371,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -396,7 +397,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -418,7 +419,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -440,7 +441,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -462,7 +463,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -484,7 +485,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -504,7 +505,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             $request->getBody()->pause();
         });
 
@@ -524,7 +525,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             $request->getBody()->resume();
         });
 
@@ -544,7 +545,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCloseWillNotCloseConnection()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
         });
 
@@ -559,7 +560,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();
         });
@@ -576,7 +577,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
         });
@@ -595,7 +596,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
         });
 
@@ -610,7 +611,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -630,7 +631,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -651,7 +652,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsPoweredByHeader()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -681,7 +682,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -711,7 +712,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -743,7 +744,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -778,7 +779,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -816,7 +817,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -852,7 +853,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -907,7 +908,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -925,7 +926,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -961,7 +962,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -996,7 +997,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 101,
                 array(
@@ -1036,7 +1037,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
                 array(
@@ -1077,7 +1078,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1115,7 +1116,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1134,7 +1135,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1167,7 +1168,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1201,7 +1202,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1233,7 +1234,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 204,
                 array(),
@@ -1266,7 +1267,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1300,7 +1301,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1334,7 +1335,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1368,7 +1369,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer($this->expectCallableNever());
+        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1405,7 +1406,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1433,7 +1434,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1464,7 +1465,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1493,7 +1494,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1521,7 +1522,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1551,7 +1552,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1578,7 +1579,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1609,7 +1610,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1641,7 +1642,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1667,7 +1668,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1694,7 +1695,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1720,7 +1721,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(function ($request) use ($errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1745,7 +1746,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(function ($request) use ($errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1767,7 +1768,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(function ($request) use ($errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1790,7 +1791,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(function ($request) use ($errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1812,7 +1813,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(function ($request) use ($errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1839,7 +1840,7 @@ class StreamingServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = new StreamingServer(Factory::create(), function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -1863,7 +1864,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1882,7 +1883,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1916,7 +1917,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -1957,7 +1958,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($body) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -1994,7 +1995,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($body) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2028,7 +2029,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(
@@ -2065,7 +2066,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDate()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2095,7 +2096,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWIthCustomDateHeaderOverwritesDefault()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
@@ -2128,7 +2129,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Date' => '')
@@ -2161,7 +2162,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseCanContainMultipleCookieHeaders()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2199,7 +2200,7 @@ class StreamingServerTest extends TestCase
 
     public function testReponseWithExpectContinueRequestContainsContinueWithLaterResponse()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2231,7 +2232,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2262,14 +2263,14 @@ class StreamingServerTest extends TestCase
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $server = new StreamingServer('invalid');
+        $server = new StreamingServer(Factory::create(), 'invalid');
     }
 
     public function testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding()
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array(),
@@ -2308,7 +2309,7 @@ class StreamingServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array('Content-Length' => 5),
@@ -2346,7 +2347,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithResponsePromise()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2374,7 +2375,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseReturnInvalidTypeWillResultInError()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2408,7 +2409,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2436,7 +2437,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2467,7 +2468,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2498,7 +2499,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Transfer-Encoding' => 'chunked'),
@@ -2534,7 +2535,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWillBeHandled()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2562,7 +2563,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2600,7 +2601,7 @@ class StreamingServerTest extends TestCase
      */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             throw new \Error('hello');
         });
 
@@ -2643,7 +2644,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2680,7 +2681,7 @@ class StreamingServerTest extends TestCase
     public function testRequestServerRequestParams()
     {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2714,7 +2715,7 @@ class StreamingServerTest extends TestCase
     public function testRequestQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2734,7 +2735,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2755,7 +2756,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2776,7 +2777,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2795,7 +2796,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCookieWithCommaValueWillBeAddedToServerRequest() {
         $requestValidation = null;
-        $server = new StreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 


### PR DESCRIPTION
For now we won't use it just yet. But this will prepare our API for
future features like keep alive connections, dead connection clean up
etc. Even though we won't use it in the next release, it will put it in
the API so we don't have to break it again when we add features that
require the event loop.