### PR TITLE
Improve documentation and use fully-qualified class names throughout the documentation  

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ See also the [Unix Domain Sockets (UDS) example](examples/14-client-unix-domain-
 
 ### Server
 
-The `Server` class is responsible for handling incoming connections and then
+The `React\Http\Server` class is responsible for handling incoming connections and then
 processing each incoming HTTP request.
 
 When a complete HTTP request has been received, it will invoke the given
@@ -923,11 +923,11 @@ which in turn extends the
 and will be passed to the callback function like this.
 
  ```php 
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $body = "The method of the request is: " . $request->getMethod();
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain'
@@ -966,10 +966,10 @@ The following parameters are currently available:
   Set to 'on' if the request used HTTPS, otherwise it won't be set
 
 ```php 
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain'
@@ -991,7 +991,7 @@ The `getQueryParams(): array` method can be used to get the query parameters
 similiar to the `$_GET` variable.
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -1001,7 +1001,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
         $body = 'The value of "foo" is: ' . htmlspecialchars($queryParams['foo']);
     }
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/html'
@@ -1045,10 +1045,10 @@ By default, this method will only return parsed data for requests using
 request headers (commonly used for `POST` requests for HTML form submission data).
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $name = $request->getParsedBody()['name'] ?? 'anonymous';
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(),
         "Hello $name!\n"
@@ -1069,11 +1069,11 @@ an XML (`Content-Type: application/xml`) request body (which is commonly used fo
 `POST`, `PUT` or `PATCH` requests in JSON-based or RESTful/RESTish APIs).
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $data = json_decode((string)$request->getBody());
     $name = $data->name ?? 'anonymous';
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array('Content-Type' => 'application/json'),
         json_encode(['message' => "Hello $name!"])
@@ -1092,11 +1092,11 @@ This array will only be filled when using the `Content-Type: multipart/form-data
 request header (commonly used for `POST` requests for HTML file uploads).
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $files = $request->getUploadedFiles();
     $name = isset($files['avatar']) ? $files['avatar']->getClientFilename() : 'nothing';
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(),
         "Uploaded $name\n"
@@ -1313,13 +1313,13 @@ The `getCookieParams(): string[]` method can be used to
 get all cookies sent with the current request.
 
 ```php 
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
         $body = "Your cookie value is: " . $request->getCookieParams()[$key];
 
-        return new Response(
+        return new React\Http\Message\Response(
             200,
             array(
                 'Content-Type' => 'text/plain'
@@ -1328,7 +1328,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
         );
     }
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain',
@@ -1385,7 +1385,7 @@ This projects ships a [`Response` class](#response) which implements the
 In its most simple form, you can use it like this:
 
 ```php 
-$server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         200,
         array(
@@ -1413,10 +1413,10 @@ To prevent this you SHOULD use a
 This example shows how such a long-term action could look like:
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) use ($loop) {
     return new Promise(function ($resolve, $reject) use ($loop) {
         $loop->addTimer(1.5, function() use ($resolve) {
-            $response = new Response(
+            $response = new React\Http\Message\Response(
                 200,
                 array(
                     'Content-Type' => 'text/plain'
@@ -1451,7 +1451,7 @@ Note that other implementations of the
 may only support strings.
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
@@ -1463,7 +1463,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
         $stream->end();
     });
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain'
@@ -1543,8 +1543,8 @@ added automatically. This is the most common use case, for example when using
 a `string` response body like this:
 
 ```php 
-$server = new Server($loop, function (ServerRequestInterface $request) {
-    return new Response(
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain'
@@ -1562,14 +1562,14 @@ response messages will contain the plain response body. If you know the length
 of your streaming response body, you MAY want to specify it explicitly like this:
 
 ```php
-$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
+$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) use ($loop) {
     $stream = new ThroughStream();
 
     $loop->addTimer(2.0, function () use ($stream) {
         $stream->end("Hello World!\n");
     });
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Length' => '13',
@@ -1765,14 +1765,14 @@ The following example adds a middleware request handler that adds the current ti
 header (`Request-Time`) and a final request handler that always returns a 200 code without a body: 
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    function (ServerRequestInterface $request, callable $next) {
+    function (Psr\Http\Message\ServerRequestInterface $request, callable $next) {
         $request = $request->withHeader('Request-Time', time());
         return $next($request);
     },
-    function (ServerRequestInterface $request) {
-        return new Response(200);
+    function (Psr\Http\Message\ServerRequestInterface $request) {
+        return new React\Http\Message\Response(200);
     }
 );
 ```
@@ -1790,16 +1790,16 @@ In order to simplify handling both paths, you can simply wrap this in a
 [`Promise\resolve()`](https://reactphp.org/promise/#resolve) call like this:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    function (ServerRequestInterface $request, callable $next) {
+    function (Psr\Http\Message\ServerRequestInterface $request, callable $next) {
         $promise = React\Promise\resolve($next($request));
         return $promise->then(function (ResponseInterface $response) {
             return $response->withHeader('Content-Type', 'text/html');
         });
     },
-    function (ServerRequestInterface $request) {
-        return new Response(200);
+    function (Psr\Http\Message\ServerRequestInterface $request) {
+        return new React\Http\Message\Response(200);
     }
 );
 ```
@@ -1813,25 +1813,25 @@ handling logic (or logging etc.) by wrapping this in a
 [`Promise`](https://reactphp.org/promise/#promise) like this:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    function (ServerRequestInterface $request, callable $next) {
+    function (Psr\Http\Message\ServerRequestInterface $request, callable $next) {
         $promise = new React\Promise\Promise(function ($resolve) use ($next, $request) {
             $resolve($next($request));
         });
         return $promise->then(null, function (Exception $e) {
-            return new Response(
+            return new React\Http\Message\Response(
                 500,
                 array(),
                 'Internal error: ' . $e->getMessage()
             );
         });
     },
-    function (ServerRequestInterface $request) {
+    function (Psr\Http\Message\ServerRequestInterface $request) {
         if (mt_rand(0, 1) === 1) {
             throw new RuntimeException('Database error');
         }
-        return new Response(200);
+        return new React\Http\Message\Response(200);
     }
 );
 ```
@@ -2376,7 +2376,7 @@ given setting applied.
 
 #### Response
 
-The `Response` class can be used to
+The `React\Http\Message\Response` class can be used to
 represent an outgoing server response message.
 
 ```php
@@ -2400,7 +2400,7 @@ which in turn extends the
 
 #### ServerRequest
 
-The `ServerRequest` class can be used to
+The `React\Http\Message\ServerRequest` class can be used to
 respresent an incoming server request message.
 
 This class implements the
@@ -2422,7 +2422,7 @@ application reacts to certain HTTP requests.
 
 #### StreamingRequestMiddleware
 
-The `StreamingRequestMiddleware` can be used to
+The `React\Http\Middleware\StreamingRequestMiddleware` can be used to
 process incoming requests with a streaming request body (without buffering).
 
 This allows you to process requests of any size without buffering the request
@@ -2480,7 +2480,7 @@ $server = new React\Http\Server(array(
 
 #### LimitConcurrentRequestsMiddleware
 
-The `LimitConcurrentRequestsMiddleware` can be used to
+The `React\Http\Middleware\LimitConcurrentRequestsMiddleware` can be used to
 limit how many next handlers can be executed concurrently.
 
 If this middleware is invoked, it will check if the number of pending
@@ -2498,9 +2498,9 @@ The following example shows how this middleware can be used to ensure no more
 than 10 handlers will be invoked at once:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    new LimitConcurrentRequestsMiddleware(10),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(10),
     $handler
 );
 ```
@@ -2510,12 +2510,12 @@ Similarly, this middleware is often used in combination with the
 to limit the total number of requests that can be buffered at once:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    new StreamingRequestMiddleware(),
-    new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
-    new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
-    new RequestBodyParserMiddleware(),
+    new React\Http\Middleware\StreamingRequestMiddleware(),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+    new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+    new React\Http\Middleware\RequestBodyParserMiddleware(),
     $handler
 );
 ```
@@ -2525,20 +2525,20 @@ that can be buffered at once and then ensure the actual request handler only
 processes one request after another without any concurrency:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    new StreamingRequestMiddleware(),
-    new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
-    new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
-    new RequestBodyParserMiddleware(),
-    new LimitConcurrentRequestsMiddleware(1), // only execute 1 handler (no concurrency)
+    new React\Http\Middleware\StreamingRequestMiddleware(),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+    new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+    new React\Http\Middleware\RequestBodyParserMiddleware(),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(1), // only execute 1 handler (no concurrency)
     $handler
 );
 ```
 
 #### RequestBodyBufferMiddleware
 
-One of the built-in middleware is the `RequestBodyBufferMiddleware` which
+One of the built-in middleware is the `React\Http\Middleware\RequestBodyBufferMiddleware` which
 can be used to buffer the whole incoming request body in memory.
 This can be useful if full PSR-7 compatibility is needed for the request handler
 and the default streaming request body handling is not needed.
@@ -2579,21 +2579,21 @@ the total number of concurrent requests.
 Usage:
 
 ```php
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    new StreamingRequestMiddleware(),
-    new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
-    new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
-    function (ServerRequestInterface $request) {
+    new React\Http\Middleware\StreamingRequestMiddleware(),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+    new React\Http\Middleware\RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
+    function (Psr\Http\Message\ServerRequestInterface $request) {
         // The body from $request->getBody() is now fully available without the need to stream it 
-        return new Response(200);
+        return new React\Http\Message\Response(200);
     },
 );
 ```
 
 #### RequestBodyParserMiddleware
 
-The `RequestBodyParserMiddleware` takes a fully buffered request body
+The `React\Http\Middleware\RequestBodyParserMiddleware` takes a fully buffered request body
 (generally from [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware)), 
 and parses the form values and file uploads from the incoming HTTP request body.
 
@@ -2613,14 +2613,14 @@ You can use `$contents = (string)$file->getStream();` to access the file
 contents and persist this to your favorite data store.
 
 ```php
-$handler = function (ServerRequestInterface $request) {
+$handler = function (Psr\Http\Message\ServerRequestInterface $request) {
     // If any, parsed form fields are now available from $request->getParsedBody()
     $body = $request->getParsedBody();
     $name = isset($body['name']) ? $body['name'] : 'unnamed';
 
     $files = $request->getUploadedFiles();
     $avatar = isset($files['avatar']) ? $files['avatar'] : null;
-    if ($avatar instanceof UploadedFileInterface) {
+    if ($avatar instanceof Psr\Http\Message\UploadedFileInterface) {
         if ($avatar->getError() === UPLOAD_ERR_OK) {
             $uploaded = $avatar->getSize() . ' bytes';
         } elseif ($avatar->getError() === UPLOAD_ERR_INI_SIZE) {
@@ -2632,7 +2632,7 @@ $handler = function (ServerRequestInterface $request) {
         $uploaded = 'nothing';
     }
 
-    return new Response(
+    return new React\Http\Message\Response(
         200,
         array(
             'Content-Type' => 'text/plain'
@@ -2641,12 +2641,12 @@ $handler = function (ServerRequestInterface $request) {
     );
 };
 
-$server = new Server(
+$server = new React\Http\Server(
     $loop,
-    new StreamingRequestMiddleware(),
-    new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
-    new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
-    new RequestBodyParserMiddleware(),
+    new React\Http\Middleware\StreamingRequestMiddleware(),
+    new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+    new React\Http\Middleware\RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
+    new React\Http\Middleware\RequestBodyParserMiddleware(),
     $handler
 );
 ```
@@ -2662,7 +2662,7 @@ explicitly passing the maximum filesize in bytes as the first parameter to the
 constructor like this:
 
 ```php
-new RequestBodyParserMiddleware(8 * 1024 * 1024); // 8 MiB limit per file
+new React\Http\Middleware\RequestBodyParserMiddleware(8 * 1024 * 1024); // 8 MiB limit per file
 ```
 
 By default, this middleware respects the
@@ -2678,7 +2678,7 @@ You can control the maximum number of file uploads per request by explicitly
 passing the second parameter to the constructor like this:
 
 ```php
-new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
+new React\Http\Middleware\RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
 ```
 
 > Note that this middleware handler simply parses everything that is already
@@ -2712,7 +2712,7 @@ new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
 
 ### ResponseException
 
-The `ResponseException` is an `Exception` sub-class that will be used to reject
+The `React\Http\Message\ResponseException` is an `Exception` sub-class that will be used to reject
 a request promise if the remote server returns a non-success status code
 (anything but 2xx or 3xx).
 You can control this behavior via the [`withRejectErrorResponse()` method](#withrejecterrorresponse).

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ multiple concurrent HTTP requests without blocking.
     * [React\Http\Message](#reacthttpmessage)
         * [Response](#response)
         * [ServerRequest](#serverrequest)
+        * [ResponseException](#responseexception)
     * [React\Http\Middleware](#reacthttpmiddleware)
         * [StreamingRequestMiddleware](#streamingrequestmiddleware)
         * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
         * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
         * [RequestBodyParserMiddleware](#requestbodyparsermiddleware)
-    * [ResponseException](#responseexception)
 * [Install](#install)
 * [Tests](#tests)
 * [License](#license)
@@ -2418,6 +2418,19 @@ application reacts to certain HTTP requests.
   request message and only adds required server methods. This base class is
   considered an implementation detail that may change in the future.
 
+#### ResponseException
+
+The `React\Http\Message\ResponseException` is an `Exception` sub-class that will be used to reject
+a request promise if the remote server returns a non-success status code
+(anything but 2xx or 3xx).
+You can control this behavior via the [`withRejectErrorResponse()` method](#withrejecterrorresponse).
+
+The `getCode(): int` method can be used to
+return the HTTP response status code.
+
+The `getResponse(): ResponseInterface` method can be used to
+access its underlying response object.
+
 ### React\Http\Middleware
 
 #### StreamingRequestMiddleware
@@ -2709,19 +2722,6 @@ new React\Http\Middleware\RequestBodyParserMiddleware(10 * 1024, 100); // 100 fi
   is left up to higher-level implementations.
   If you want to respect this setting, you have to check its value and
   effectively avoid using this middleware entirely.
-
-### ResponseException
-
-The `React\Http\Message\ResponseException` is an `Exception` sub-class that will be used to reject
-a request promise if the remote server returns a non-success status code
-(anything but 2xx or 3xx).
-You can control this behavior via the [`withRejectErrorResponse()` method](#withrejecterrorresponse).
-
-The `getCode(): int` method can be used to
-return the HTTP response status code.
-
-The `getResponse(): ResponseInterface` method can be used to
-access its underlying response object.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ multiple concurrent HTTP requests without blocking.
         * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
         * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
         * [RequestBodyParserMiddleware](#requestbodyparsermiddleware)
-    * [ResponseInterface](#responseinterface)
-    * [RequestInterface](#requestinterface)
     * [ResponseException](#responseexception)
 * [Install](#install)
 * [Tests](#tests)
@@ -160,14 +158,16 @@ method. If you want to use any other or even custom HTTP request method, you can
 use the [`request()`](#request) method.
 
 Each of the above methods supports async operation and either *fulfills* with a
-[`ResponseInterface`](#responseinterface) or *rejects* with an `Exception`.
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+or *rejects* with an `Exception`.
 Please see the following chapter about [promises](#promises) for more details.
 
 ### Promises
 
 Sending requests is async (non-blocking), so you can actually send multiple
 requests in parallel.
-The `Browser` will respond to each request with a [`ResponseInterface`](#responseinterface)
+The `Browser` will respond to each request with a
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
 message, the order is not guaranteed.
 Sending requests uses a [Promise](https://github.com/reactphp/promise)-based
 interface that makes it easy to react to when an HTTP request is completed
@@ -474,11 +474,12 @@ the response body in small chunks as data is received and forwards this data
 through [ReactPHP's Stream API](https://github.com/reactphp/stream). This works
 for (any number of) responses of arbitrary sizes.
 
-This means it resolves with a normal [`ResponseInterface`](#responseinterface),
+This means it resolves with a normal
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface),
 which can be used to access the response message parameters as usual.
 You can access the message body as usual, however it now also
-implements ReactPHP's [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
-as well as parts of the PSR-7's [`StreamInterface`](https://www.php-fig.org/psr/psr-7/#3-4-psr-http-message-streaminterface).
+implements [ReactPHP's `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+as well as parts of the [PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface).
 
 ```php
 $browser->requestStreaming('GET', $url)->then(function (Psr\Http\Message\ResponseInterface $response) {
@@ -568,7 +569,7 @@ Besides streaming the response body, you can also stream the request body.
 This can be useful if you want to send big POST requests (uploading files etc.)
 or process many outgoing streams at once.
 Instead of passing the body as a string, you can simply pass an instance
-implementing ReactPHP's [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+implementing [ReactPHP's `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
 to the [request methods](#request-methods) like this:
 
 ```php
@@ -620,7 +621,7 @@ $connector = new React\Socket\Connector($loop, array(
 $browser = new React\Http\Browser($loop, $connector);
 ```
 
-See also the [HTTP CONNECT proxy example](examples/11-http-connect-proxy.php).
+See also the [HTTP CONNECT proxy example](examples/11-client-http-connect-proxy.php).
 
 ### SOCKS proxy
 
@@ -647,7 +648,7 @@ $connector = new React\Socket\Connector($loop, array(
 $browser = new React\Http\Browser($loop, $connector);
 ```
 
-See also the [SOCKS proxy example](examples/12-socks-proxy.php).
+See also the [SOCKS proxy example](examples/12-client-socks-proxy.php).
 
 ### SSH proxy
 
@@ -676,7 +677,7 @@ $connector = new React\Socket\Connector($loop, array(
 $browser = new React\Http\Browser($loop, $connector);
 ```
 
-See also the [SSH proxy example](examples/13-ssh-proxy.php).
+See also the [SSH proxy example](examples/13-client-ssh-proxy.php).
 
 ### Unix domain sockets
 
@@ -701,7 +702,7 @@ $client->get('http://localhost/info')->then(function (Psr\Http\Message\ResponseI
 });
 ```
 
-See also the [Unix Domain Sockets (UDS) example](examples/14-unix-domain-sockets.php).
+See also the [Unix Domain Sockets (UDS) example](examples/14-client-unix-domain-sockets.php).
 
 
 ## Server Usage
@@ -916,9 +917,9 @@ incoming connections and then processing each incoming HTTP request.
 The request object will be processed once the request has
 been received by the client.
 This request object implements the
-[PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface)
+[PSR-7 `ServerRequestInterface`](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface)
 which in turn extends the
-[PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface)
+[PSR-7 `RequestInterface`](https://www.php-fig.org/psr/psr-7/#32-psrhttpmessagerequestinterface)
 and will be passed to the callback function like this.
 
  ```php 
@@ -937,9 +938,9 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
 ```
 
 For more details about the request object, also check out the documentation of
-[PSR-7 ServerRequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#321-psrhttpmessageserverrequestinterface)
+[PSR-7 `ServerRequestInterface`](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface)
 and
-[PSR-7 RequestInterface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#32-psrhttpmessagerequestinterface).
+[PSR-7 `RequestInterface`](https://www.php-fig.org/psr/psr-7/#32-psrhttpmessagerequestinterface).
 
 #### Request parameters
 
@@ -1149,16 +1150,19 @@ access the request body stream.
 In the streaming mode, this method returns a stream instance that implements both the
 [PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface)
 and the [ReactPHP `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface).
-However, most of the PSR-7 `StreamInterface` methods have been
-designed under the assumption of being in control of a synchronous request body.
+However, most of the
+[PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface)
+methods have been designed under the assumption of being in control of a
+synchronous request body.
 Given that this does not apply to this server, the following
-PSR-7 `StreamInterface` methods are not used and SHOULD NOT be called:
+[PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface)
+methods are not used and SHOULD NOT be called:
 `tell()`, `eof()`, `seek()`, `rewind()`, `write()` and `read()`.
 If this is an issue for your use case and/or you want to access uploaded files,
 it's highly recommended to use a buffered [request body](#request-body) or use the
 [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware) instead.
-The ReactPHP `ReadableStreamInterface` gives you access to the incoming
-request body as the individual chunks arrive:
+The [ReactPHP `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+gives you access to the incoming request body as the individual chunks arrive:
 
 ```php
 $server = new React\Http\Server(
@@ -1223,7 +1227,7 @@ A response message can still be sent (unless the connection is already closed).
 A `close` event will be emitted after an `error` or `end` event.
 
 For more details about the request body stream, check out the documentation of
-[ReactPHP ReadableStreamInterface](https://github.com/reactphp/stream#readablestreaminterface).
+[ReactPHP `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface).
 
 The `getSize(): ?int` method can be used to
 get the size of the request body, similar to PHP's `$_SERVER['CONTENT_LENGTH']` variable.
@@ -1371,13 +1375,14 @@ responsible for processing the request and returning a response, which will be
 delivered to the client.
 
 This function MUST return an instance implementing
-[PSR-7 `ResponseInterface`](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#33-psrhttpmessageresponseinterface)
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
 object or a 
 [ReactPHP Promise](https://github.com/reactphp/promise)
-which resolves with a PSR-7 `ResponseInterface` object.
+which resolves with a [PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface) object.
 
-This projects ships a [`Response` class](#response) which implements the PSR-7
-`ResponseInterface`. In its most simple form, you can use it like this:
+This projects ships a [`Response` class](#response) which implements the
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface).
+In its most simple form, you can use it like this:
 
 ```php 
 $server = new React\Http\Server($loop, function (ServerRequestInterface $request) {
@@ -1392,7 +1397,8 @@ $server = new React\Http\Server($loop, function (ServerRequestInterface $request
 ```
 
 We use this [`Response` class](#response) throughout our project examples, but
-feel free to use any other implementation of the PSR-7 `ResponseInterface`.
+feel free to use any other implementation of the
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface).
 See also the [`Response` class](#response) for more details.
 
 #### Deferred response
@@ -1437,11 +1443,12 @@ If a promise is resolved after the client closes, it will simply be ignored.
 #### Streaming outgoing response
 
 The `Response` class in this project supports to add an instance which implements the
-[ReactPHP ReadableStreamInterface](https://github.com/reactphp/stream#readablestreaminterface)
+[ReactPHP `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
 for the response body.
 So you are able stream data directly into the response body.
-Note that other implementations of the `PSR-7 ResponseInterface` likely
-only support strings.
+Note that other implementations of the
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+may only support strings.
 
 ```php
 $server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
@@ -1494,8 +1501,9 @@ in this case (if applicable).
   writable side of the stream.
   This can be avoided by either rejecting all requests with the `CONNECT`
   method (which is what most *normal* origin HTTP servers would likely do) or
-  or ensuring that only ever an instance of `ReadableStreamInterface` is
-  used.
+  or ensuring that only ever an instance of
+  [ReactPHP's `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+  is used.
 >
 > The `101` (Switching Protocols) response code is useful for the more advanced
   `Upgrade` requests, such as upgrading to the WebSocket protocol or
@@ -1711,13 +1719,17 @@ As such, this project supports the concept of middleware request handlers.
 A middleware request handler is expected to adhere the following rules:
 
 * It is a valid `callable`.
-* It accepts `ServerRequestInterface` as first argument and an optional
-  `callable` as second argument.
+* It accepts an instance implementing
+  [PSR-7 `ServerRequestInterface`](https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface)
+  as first argument and an optional `callable` as second argument.
 * It returns either:
-  * An instance implementing `ResponseInterface` for direct consumption.
+  * An instance implementing
+    [PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+    for direct consumption.
   * Any promise which can be consumed by
     [`Promise\resolve()`](https://reactphp.org/promise/#resolve) resolving to a
-  `ResponseInterface` for deferred consumption.
+    [PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+    for deferred consumption.
   * It MAY throw an `Exception` (or return a rejected promise) in order to
     signal an error condition and abort the chain.
 * It calls `$next($request)` to continue processing the next middleware
@@ -1772,8 +1784,8 @@ $server = new Server(
 Similarly, you can use the result of the `$next` middleware request handler
 function to modify the outgoing response.
 Note that as per the above documentation, the `$next` middleware request handler may return a
-`ResponseInterface` directly or one wrapped in a promise for deferred
-resolution.
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+directly or one wrapped in a promise for deferred resolution.
 In order to simplify handling both paths, you can simply wrap this in a
 [`Promise\resolve()`](https://reactphp.org/promise/#resolve) call like this:
 
@@ -1840,8 +1852,9 @@ encourages third-party middleware implementations.
 While we would love to support PSR-15 directly in `react/http`, we understand
 that this interface does not specifically target async APIs and as such does
 not take advantage of promises for [deferred responses](#deferred-response).
-The gist of this is that where PSR-15 enforces a `ResponseInterface` return
-value, we also accept a `PromiseInterface<ResponseInterface>`.
+The gist of this is that where PSR-15 enforces a
+[PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
+return value, we also accept a `PromiseInterface<ResponseInterface>`.
 As such, we suggest using the external
 [PSR-15 middleware adapter](https://github.com/friends-of-reactphp/http-middleware-psr15-adapter)
 that uses on the fly monkey patching of these return values which makes using
@@ -2116,7 +2129,7 @@ $browser->requestStreaming('GET', $url)->then(function (Psr\Http\Message\Respons
 });
 ```
 
-See also [`ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
+See also [ReactPHP's `ReadableStreamInterface`](https://github.com/reactphp/stream#readablestreaminterface)
 and the [streaming response](#streaming-response) for more details,
 examples and possible use-cases.
 
@@ -2381,10 +2394,9 @@ This class implements the
 which in turn extends the
 [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
 
-> Internally, this class extends the underlying `\RingCentral\Psr7\Response`
-  class. The only difference is that this class will accept implemenations
-  of ReactPHPs `ReadableStreamInterface` for the `$body` argument. This base
-  class is considered an implementation detail that may change in the future.
+> Internally, this implementation builds on top of an existing incoming
+  response message and only adds required streaming support. This base class is
+  considered an implementation detail that may change in the future.
 
 #### ServerRequest
 
@@ -2593,7 +2605,8 @@ Instead of relying on these superglobals, you can use the
 `$request->getParsedBody()` and `$request->getUploadedFiles()` methods
 as defined by PSR-7.
 
-Accordingly, each file upload will be represented as instance implementing [`UploadedFileInterface`](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md#36-psrhttpmessageuploadedfileinterface).
+Accordingly, each file upload will be represented as instance implementing the
+[PSR-7 `UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface).
 Due to its blocking nature, the `moveTo()` method is not available and throws
 a `RuntimeException` instead.
 You can use `$contents = (string)$file->getStream();` to access the file
@@ -2697,26 +2710,6 @@ new RequestBodyParserMiddleware(10 * 1024, 100); // 100 files with 10 KiB each
   If you want to respect this setting, you have to check its value and
   effectively avoid using this middleware entirely.
 
-### ResponseInterface
-
-The `Psr\Http\Message\ResponseInterface` represents the incoming response received from the [`Browser`](#browser).
-
-This is a standard interface defined in
-[PSR-7: HTTP message interfaces](https://www.php-fig.org/psr/psr-7/), see its
-[`ResponseInterface` definition](https://www.php-fig.org/psr/psr-7/#3-3-psr-http-message-responseinterface)
-which in turn extends the
-[`MessageInterface` definition](https://www.php-fig.org/psr/psr-7/#3-1-psr-http-message-messageinterface).
-
-### RequestInterface
-
-The `Psr\Http\Message\RequestInterface` represents the outgoing request to be sent via the [`Browser`](#browser).
-
-This is a standard interface defined in
-[PSR-7: HTTP message interfaces](https://www.php-fig.org/psr/psr-7/), see its
-[`RequestInterface` definition](https://www.php-fig.org/psr/psr-7/#3-2-psr-http-message-requestinterface)
-which in turn extends the
-[`MessageInterface` definition](https://www.php-fig.org/psr/psr-7/#3-1-psr-http-message-messageinterface).
-
 ### ResponseException
 
 The `ResponseException` is an `Exception` sub-class that will be used to reject
@@ -2728,7 +2721,7 @@ The `getCode(): int` method can be used to
 return the HTTP response status code.
 
 The `getResponse(): ResponseInterface` method can be used to
-access its underlying [`ResponseInterface`](#responseinterface) object.
+access its underlying response object.
 
 ## Install
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -2,16 +2,15 @@
 
 namespace React\Http;
 
+use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\LoopInterface;
 use React\Http\Io\Sender;
 use React\Http\Io\Transaction;
 use React\Http\Message\MessageFactory;
-use InvalidArgumentException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\UriInterface;
-use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
+use InvalidArgumentException;
 
 /**
  * @final This class is final and shouldn't be extended as it is likely to be marked final in a future relase.
@@ -719,7 +718,7 @@ class Browser
 
     /**
      * @param string                         $method
-     * @param string|UriInterface            $url
+     * @param string                         $url
      * @param array                          $headers
      * @param string|ReadableStreamInterface $contents
      * @return PromiseInterface<ResponseInterface,Exception>

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -4,9 +4,9 @@ namespace React\Http;
 
 use Psr\Http\Message\ResponseInterface;
 use React\EventLoop\LoopInterface;
+use React\Http\Io\MessageFactory;
 use React\Http\Io\Sender;
 use React\Http\Io\Transaction;
-use React\Http\Message\MessageFactory;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;

--- a/src/Io/MessageFactory.php
+++ b/src/Io/MessageFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\Http\Message;
+namespace React\Http\Io;
 
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;

--- a/src/Io/ReadableBodyStream.php
+++ b/src/Io/ReadableBodyStream.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace React\Http\Message;
+namespace React\Http\Io;
 
 use Evenement\EventEmitter;
 use Psr\Http\Message\StreamInterface;

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -2,7 +2,6 @@
 
 namespace React\Http\Io;
 
-use React\Http\Message\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Client\Client as HttpClient;

--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -2,12 +2,11 @@
 
 namespace React\Http\Io;
 
-use React\Http\Message\ResponseException;
-use React\Http\Message\MessageFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use React\EventLoop\LoopInterface;
+use React\Http\Message\ResponseException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Stream\ReadableStreamInterface;

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -25,10 +25,9 @@ use Psr\Http\Message\StreamInterface;
  * which in turn extends the
  * [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
  *
- * > Internally, this class extends the underlying `\RingCentral\Psr7\Response`
- *   class. The only difference is that this class will accept implemenations
- *   of ReactPHPs `ReadableStreamInterface` for the `$body` argument. This base
- *   class is considered an implementation detail that may change in the future.
+ * > Internally, this implementation builds on top of an existing incoming
+ *   response message and only adds required streaming support. This base class is
+ *   considered an implementation detail that may change in the future.
  *
  * @see \Psr\Http\Message\ResponseInterface
  */

--- a/src/Message/ResponseException.php
+++ b/src/Message/ResponseException.php
@@ -32,7 +32,7 @@ final class ResponseException extends RuntimeException
     }
 
     /**
-     * Access its underlying [`ResponseInterface`](#responseinterface) object.
+     * Access its underlying response object.
      *
      * @return ResponseInterface
      */

--- a/src/Message/ResponseException.php
+++ b/src/Message/ResponseException.php
@@ -6,7 +6,7 @@ use RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * The `ResponseException` is an `Exception` sub-class that will be used to reject
+ * The `React\Http\Message\ResponseException` is an `Exception` sub-class that will be used to reject
  * a request promise if the remote server returns a non-success status code
  * (anything but 2xx or 3xx).
  * You can control this behavior via the [`withRejectErrorResponse()` method](#withrejecterrorresponse).

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -29,10 +29,10 @@ use React\Stream\ReadableStreamInterface;
  * than 10 handlers will be invoked at once:
  *
  * ```php
- * $server = new Server(
+ * $server = new React\Http\Server(
  *     $loop,
- *     new StreamingRequestMiddleware(),
- *     new LimitConcurrentRequestsMiddleware(10),
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(10),
  *     $handler
  * );
  * ```
@@ -42,12 +42,12 @@ use React\Stream\ReadableStreamInterface;
  * to limit the total number of requests that can be buffered at once:
  *
  * ```php
- * $server = new Server(
+ * $server = new React\Http\Server(
  *     $loop,
- *     new StreamingRequestMiddleware(),
- *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
- *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
- *     new RequestBodyParserMiddleware(),
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+ *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+ *     new React\Http\Middleware\RequestBodyParserMiddleware(),
  *     $handler
  * );
  * ```
@@ -57,13 +57,13 @@ use React\Stream\ReadableStreamInterface;
  * processes one request after another without any concurrency:
  *
  * ```php
- * $server = new Server(
+ * $server = new React\Http\Server(
  *     $loop,
- *     new StreamingRequestMiddleware(),
- *     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
- *     new RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
- *     new RequestBodyParserMiddleware(),
- *     new LimitConcurrentRequestsMiddleware(1), // only execute 1 handler (no concurrency)
+ *     new React\Http\Middleware\StreamingRequestMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
+ *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
+ *     new React\Http\Middleware\RequestBodyParserMiddleware(),
+ *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(1), // only execute 1 handler (no concurrency)
  *     $handler
  * );
  * ```

--- a/src/Server.php
+++ b/src/Server.php
@@ -14,7 +14,7 @@ use React\Http\Middleware\RequestBodyParserMiddleware;
 use React\Socket\ServerInterface;
 
 /**
- * The `Server` class is responsible for handling incoming connections and then
+ * The `React\Http\Server` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
  * When a complete HTTP request has been received, it will invoke the given
@@ -292,9 +292,9 @@ final class Server extends EventEmitter
      *
      * @param ServerInterface $socket
      */
-    public function listen(ServerInterface $server)
+    public function listen(ServerInterface $socket)
     {
-        $this->streamingServer->listen($server);
+        $this->streamingServer->listen($socket);
     }
 
     /**

--- a/tests/Io/MessageFactoryTest.php
+++ b/tests/Io/MessageFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace React\Tests\Http\Message;
+namespace React\Tests\Http\Io;
 
-use React\Http\Message\MessageFactory;
+use React\Http\Io\MessageFactory;
 use PHPUnit\Framework\TestCase;
 
 class MessageFactoryTest extends TestCase

--- a/tests/Io/ReadableBodyStreamTest.php
+++ b/tests/Io/ReadableBodyStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace React\Tests\Http\Message;
+namespace React\Tests\Http\Io;
 
-use React\Http\Message\ReadableBodyStream;
+use React\Http\Io\ReadableBodyStream;
 use React\Tests\Http\TestCase;
 use React\Stream\ThroughStream;
 

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -5,8 +5,8 @@ namespace React\Tests\Http\Io;
 use Clue\React\Block;
 use React\Http\Client\Client as HttpClient;
 use React\Http\Client\RequestData;
+use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
-use React\Http\Message\ReadableBodyStream;
 use React\Promise;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
@@ -26,7 +26,7 @@ class SenderTest extends TestCase
 
     public function testCreateFromLoop()
     {
-        $sender = Sender::createFromLoop($this->loop, null, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = Sender::createFromLoop($this->loop, null, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $this->assertInstanceOf('React\Http\Io\Sender', $sender);
     }
@@ -36,7 +36,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->never())->method('connect');
 
-        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('GET', 'www.google.com');
 
@@ -51,7 +51,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\reject(new \RuntimeException('Rejected')));
 
-        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -71,7 +71,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('POST', 'http://www.google.com/', array(), 'hello');
         $sender->send($request);
@@ -87,7 +87,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('POST', 'http://www.google.com/', array(), '');
         $sender->send($request);
@@ -106,7 +106,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array(), new ReadableBodyStream($stream));
@@ -122,7 +122,7 @@ class SenderTest extends TestCase
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array(), new ReadableBodyStream($stream));
@@ -142,7 +142,7 @@ class SenderTest extends TestCase
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array(), new ReadableBodyStream($stream));
@@ -162,7 +162,7 @@ class SenderTest extends TestCase
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $expected = new \RuntimeException();
         $stream = new ThroughStream();
@@ -192,7 +192,7 @@ class SenderTest extends TestCase
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array(), new ReadableBodyStream($stream));
@@ -220,7 +220,7 @@ class SenderTest extends TestCase
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->willReturn($outgoing);
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array(), new ReadableBodyStream($stream));
@@ -247,7 +247,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://www.google.com/', array('Content-Length' => '100'), new ReadableBodyStream($stream));
@@ -264,7 +264,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('GET', 'http://www.google.com/');
         $sender->send($request);
@@ -280,7 +280,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('CUSTOM', 'http://www.google.com/');
         $sender->send($request);
@@ -296,7 +296,7 @@ class SenderTest extends TestCase
             '1.1'
         )->willReturn($this->getMockBuilder('React\Http\Client\Request')->disableOriginalConstructor()->getMock());
 
-        $sender = new Sender($client, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($client, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('CUSTOM', 'http://www.google.com/', array('Content-Length' => '0'));
         $sender->send($request);
@@ -311,7 +311,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn($promise);
 
-        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -330,7 +330,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($connection));
 
-        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender(new HttpClient($this->loop, $connector), $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -387,7 +387,7 @@ class SenderTest extends TestCase
 
         $http->expects($this->once())->method('request')->with($method, $uri, $headers, $protocolVersion)->willReturn($request);
 
-        $sender = new Sender($http, $this->getMockBuilder('React\Http\Message\MessageFactory')->getMock());
+        $sender = new Sender($http, $this->getMockBuilder('React\Http\Io\MessageFactory')->getMock());
         $sender->send($Request);
     }
 }

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -3,16 +3,16 @@
 namespace React\Tests\Http\Io;
 
 use Clue\React\Block;
-use React\Http\Io\Transaction;
-use React\Http\Message\MessageFactory;
-use React\Http\Message\ResponseException;
-use React\Tests\Http\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\RequestInterface;
+use React\Http\Io\MessageFactory;
+use React\Http\Io\Transaction;
+use React\Http\Message\ResponseException;
 use React\EventLoop\Factory;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
 use RingCentral\Psr7\Response;
 
 class TransactionTest extends TestCase


### PR DESCRIPTION
This simple changeset improves the documentation by updating all references and moves around some internal classes to ease documentation of the `Message` namespace. It does not affect the public APIs.

Builds on top of #374 and #370