### PR TITLE
Add `StreamingRequestMiddleware` to stream incoming requests, mark `StreamingServer` as internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,32 @@ Event-driven, streaming plaintext HTTP and secure HTTPS server for [ReactPHP](ht
 
 * [Quickstart example](#quickstart-example)
 * [Usage](#usage)
-  * [Server](#server)
-  * [StreamingServer](#streamingserver)
-  * [listen()](#listen)
-  * [Request](#request)
-    * [Request parameters](#request-parameters)
-    * [Query parameters](#query-parameters)
-    * [Request body](#request-body)
-    * [Streaming request](#streaming-request)
-    * [Request method](#request-method)
-    * [Cookie parameters](#cookie-parameters)
-    * [Invalid request](#invalid-request)
-  * [Response](#response)
-    * [Deferred response](#deferred-response)
-    * [Streaming response](#streaming-response)
-    * [Response length](#response-length)
-    * [Invalid response](#invalid-response)
-    * [Default response headers](#default-response-headers)
-  * [Middleware](#middleware)
-    * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
-    * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
-    * [RequestBodyParserMiddleware](#requestbodyparsermiddleware)
-    * [Third-Party Middleware](#third-party-middleware)
+    * [Server](#server)
+    * [StreamingServer](#streamingserver)
+    * [listen()](#listen)
+    * [Request](#request)
+        * [Request parameters](#request-parameters)
+        * [Query parameters](#query-parameters)
+        * [Request body](#request-body)
+        * [Streaming request](#streaming-request)
+        * [Request method](#request-method)
+        * [Cookie parameters](#cookie-parameters)
+        * [Invalid request](#invalid-request)
+    * [Response](#response)
+        * [Deferred response](#deferred-response)
+        * [Streaming response](#streaming-response)
+        * [Response length](#response-length)
+        * [Invalid response](#invalid-response)
+        * [Default response headers](#default-response-headers)
+    * [Middleware](#middleware)
+        * [Custom middleware](#custom-middleware)
+        * [Third-Party Middleware](#third-party-middleware)
+* [API](#api)
+    * [React\Http\Middleware](#reacthttpmiddleware)
+        * [StreamingRequestMiddleware](#streamingrequestmiddleware)
+        * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
+        * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
+        * [RequestBodyParserMiddleware](#requestbodyparsermiddleware)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -1046,6 +1050,8 @@ Many common use cases involve validating, processing, manipulating the incoming
 HTTP request before passing it to the final business logic request handler.
 As such, this project supports the concept of middleware request handlers.
 
+#### Custom middleware
+
 A middleware request handler is expected to adhere the following rules:
 
 * It is a valid `callable`.
@@ -1159,6 +1165,39 @@ $server = new Server(array(
     }
 ));
 ```
+
+#### Third-Party Middleware
+
+While this project does provide the means to *use* middleware implementations
+(see above), it does not aim to *define* how middleware implementations should
+look like. We realize that there's a vivid ecosystem of middleware
+implementations and ongoing effort to standardize interfaces between these with
+[PSR-15](https://www.php-fig.org/psr/psr-15/) (HTTP Server Request Handlers)
+and support this goal.
+As such, this project only bundles a few middleware implementations that are
+required to match PHP's request behavior (see
+[middleware implementations](#react-http-middleware)) and otherwise actively
+encourages third-party middleware implementations.
+
+While we would love to support PSR-15 directly in `react/http`, we understand
+that this interface does not specifically target async APIs and as such does
+not take advantage of promises for [deferred responses](#deferred-response).
+The gist of this is that where PSR-15 enforces a `ResponseInterface` return
+value, we also accept a `PromiseInterface<ResponseInterface>`.
+As such, we suggest using the external
+[PSR-15 middleware adapter](https://github.com/friends-of-reactphp/http-middleware-psr15-adapter)
+that uses on the fly monkey patching of these return values which makes using
+most PSR-15 middleware possible with this package without any changes required.
+
+Other than that, you can also use the above [middleware definition](#middleware)
+to create custom middleware. A non-exhaustive list of third-party middleware can
+be found at the [middleware wiki](https://github.com/reactphp/reactphp/wiki/Users#http-middleware).
+If you build or know a custom middleware, make sure to let the world know and
+feel free to add it to this list.
+
+## API
+
+### React\Http\Middleware
 
 #### LimitConcurrentRequestsMiddleware
 
@@ -1381,34 +1420,6 @@ new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
   is left up to higher-level implementations.
   If you want to respect this setting, you have to check its value and
   effectively avoid using this middleware entirely.
-
-#### Third-Party Middleware
-
-While this project does provide the means to *use* middleware implementations
-(see above), it does not aim to *define* how middleware implementations should
-look like. We realize that there's a vivid ecosystem of middleware
-implementations and ongoing effort to standardize interfaces between these with
-[PSR-15](https://www.php-fig.org/psr/psr-15/) (HTTP Server Request Handlers)
-and support this goal.
-As such, this project only bundles a few middleware implementations that are
-required to match PHP's request behavior (see above) and otherwise actively
-encourages third-party middleware implementations.
-
-While we would love to support PSR-15 directy in `react/http`, we understand
-that this interface does not specifically target async APIs and as such does
-not take advantage of promises for [deferred responses](#deferred-response).
-The gist of this is that where PSR-15 enforces a `ResponseInterface` return
-value, we also accept a `PromiseInterface<ResponseInterface>`.
-As such, we suggest using the external
-[PSR-15 middleware adapter](https://github.com/friends-of-reactphp/http-middleware-psr15-adapter)
-that uses on the fly monkey patching of these return values which makes using
-most PSR-15 middleware possible with this package without any changes required.
-
-Other than that, you can also use the above [middleware definition](#middleware)
-to create custom middleware. A non-exhaustive list of third-party middleware can
-be found at the [middleware wiki](https://github.com/reactphp/http/wiki/Middleware).
-If you build or know a custom middleware, make sure to let the world know and
-feel free to add it to this list.
 
 ## Install
 

--- a/examples/08-stream-response.php
+++ b/examples/08-stream-response.php
@@ -10,8 +10,6 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-// Note how this example still uses `Server` instead of `StreamingServer`.
-// The `StreamingServer` is only required for streaming *incoming* requests.
 $server = new Server(function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);

--- a/examples/12-upload.php
+++ b/examples/12-upload.php
@@ -13,8 +13,9 @@ use React\EventLoop\Factory;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
+use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Response;
-use React\Http\StreamingServer;
+use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -121,9 +122,10 @@ HTML;
     );
 };
 
-// Note how this example explicitly uses the advanced `StreamingServer` to apply
+// Note how this example explicitly uses the advanced `StreamingRequestMiddleware` to apply
 // custom request buffering limits below before running our request handler.
-$server = new StreamingServer(array(
+$server = new Server(array(
+    new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
     new RequestBodyParserMiddleware(100 * 1024, 1), // 1 file with 100 KiB max, reject upload otherwise

--- a/examples/21-http-proxy.php
+++ b/examples/21-http-proxy.php
@@ -10,10 +10,10 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-// Note how this example uses the `Server` instead of `StreamingServer`.
+// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // This means that this proxy buffers the whole request before "processing" it.
 // As such, this is store-and-forward proxy. This could also use the advanced
-// `StreamingServer` to forward the incoming request as it comes in.
+// `StreamingRequestMiddleware` to forward the incoming request as it comes in.
 $server = new Server(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(

--- a/examples/22-connect-proxy.php
+++ b/examples/22-connect-proxy.php
@@ -12,7 +12,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = Factory::create();
 $connector = new Connector($loop);
 
-// Note how this example uses the `Server` instead of `StreamingServer`.
+// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // Unlike the plain HTTP proxy, the CONNECT method does not contain a body
 // and we establish an end-to-end connection over the stream object, so this
 // doesn't have to store any payload data in memory at all.

--- a/examples/31-upgrade-echo.php
+++ b/examples/31-upgrade-echo.php
@@ -27,7 +27,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-// Note how this example uses the `Server` instead of `StreamingServer`.
+// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
 $server = new Server(function (ServerRequestInterface $request) use ($loop) {

--- a/examples/32-upgrade-chat.php
+++ b/examples/32-upgrade-chat.php
@@ -35,7 +35,7 @@ $loop = Factory::create();
 // this means that any Upgraded data will simply be sent back to the client
 $chat = new ThroughStream();
 
-// Note how this example uses the `Server` instead of `StreamingServer`.
+// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
 $server = new Server(function (ServerRequestInterface $request) use ($loop, $chat) {

--- a/examples/99-benchmark-download.php
+++ b/examples/99-benchmark-download.php
@@ -86,8 +86,6 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-// Note how this example still uses `Server` instead of `StreamingServer`.
-// The `StreamingServer` is only required for streaming *incoming* requests.
 $server = new Server(function (ServerRequestInterface $request) use ($loop) {
     switch ($request->getUri()->getPath()) {
         case '/':

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -1,18 +1,11 @@
 <?php
 
-namespace React\Http;
+namespace React\Http\Io;
 
 use Evenement\EventEmitter;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Io\ChunkedDecoder;
-use React\Http\Io\ChunkedEncoder;
-use React\Http\Io\CloseProtectionStream;
-use React\Http\Io\HttpBodyStream;
-use React\Http\Io\LengthLimitedStream;
-use React\Http\Io\MiddlewareRunner;
-use React\Http\Io\RequestHeaderParser;
-use React\Http\Io\ServerRequest;
+use React\Http\Response;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;
@@ -22,7 +15,7 @@ use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 
 /**
- * The advanced `StreamingServer` class is responsible for handling incoming connections and then
+ * The internal `StreamingServer` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
  * Unlike the [`Server`](#server) class, it does not buffer and parse the incoming
@@ -80,9 +73,11 @@ use React\Stream\WritableStreamInterface;
  * handler function may not be fully compatible with PSR-7. See also
  * [streaming request](#streaming-request) below for more details.
  *
+ * @see \React\Http\Server
  * @see Request
  * @see Response
  * @see self::listen()
+ * @internal
  */
 final class StreamingServer extends EventEmitter
 {
@@ -131,44 +126,8 @@ final class StreamingServer extends EventEmitter
     /**
      * Starts listening for HTTP requests on the given socket server instance
      *
-     * The server needs to be attached to an instance of
-     * `React\Socket\ServerInterface` which emits underlying streaming
-     * connections in order to then parse incoming data as HTTP.
-     * For each request, it executes the callback function passed to the
-     * constructor with the respective [request](#request) object and expects
-     * a respective [response](#response) object in return.
-     *
-     * You can attach this to a
-     * [`React\Socket\Server`](https://github.com/reactphp/socket#server)
-     * in order to start a plaintext HTTP server like this:
-     *
-     * ```php
-     * $server = new StreamingServer($handler);
-     *
-     * $socket = new React\Socket\Server(8080, $loop);
-     * $server->listen($socket);
-     * ```
-     *
-     * See also [example #1](examples) for more details.
-     *
-     * Similarly, you can also attach this to a
-     * [`React\Socket\SecureServer`](https://github.com/reactphp/socket#secureserver)
-     * in order to start a secure HTTPS server like this:
-     *
-     * ```php
-     * $server = new StreamingServer($handler);
-     *
-     * $socket = new React\Socket\Server(8080, $loop);
-     * $socket = new React\Socket\SecureServer($socket, $loop, array(
-     *     'local_cert' => __DIR__ . '/localhost.pem'
-     * ));
-     *
-     * $server->listen($socket);
-     * ```
-     *
-     * See also [example #11](examples) for more details.
-     *
      * @param ServerInterface $socket
+     * @see \React\Http\Server::listen()
      */
     public function listen(ServerInterface $socket)
     {

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -29,7 +29,8 @@ use React\Stream\ReadableStreamInterface;
  * than 10 handlers will be invoked at once:
  *
  * ```php
- * $server = new StreamingServer(array(
+ * $server = new Server(array(
+ *     new StreamingRequestMiddleware(),
  *     new LimitConcurrentRequestsMiddleware(10),
  *     $handler
  * ));
@@ -40,7 +41,8 @@ use React\Stream\ReadableStreamInterface;
  * to limit the total number of requests that can be buffered at once:
  *
  * ```php
- * $server = new StreamingServer(array(
+ * $server = new Server(array(
+ *     new StreamingRequestMiddleware(),
  *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
  *     new RequestBodyParserMiddleware(),
@@ -53,7 +55,8 @@ use React\Stream\ReadableStreamInterface;
  * processes one request after another without any concurrency:
  *
  * ```php
- * $server = new StreamingServer(array(
+ * $server = new Server(array(
+ *     new StreamingRequestMiddleware(),
  *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
  *     new RequestBodyParserMiddleware(),

--- a/src/Middleware/StreamingRequestMiddleware.php
+++ b/src/Middleware/StreamingRequestMiddleware.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace React\Http\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Process incoming requests with a streaming request body (without buffering).
+ *
+ * This allows you to process requests of any size without buffering the request
+ * body in memory. Instead, it will represent the request body as a
+ * [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+ * that emit chunks of incoming data as it is received:
+ *
+ * ```php
+ * $server = new React\Http\Server(array(
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     function (Psr\Http\Message\ServerRequestInterface $request) {
+ *         $body = $request->getBody();
+ *         assert($body instanceof Psr\Http\Message\StreamInterface);
+ *         assert($body instanceof React\Stream\ReadableStreamInterface);
+ *
+ *         return new React\Promise\Promise(function ($resolve) use ($body) {
+ *             $bytes = 0;
+ *             $body->on('data', function ($chunk) use (&$bytes) {
+ *                 $bytes += \count($chunk);
+ *             });
+ *             $body->on('close', function () use (&$bytes, $resolve) {
+ *                 $resolve(new React\Http\Response(
+ *                     200,
+ *                     [],
+ *                     "Received $bytes bytes\n"
+ *                 ));
+ *             });
+ *         });
+ *     }
+ * ));
+ * ```
+ *
+ * See also [streaming incoming request](../../README.md#streaming-incoming-request)
+ * for more details.
+ *
+ * Additionally, this middleware can be used in combination with the
+ * [`LimitConcurrentRequestsMiddleware`](#limitconcurrentrequestsmiddleware) and
+ * [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware) (see below)
+ * to explicitly configure the total number of requests that can be handled at
+ * once:
+ *
+ * ```php
+ * $server = new React\Http\Server(array(
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+ *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+ *     new React\Http\Middleware\RequestBodyParserMiddleware(),
+ *     $handler
+ * ));
+ * ```
+ *
+ * > Internally, this class is used as a "marker" to not trigger the default
+ *   request buffering behavior in the `Server`. It does not implement any logic
+ *   on its own.
+ */
+final class StreamingRequestMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, $next)
+    {
+        return $next($request);
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ namespace React\Http;
 
 use Evenement\EventEmitter;
 use React\Http\Io\IniUtil;
+use React\Http\Io\StreamingServer;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
@@ -14,15 +15,14 @@ use React\Socket\ServerInterface;
  * The `Server` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
- * It buffers and parses the complete incoming HTTP request in memory. Once the
- * complete request has been received, it will invoke the request handler function.
- * This request handler function needs to be passed to the constructor and will be
- * invoked with the respective [request](#request) object and expects a
- * [response](#response) object in return:
+ * When a complete HTTP request has been received, it will invoke the given
+ * request handler function. This request handler function needs to be passed to
+ * the constructor and will be invoked with the respective [request](#request)
+ * object and expects a [response](#response) object in return:
  *
  * ```php
- * $server = new Server(function (ServerRequestInterface $request) {
- *     return new Response(
+ * $server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
+ *     return new React\Http\Response(
  *         200,
  *         array(
  *             'Content-Type' => 'text/plain'
@@ -35,35 +35,36 @@ use React\Socket\ServerInterface;
  * Each incoming HTTP request message is always represented by the
  * [PSR-7 `ServerRequestInterface`](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface),
  * see also following [request](#request) chapter for more details.
+ *
  * Each outgoing HTTP response message is always represented by the
  * [PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface),
  * see also following [response](#response) chapter for more details.
  *
- * In order to process any connections, the server needs to be attached to an
- * instance of `React\Socket\ServerInterface` through the [`listen()`](#listen) method
- * as described in the following chapter. In its most simple form, you can attach
- * this to a [`React\Socket\Server`](https://github.com/reactphp/socket#server)
- * in order to start a plaintext HTTP server like this:
+ * In order to start listening for any incoming connections, the `Server` needs
+ * to be attached to an instance of
+ * [`React\Socket\ServerInterface`](https://github.com/reactphp/socket#serverinterface)
+ * through the [`listen()`](#listen) method as described in the following
+ * chapter. In its most simple form, you can attach this to a
+ * [`React\Socket\Server`](https://github.com/reactphp/socket#server) in order
+ * to start a plaintext HTTP server like this:
  *
  * ```php
- * $server = new Server($handler);
+ * $server = new React\Http\Server($handler);
  *
  * $socket = new React\Socket\Server('0.0.0.0:8080', $loop);
  * $server->listen($socket);
  * ```
  *
- * See also the [`listen()`](#listen) method and the [first example](examples) for more details.
+ * See also the [`listen()`](#listen) method and the [first example](../examples/)
+ * for more details.
  *
- * The `Server` class is built as a facade around the underlying
- * [`StreamingServer`](#streamingserver) to provide sane defaults for 80% of the
- * use cases and is the recommended way to use this library unless you're sure
- * you know what you're doing.
- *
- * Unlike the underlying [`StreamingServer`](#streamingserver), this class
- * buffers and parses the complete incoming HTTP request in memory. Once the
- * complete request has been received, it will invoke the request handler
- * function. This means the [request](#request) passed to your request handler
- * function will be fully compatible with PSR-7.
+ * By default, the `Server` buffers and parses the complete incoming HTTP
+ * request in memory. It will invoke the given request handler function when the
+ * complete request headers and request body has been received. This means the
+ * [request](#request) object passed to your request handler function will be
+ * fully compatible with PSR-7 (http-message). This provides sane defaults for
+ * 80% of the use cases and is the recommended way to use this library unless
+ * you're sure you know what you're doing.
  *
  * On the other hand, buffering complete HTTP requests in memory until they can
  * be processed by your request handler function means that this class has to
@@ -85,9 +86,9 @@ use React\Socket\ServerInterface;
  * max_file_uploads 20
  * ```
  *
- * In particular, the `post_max_size` setting limits how much memory a single HTTP
- * request is allowed to consume while buffering its request body. On top of
- * this, this class will try to avoid consuming more than 1/4 of your
+ * In particular, the `post_max_size` setting limits how much memory a single
+ * HTTP request is allowed to consume while buffering its request body. On top
+ * of this, this class will try to avoid consuming more than 1/4 of your
  * `memory_limit` for buffering multiple concurrent HTTP requests. As such, with
  * the above default settings of `128M` max, it will try to consume no more than
  * `32M` for buffering multiple concurrent HTTP requests. As a consequence, it
@@ -95,16 +96,52 @@ use React\Socket\ServerInterface;
  *
  * It is imperative that you assign reasonable values to your PHP ini settings.
  * It is usually recommended to either reduce the memory a single request is
- * allowed to take (set `post_max_size 1M` or less) or to increase the total memory
- * limit to allow for more concurrent requests (set `memory_limit 512M` or more).
- * Failure to do so means that this class may have to disable concurrency and
- * only handle one request at a time.
+ * allowed to take (set `post_max_size 1M` or less) or to increase the total
+ * memory limit to allow for more concurrent requests (set `memory_limit 512M`
+ * or more). Failure to do so means that this class may have to disable
+ * concurrency and only handle one request at a time.
  *
- * Internally, this class automatically assigns these limits to the
- * [middleware](#middleware) request handlers as described below. For more
- * advanced use cases, you may also use the advanced
- * [`StreamingServer`](#streamingserver) and assign these middleware request
- * handlers yourself as described in the following chapters.
+ * As an alternative to the above buffering defaults, you can also configure
+ * the `Server` explicitly to override these defaults. You can use the
+ * [`LimitConcurrentRequestsMiddleware`](#limitconcurrentrequestsmiddleware) and
+ * [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware) (see below)
+ * to explicitly configure the total number of requests that can be handled at
+ * once like this:
+ *
+ * ```php
+ * $server = new React\Http\Server(array(
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+ *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+ *     new React\Http\Middleware\RequestBodyParserMiddleware(),
+ *     $handler
+ * ));
+ * ```
+ *
+ * > Internally, this class automatically assigns these middleware handlers
+ *   automatically when no [`StreamingRequestMiddleware`](#streamingrequestmiddleware)
+ *   is given. Accordingly, you can use this example to override all default
+ *   settings to implement custom limits.
+ *
+ * As an alternative to buffering the complete request body in memory, you can
+ * also use a streaming approach where only small chunks of data have to be kept
+ * in memory:
+ *
+ * ```php
+ * $server = new React\Http\Server(array(
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     $handler
+ * ));
+ * ```
+ *
+ * In this case, it will invoke the request handler function once the HTTP
+ * request headers have been received, i.e. before receiving the potentially
+ * much larger HTTP request body. This means the [request](#request) passed to
+ * your request handler function may not be fully compatible with PSR-7. This is
+ * specifically designed to help with more advanced use cases where you want to
+ * have full control over consuming the incoming HTTP request body and
+ * concurrency settings. See also [streaming incoming request](#streaming-incoming-request)
+ * below for more details.
  */
 final class Server extends EventEmitter
 {
@@ -119,7 +156,15 @@ final class Server extends EventEmitter
     private $streamingServer;
 
     /**
-     * @see StreamingServer::__construct()
+     * Creates an HTTP server that invokes the given callback for each incoming HTTP request
+     *
+     * In order to process any connections, the server needs to be attached to an
+     * instance of `React\Socket\ServerInterface` which emits underlying streaming
+     * connections in order to then parse incoming data as HTTP.
+     * See also [listen()](#listen) for more details.
+     *
+     * @param callable|callable[] $requestHandler
+     * @see self::listen()
      */
     public function __construct($requestHandler)
     {
@@ -167,7 +212,53 @@ final class Server extends EventEmitter
     }
 
     /**
-     * @see StreamingServer::listen()
+     * Starts listening for HTTP requests on the given socket server instance
+     *
+     * The given [`React\Socket\ServerInterface`](https://github.com/reactphp/socket#serverinterface)
+     * is responsible for emitting the underlying streaming connections. This
+     * HTTP server needs to be attached to it in order to process any
+     * connections and pase incoming streaming data as incoming HTTP request
+     * messages. In its most common form, you can attach this to a
+     * [`React\Socket\Server`](https://github.com/reactphp/socket#server) in
+     * order to start a plaintext HTTP server like this:
+     *
+     * ```php
+     * $server = new React\Http\Server($handler);
+     *
+     * $socket = new React\Socket\Server(8080, $loop);
+     * $server->listen($socket);
+     * ```
+     *
+     * See also [example #1](examples) for more details.
+     *
+     * This example will start listening for HTTP requests on the alternative
+     * HTTP port `8080` on all interfaces (publicly). As an alternative, it is
+     * very common to use a reverse proxy and let this HTTP server listen on the
+     * localhost (loopback) interface only by using the listen address
+     * `127.0.0.1:8080` instead. This way, you host your application(s) on the
+     * default HTTP port `80` and only route specific requests to this HTTP
+     * server.
+     *
+     * Likewise, it's usually recommended to use a reverse proxy setup to accept
+     * secure HTTPS requests on default HTTPS port `443` (TLS termination) and
+     * only route plaintext requests to this HTTP server. As an alternative, you
+     * can also accept secure HTTPS requests with this HTTP server by attaching
+     * this to a [`React\Socket\Server`](https://github.com/reactphp/socket#server)
+     * using a secure TLS listen address, a certificate file and optional
+     * `passphrase` like this:
+     *
+     * ```php
+     * $server = new React\Http\Server($handler);
+     *
+     * $socket = new React\Socket\Server('tls://0.0.0.0:8443', $loop, array(
+     *     'local_cert' => __DIR__ . '/localhost.pem'
+     * ));
+     * $server->listen($socket);
+     * ```
+     *
+     * See also [example #11](examples) for more details.
+     *
+     * @param ServerInterface $socket
      */
     public function listen(ServerInterface $server)
     {

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace React\Tests\Http;
+namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\StreamingServer;
 use React\Http\Response;
-use React\Http\StreamingServer;
 use React\Promise\Promise;
 use React\Stream\ThroughStream;
+use React\Tests\Http\SocketServerStub;
+use React\Tests\Http\TestCase;
 
 class StreamingServerTest extends TestCase
 {

--- a/tests/Middleware/StreamingRequestMiddlewareTest.php
+++ b/tests/Middleware/StreamingRequestMiddlewareTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace React\Tests\Http\Middleware;
+
+use React\Http\Middleware\StreamingRequestMiddleware;
+use React\Http\Io\ServerRequest;
+use React\Http\Response;
+use React\Tests\Http\TestCase;
+
+class StreamingRequestMiddlewareTest extends TestCase
+{
+    public function testInvokeMiddlewareReturnsResponseFromFollowingHandler()
+    {
+        $middleware = new StreamingRequestMiddleware();
+
+        $response = new Response();
+        $ret = $middleware(new ServerRequest('GET', 'https://example.com/'), function () use ($response) {
+            return $response;
+        });
+
+        $this->assertSame($response, $ret);
+    }
+}


### PR DESCRIPTION
This changeset adds a new `StreamingRequestMiddleware` to stream incoming requests and marks the existing `StreamingServer` as internal:

```php
// unchanged: Server class is unchanged
$server = new React\Http\Server($handler);

// old: advanced StreamingServer is now internal only
$server = new React\Http\StreamingServer($handler);

// new: use StreamingRequestMiddleware instead of StreamingServer
$server = new React\Http\Server(array(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     $handler
));
```

I've tried to keep the changeset as minimal as possible and most changes are in fact documentation only. See also each individual commit. Among others, this allows us to streaming the documentation and will allow us to improve default buffering behavior as discussed in #365/#360 and others. This will be filed as a follow-up PR once this PR is in.

Resolves #343