### PR TITLE
Server requst body empty when request from dot net app

### DIFF
--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -278,7 +278,7 @@ final class MultipartParser
     private function getParameterFromHeader(array $header, $parameter)
     {
         foreach ($header as $part) {
-            if (\preg_match('/' . $parameter . '="?(.*)"$/', $part, $matches)) {
+            if (\preg_match('/' . $parameter . '="?(.*?)"?$/', $part, $matches)) {
                 return $matches[1];
             }
         }

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -93,7 +93,7 @@ final class MultipartParser
     public function parse(ServerRequestInterface $request)
     {
         $contentType = $request->getHeaderLine('content-type');
-        if(!\preg_match('/boundary="?(.*)"?$/', $contentType, $matches)) {
+        if(!\preg_match('/boundary="?(.*?)"?$/', $contentType, $matches)) {
             return $request;
         }
 

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -66,6 +66,39 @@ final class MultipartParserTest extends TestCase
         );
     }
 
+    public function testPostWithQuotationMarkEncapsulatedBoundary()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[one]\"\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=\"users[two]\"\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data; boundary="' . $boundary . '"',
+        ), $data, 1.1);
+
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertSame(
+            array(
+                'users' => array(
+                    'one' => 'single',
+                    'two' => 'second',
+                ),
+            ),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
     public function testPostStringOverwritesMap()
     {
         $boundary = "---------------------------5844729766471062541057622570";

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -99,6 +99,39 @@ final class MultipartParserTest extends TestCase
         );
     }
 
+    public function testPostFormDataNamesWithoutQuotationMark()
+    {
+        $boundary = "---------------------------5844729766471062541057622570";
+
+        $data  = "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=users[one]\r\n";
+        $data .= "\r\n";
+        $data .= "single\r\n";
+        $data .= "--$boundary\r\n";
+        $data .= "Content-Disposition: form-data; name=users[two]\r\n";
+        $data .= "\r\n";
+        $data .= "second\r\n";
+        $data .= "--$boundary--\r\n";
+
+        $request = new ServerRequest('POST', 'http://example.com/', array(
+            'Content-Type' => 'multipart/form-data; boundary="' . $boundary . '"',
+        ), $data, 1.1);
+
+        $parser = new MultipartParser();
+        $parsedRequest = $parser->parse($request);
+
+        $this->assertEmpty($parsedRequest->getUploadedFiles());
+        $this->assertSame(
+            array(
+                'users' => array(
+                    'one' => 'single',
+                    'two' => 'second',
+                ),
+            ),
+            $parsedRequest->getParsedBody()
+        );
+    }
+
     public function testPostStringOverwritesMap()
     {
         $boundary = "---------------------------5844729766471062541057622570";


### PR DESCRIPTION
tl;dr; [\React\Http\Io\MultipartParser::parse()](https://github.com/reactphp/http/blob/master/src/Io/MultipartParser.php#L96) boundary regex matches ending optional quotation mark (") causing it to be invalid and unmatchable in request body.

----

Hi,
i was trying to send a request to a running react http server.
But when i tried to send post request with the System.Net.Http.MultipartFormDataContent the body was ignored and no files arrived. 

I used the [http example](https://github.com/reactphp/http/blob/master/examples/12-upload.php) to confirm that my implementation was not the cause of this problem.

When i used a 'normal' webserver or even the builtin php server the post body and files were present.
After a lot of trying to get the data to be sent in different ways with no success i fired up wireshark.
I was watching looking at the parsed http messages (my bad) which did not show the real difference between the requests from the browser and the .net app.
`MIME Multipart Media Encapsulation, Type: multipart/form-data, Boundary: "----WebKitFormBoundaryEWssHEhuSXsAIY93"`
`MIME Multipart Media Encapsulation, Type: multipart/form-data, Boundary: "----YspPrintAppBoundaryx2Dtzcda4C"`

Chrome (and i guess more browsers) do not encapsulate the boundary within quotation marks, the System.Net.Http.MultipartFormDataContent does.

So what really was being sent: 
`multipart/form-data; boundary=----WebKitFormBoundaryEWssHEhuSXsAIY93`
and
`multipart/form-data; boundary="----YspPrintAppBoundaryx2Dtzcda4C"`

will match respectively:
`----WebKitFormBoundaryEWssHEhuSXsAIY93`
and
`----YspPrintAppBoundaryx2Dtzcda4C"`

I think if the regex is changed from: 
`/boundary="?(.*)"?$/`
to a less greedy variant:
`/boundary="?(.*?)"?$/`
will fix this issue.


ps. after writing this and further testing i noticed the post body array was still empty. This was caused by [similar situation](https://github.com/reactphp/http/blob/master/src/Io/MultipartParser.php#L281) but this time the .net http client does not encapsulates the form field names in the `content-disposition` header.

pps. i added (read: copied) 2 unit tests to test this behaviour. Is that sufficient?


