### PR TITLE
Support PHP 8, update to reactphp/socket v1.6 and adjust type checks for invalid chunk headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "react/event-loop": "^1.0 || ^0.5",
         "react/promise": "^2.3 || ^1.2.1",
         "react/promise-stream": "^1.1",
-        "react/socket": "^1.1",
-        "react/stream": "^1.0 || ^0.7.5",
+        "react/socket": "^1.6",
+        "react/stream": "^1.1",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -119,7 +119,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop, array('tcp' => array('backlog' => 511)));
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/src/Io/ChunkedDecoder.php
+++ b/src/Io/ChunkedDecoder.php
@@ -123,7 +123,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
                 }
 
                 $this->chunkSize = @\hexdec($hexValue);
-                if (\dechex($this->chunkSize) !== $hexValue) {
+                if (!\is_int($this->chunkSize) || \dechex($this->chunkSize) !== $hexValue) {
                     $this->handleError(new Exception($hexValue . ' is not a valid hexadecimal number'));
                     return;
                 }


### PR DESCRIPTION
This changeset adds supports for PHP 8. 🎉

Update to reactphp/socket v1.6 (support PHP 8), specifically https://github.com/reactphp/socket/pull/246. Additionally, `dechex()` throws a type error as of PHP 8 beta 2 (https://3v4l.org/RHg0i) that can be exhibited when trying to verify excessive chunk headers that exceed integer bounds. This is similar to #357 which adjusted this for PHP 7.4 recently.

This means this component now supports PHP 8 just fine 🎉

```bash
$ docker run -it --rm --net host -v `pwd`:/data --workdir /data php:8.0.0beta2-cli-alpine php vendor/bin/phpunit                                                                          
PHPUnit 9.3.8 by Sebastian Bergmann and contributors.                                                                                                                                                                         
                                                                                                                                                                                                                              
Warning:       Your XML configuration validates against a deprecated schema.                                                                                                                                                  
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!                                                                                                                                                
                                                                                                                                                                                                                              
.............................................................W.  63 / 673 (  9%)                                                                                                                                              
.......WWWW.................................................... 126 / 673 ( 18%)                                                                                                                                              
.........SS...S...........W.W......WWWW.............W......W... 189 / 673 ( 28%)                                                                                                                                              
............................................................... 252 / 673 ( 37%)                                                                                                                                              
............................................................... 315 / 673 ( 46%)                                                                                                                                              
............................................................... 378 / 673 ( 56%)                                                                                                                                              
............................................................... 441 / 673 ( 65%)                                                                                                                                              
............................................................... 504 / 673 ( 74%)                                                                                                                                              
...................................................WWWWW..WW..W 567 / 673 ( 84%)                                                                                                                                              
............................................................... 630 / 673 ( 93%)                                                                                                                                              
...........................................                     673 / 673 (100%)                                                                                                                                              
                                                                                                                                                                                                                              
Time: 00:16.701, Memory: 20.00 MB                                                                                                                                                                                             
                                                                                                                                                                                                                              
There were 21 warnings:

…

WARNINGS!
Tests: 673, Assertions: 1591, Warnings: 21, Skipped: 3.
```

This currently reports a bunch of warnings due to some deprecations introduced in PHPUnit 9.3, but it works perfectly fine otherwise. In other words, you will currently see the same warning in the test output for PHP 7.4 and the test suite passes just fine on all supported PHP versions. I've discussed these deprecation warnings with @SimonFrings who will address this with a follow-up PR for #364.