### PR TITLE
Support skipping all online tests with `--exclude-group internet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2741,6 +2741,14 @@ To run the test suite, go to the project root and run:
 $ php vendor/bin/phpunit
 ```
 
+The test suite also contains a number of functional integration tests that rely
+on a stable internet connection.
+If you do not want to run these, they can simply be skipped like this:
+
+```bash
+$ php vendor/bin/phpunit --exclude-group internet
+```
+
 ## License
 
 MIT, see [LICENSE file](LICENSE).

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -101,6 +101,10 @@ class FunctionalIntegrationTest extends TestCase
     /** @group internet */
     public function testPostDataReturnsData()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
+        }
+
         $loop = Factory::create();
         $client = new Client($loop);
 
@@ -130,6 +134,10 @@ class FunctionalIntegrationTest extends TestCase
     /** @group internet */
     public function testPostJsonReturnsData()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
+        }
+
         $loop = Factory::create();
         $client = new Client($loop);
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -351,25 +351,25 @@ class FunctionalBrowserTest extends TestCase
     }
 
     /**
-     * @group online
+     * @group internet
      * @doesNotPerformAssertions
      */
     public function testCanAccessHttps()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
         }
 
         Block\await($this->browser->get('https://www.google.com/'), $this->loop);
     }
 
     /**
-     * @group online
+     * @group internet
      */
     public function testVerifyPeerEnabledForBadSslRejects()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
         }
 
         $connector = new Connector($this->loop, array(
@@ -385,13 +385,13 @@ class FunctionalBrowserTest extends TestCase
     }
 
     /**
-     * @group online
+     * @group internet
      * @doesNotPerformAssertions
      */
     public function testVerifyPeerDisabledForBadSslResolves()
     {
-        if (!function_exists('stream_socket_enable_crypto')) {
-            $this->markTestSkipped('Not supported on your platform (outdated HHVM?)');
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported on HHVM');
         }
 
         $connector = new Connector($this->loop, array(
@@ -406,7 +406,7 @@ class FunctionalBrowserTest extends TestCase
     }
 
     /**
-     * @group online
+     * @group internet
      */
     public function testInvalidPort()
     {

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -340,9 +340,6 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Unable to parse invalid request-line', $error->getMessage());
     }
 
-    /**
-     * @group a
-     */
     public function testInvalidMalformedRequestHeadersThrowsParseException()
     {
         $error = null;
@@ -362,9 +359,6 @@ class RequestHeaderParserTest extends TestCase
         $this->assertSame('Unable to parse invalid request header fields', $error->getMessage());
     }
 
-    /**
-     * @group a
-     */
     public function testInvalidMalformedRequestHeadersWhitespaceThrowsParseException()
     {
         $error = null;


### PR DESCRIPTION
This simple PR add supports for skipping all online tests with `vendor/bin/phpunit --exclude-group internet`.

Builds on top of #364, https://github.com/reactphp/http-client/pull/109 and others.