### PR TITLE
Fix calculating concurrency when `post_max_size` ini is unlimited

### DIFF
--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -53,6 +53,11 @@ class IniUtilTest extends TestCase
         $this->assertEquals($output, IniUtil::iniSizeToBytes($input));
     }
 
+    public function testIniSizeToBytesWithInvalidSuffixReturnsNumberWithoutSuffix()
+    {
+        $this->assertEquals('2', IniUtil::iniSizeToBytes('2x'));
+    }
+
     public function provideInvalidInputIniSizeToBytes()
     {
         return array(

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -183,4 +183,48 @@ final class ServerTest extends TestCase
 
         return $data;
     }
+
+    public function provideIniSettingsForConcurrency()
+    {
+        return array(
+            'default settings' => array(
+                '128M',
+                '8M',
+                4
+            ),
+            'unlimited memory_limit limited to maximum concurrency' => array(
+                '-1',
+                '8M',
+                100
+            ),
+            'unlimited post_max_size' => array(
+                '128M',
+                '0',
+                1
+            ),
+            'small post_max_size limited to maximum concurrency' => array(
+                '128M',
+                '1k',
+                100
+            )
+        );
+    }
+
+    /**
+     * @param string $memory_limit
+     * @param string $post_max_size
+     * @param int    $expectedConcurrency
+     * @dataProvider provideIniSettingsForConcurrency
+     */
+    public function testServerConcurrency($memory_limit, $post_max_size, $expectedConcurrency)
+    {
+        $server = new Server(function () { });
+
+        $ref = new \ReflectionMethod($server, 'getConcurrentRequestsLimit');
+        $ref->setAccessible(true);
+
+        $value = $ref->invoke($server, $memory_limit, $post_max_size);
+
+        $this->assertEquals($expectedConcurrency, $value);
+    }
 }


### PR DESCRIPTION
Setting `post_max_size` to `0` means the HTTP request body size is unlimited. This has a similar effect to setting it to a very large value (e.g. `4G`). Accordingly, we have to limit concurrency to not exceed the `memory_limit` setting (see also #342).

In other words, this is more of an edge case and it's usually not recommended to allow keeping a very large HTTP request body in memory. The `post_max_size` should be limited to a reasonable value to support decent concurrency.

Resolves #360