### PR TITLE
Expose ReactPHP in `User-Agent` and `Server` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,29 +1611,57 @@ create your own HTTP response message instead.
 When a response is returned from the request handler function, it will be
 processed by the [`Server`](#server) and then sent back to the client.
 
-The `Server` will automatically add the protocol version of the request, so you
-don't have to.
-
-A `Date` header will be automatically added with the system date and time if none is given.
-You can add a custom `Date` header yourself like this:
+A `Server: ReactPHP/1` response header will be added automatically. You can add
+a custom `Server` response header like this:
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
-    return new Response(
+$server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
         200,
         array(
-            'Date' => date('D, d M Y H:i:s T')
+            'Server' => 'PHP/3'
         )
     );
 });
 ```
 
-If you don't have a appropriate clock to rely on, you should
-unset this header with an empty string:
+If you do not want to send this `Sever` response header at all (such as when you
+don't want to expose the underlying server software), you can use an empty
+string value like this:
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
-    return new Response(
+$server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
+        200,
+        array(
+            'Server' => ''
+        )
+    );
+});
+```
+
+A `Date` response header will be added automatically with the current system
+date and time if none is given. You can add a custom `Date` response header
+like this:
+
+```php
+$server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
+        200,
+        array(
+            'Date' => gmdate('D, d M Y H:i:s \G\M\T')
+        )
+    );
+});
+```
+
+If you do not want to send this `Date` response header at all (such as when you
+don't have an appropriate clock to rely on), you can use an empty string value
+like this:
+
+```php
+$server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
         200,
         array(
             'Date' => ''
@@ -1642,33 +1670,10 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
 });
 ```
 
-Note that it will automatically assume a `X-Powered-By: react/alpha` header
-unless your specify a custom `X-Powered-By` header yourself:
-
-```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
-    return new Response(
-        200,
-        array(
-            'X-Powered-By' => 'PHP 3'
-        )
-    );
-});
-```
-
-If you do not want to send this header at all, you can use an empty string as
-value like this:
-
-```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
-    return new Response(
-        200,
-        array(
-            'X-Powered-By' => ''
-        )
-    );
-});
-```
+The `Server` class will automatically add the protocol version of the request,
+so you don't have to. For instance, if the client sends the request using the
+HTTP/1.1 protocol version, the response message will also use the same protocol
+version, no matter what version is returned from the request handler function.
 
 Note that persistent connections (`Connection: keep-alive`) are currently
 not supported.

--- a/src/Client/RequestData.php
+++ b/src/Client/RequestData.php
@@ -29,7 +29,7 @@ class RequestData
         $defaults = array_merge(
             array(
                 'Host'          => $this->getHost().$port,
-                'User-Agent'    => 'React/alpha',
+                'User-Agent'    => 'ReactPHP/1',
             ),
             $connectionHeaders,
             $authHeaders

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -244,11 +244,11 @@ final class StreamingServer extends EventEmitter
         $version = $request->getProtocolVersion();
         $response = $response->withProtocolVersion($version);
 
-        // assign default "X-Powered-By" header automatically
-        if (!$response->hasHeader('X-Powered-By')) {
-            $response = $response->withHeader('X-Powered-By', 'React/alpha');
-        } elseif ($response->getHeaderLine('X-Powered-By') === ''){
-            $response = $response->withoutHeader('X-Powered-By');
+        // assign default "Server" header automatically
+        if (!$response->hasHeader('Server')) {
+            $response = $response->withHeader('Server', 'ReactPHP/1');
+        } elseif ($response->getHeaderLine('Server') === ''){
+            $response = $response->withoutHeader('Server');
         }
 
         // assign default "Date" header from current time automatically

--- a/tests/Client/RequestDataTest.php
+++ b/tests/Client/RequestDataTest.php
@@ -14,7 +14,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -27,7 +27,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET /path?hello=world HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -40,7 +40,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET /?0 HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -53,7 +53,7 @@ class RequestDataTest extends TestCase
 
         $expected = "OPTIONS / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -66,7 +66,7 @@ class RequestDataTest extends TestCase
 
         $expected = "OPTIONS * HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -80,7 +80,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -131,7 +131,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -145,7 +145,7 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: React/alpha\r\n" .
+            "User-Agent: ReactPHP/1\r\n" .
             "Authorization: Basic am9objpkdW1teQ==\r\n" .
             "\r\n";
 

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -650,7 +650,7 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', array($data));
     }
 
-    public function testResponseContainsPoweredByHeader()
+    public function testResponseContainsServerHeader()
     {
         $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
             return new Response();
@@ -675,7 +675,7 @@ class StreamingServerTest extends TestCase
         $data = $this->createGetRequest();
         $this->connection->emit('data', array($data));
 
-        $this->assertContainsString("\r\nX-Powered-By: React/alpha\r\n", $buffer);
+        $this->assertContainsString("\r\nServer: ReactPHP/1\r\n", $buffer);
     }
 
     public function testResponsePendingPromiseWillNotSendAnything()
@@ -931,7 +931,7 @@ class StreamingServerTest extends TestCase
                 200,
                 array(
                     'date' => '',
-                    'x-powered-by' => '',
+                    'server' => '',
                     'Upgrade' => 'demo'
                 ),
                 'foo'
@@ -967,7 +967,7 @@ class StreamingServerTest extends TestCase
                 200,
                 array(
                     'date' => '',
-                    'x-powered-by' => ''
+                    'server' => ''
                 ),
                 'foo'
             );
@@ -1002,7 +1002,7 @@ class StreamingServerTest extends TestCase
                 101,
                 array(
                     'date' => '',
-                    'x-powered-by' => '',
+                    'server' => '',
                     'Upgrade' => 'demo'
                 ),
                 'foo'
@@ -1042,7 +1042,7 @@ class StreamingServerTest extends TestCase
                 101,
                 array(
                     'date' => '',
-                    'x-powered-by' => '',
+                    'server' => '',
                     'Upgrade' => 'demo'
                 ),
                 $stream
@@ -2171,7 +2171,7 @@ class StreamingServerTest extends TestCase
                         'session=abc'
                     ),
                     'Date' => '',
-                    'X-Powered-By' => ''
+                    'Server' => ''
                 )
             );
         });


### PR DESCRIPTION
The `Browser` now sends a `User-Agent: ReactPHP/1` request header (was `User-Agent: React/alpha`) by default.

The `Server` now sends a `Server: ReactPHP/1` response header (was `X-Powered-By: React/alpha`) by default.

Both can be overridden by explicitly assigning other header values as usual.