### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and replace deprecated at() Mocks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -23,9 +23,10 @@ matrix:
     - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
   - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest -n; fi
 
 script:
-  - ./vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi
   - if [ "$DEPENDENCIES" = "lowest" ]; then php -n tests/benchmark-middleware-runner.php; fi

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "clue/http-proxy-react": "^1.3",
         "clue/reactphp-ssh-proxy": "^1.0",
         "clue/socks-react": "^1.0",
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "React\\Http\\": "src" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Client/RequestTest.php
+++ b/tests/Client/RequestTest.php
@@ -36,46 +36,21 @@ class RequestTest extends TestCase
 
         $this->successfulConnectionMock();
 
-        $this->stream
-            ->expects($this->at(0))
-            ->method('on')
-            ->with('drain', $this->identicalTo(array($request, 'handleDrain')));
-        $this->stream
-            ->expects($this->at(1))
-            ->method('on')
-            ->with('data', $this->identicalTo(array($request, 'handleData')));
-        $this->stream
-            ->expects($this->at(2))
-            ->method('on')
-            ->with('end', $this->identicalTo(array($request, 'handleEnd')));
-        $this->stream
-            ->expects($this->at(3))
-            ->method('on')
-            ->with('error', $this->identicalTo(array($request, 'handleError')));
-        $this->stream
-            ->expects($this->at(4))
-            ->method('on')
-            ->with('close', $this->identicalTo(array($request, 'handleClose')));
-        $this->stream
-            ->expects($this->at(6))
-            ->method('removeListener')
-            ->with('drain', $this->identicalTo(array($request, 'handleDrain')));
-        $this->stream
-            ->expects($this->at(7))
-            ->method('removeListener')
-            ->with('data', $this->identicalTo(array($request, 'handleData')));
-        $this->stream
-            ->expects($this->at(8))
-            ->method('removeListener')
-            ->with('end', $this->identicalTo(array($request, 'handleEnd')));
-        $this->stream
-            ->expects($this->at(9))
-            ->method('removeListener')
-            ->with('error', $this->identicalTo(array($request, 'handleError')));
-        $this->stream
-            ->expects($this->at(10))
-            ->method('removeListener')
-            ->with('close', $this->identicalTo(array($request, 'handleClose')));
+        $this->stream->expects($this->exactly(6))->method('on')->withConsecutive(
+            array('drain', $this->identicalTo(array($request, 'handleDrain'))),
+            array('data', $this->identicalTo(array($request, 'handleData'))),
+            array('end', $this->identicalTo(array($request, 'handleEnd'))),
+            array('error', $this->identicalTo(array($request, 'handleError'))),
+            array('close', $this->identicalTo(array($request, 'handleClose')))
+        );
+
+        $this->stream->expects($this->exactly(5))->method('removeListener')->withConsecutive(
+            array('drain', $this->identicalTo(array($request, 'handleDrain'))),
+            array('data', $this->identicalTo(array($request, 'handleData'))),
+            array('end', $this->identicalTo(array($request, 'handleEnd'))),
+            array('error', $this->identicalTo(array($request, 'handleError'))),
+            array('close', $this->identicalTo(array($request, 'handleClose')))
+        );
 
         $request->on('end', $this->expectCallableNever());
 
@@ -223,18 +198,11 @@ class RequestTest extends TestCase
 
         $this->successfulConnectionMock();
 
-        $this->stream
-            ->expects($this->at(5))
-            ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#"));
-        $this->stream
-            ->expects($this->at(6))
-            ->method('write')
-            ->with($this->identicalTo("post"));
-        $this->stream
-            ->expects($this->at(7))
-            ->method('write')
-            ->with($this->identicalTo("data"));
+        $this->stream->expects($this->exactly(3))->method('write')->withConsecutive(
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#")),
+            array($this->identicalTo("post")),
+            array($this->identicalTo("data"))
+        );
 
         $request->write("some");
         $request->write("post");
@@ -253,15 +221,12 @@ class RequestTest extends TestCase
 
         $resolveConnection = $this->successfulAsyncConnectionMock();
 
-        $this->stream
-            ->expects($this->at(5))
-            ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#"))
-            ->willReturn(true);
-        $this->stream
-            ->expects($this->at(6))
-            ->method('write')
-            ->with($this->identicalTo("data"));
+        $this->stream->expects($this->exactly(2))->method('write')->withConsecutive(
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#")),
+            array($this->identicalTo("data"))
+        )->willReturn(
+            true
+        );
 
         $this->assertFalse($request->write("some"));
         $this->assertFalse($request->write("post"));
@@ -292,15 +257,12 @@ class RequestTest extends TestCase
 
         $resolveConnection = $this->successfulAsyncConnectionMock();
 
-        $this->stream
-            ->expects($this->at(0))
-            ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#"))
-            ->willReturn(false);
-        $this->stream
-            ->expects($this->at(1))
-            ->method('write')
-            ->with($this->identicalTo("data"));
+        $this->stream->expects($this->exactly(2))->method('write')->withConsecutive(
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#")),
+            array($this->identicalTo("data"))
+        )->willReturn(
+            false
+        );
 
         $this->assertFalse($request->write("some"));
         $this->assertFalse($request->write("post"));
@@ -327,18 +289,11 @@ class RequestTest extends TestCase
 
         $this->successfulConnectionMock();
 
-        $this->stream
-            ->expects($this->at(5))
-            ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#"));
-        $this->stream
-            ->expects($this->at(6))
-            ->method('write')
-            ->with($this->identicalTo("post"));
-        $this->stream
-            ->expects($this->at(7))
-            ->method('write')
-            ->with($this->identicalTo("data"));
+        $this->stream->expects($this->exactly(3))->method('write')->withConsecutive(
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#")),
+            array($this->identicalTo("post")),
+            array($this->identicalTo("data"))
+        );
 
         $loop = $this
             ->getMockBuilder('React\EventLoop\LoopInterface')

--- a/tests/Io/ChunkedDecoderTest.php
+++ b/tests/Io/ChunkedDecoderTest.php
@@ -8,6 +8,9 @@ use React\Tests\Http\TestCase;
 
 class ChunkedDecoderTest extends TestCase
 {
+    private $input;
+    private $parser;
+
     /**
      * @before
      */
@@ -28,11 +31,17 @@ class ChunkedDecoderTest extends TestCase
 
     public function testTwoChunks()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
         $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
+
+        $this->assertEquals(array('hello', 'bla'), $buffer);
     }
 
     public function testEnd()
@@ -46,12 +55,18 @@ class ChunkedDecoderTest extends TestCase
 
     public function testParameterWithEnd()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'bla')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('error', $this->expectCallableNever());
 
         $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
+
+        $this->assertEquals(array('hello', 'bla'), $buffer);
     }
 
     public function testInvalidChunk()
@@ -118,7 +133,11 @@ class ChunkedDecoderTest extends TestCase
 
     public function testCompletlySplitted()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('we', 'lt')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('close', $this->expectCallableNever());
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
@@ -127,25 +146,36 @@ class ChunkedDecoderTest extends TestCase
         $this->input->emit('data', array("\r\n"));
         $this->input->emit('data', array("we"));
         $this->input->emit('data', array("lt\r\n"));
+
+        $this->assertEquals(array('we', 'lt'), $buffer);
     }
 
     public function testMixed()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(3, array('we', 'lt', 'hello')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('close', $this->expectCallableNever());
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
         $this->input->emit('data', array("4"));
         $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("we"));
-        $this->input->emit('data', array("lt\r\n"));
+        $this->input->emit('data', array("welt\r\n"));
         $this->input->emit('data', array("5\r\nhello\r\n"));
+
+        $this->assertEquals(array('welt', 'hello'), $buffer);
     }
 
     public function testBigger()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('abcdeabcdeabcdea', 'hello')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('close', $this->expectCallableNever());
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
@@ -155,11 +185,17 @@ class ChunkedDecoderTest extends TestCase
         $this->input->emit('data', array("\r\n"));
         $this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
         $this->input->emit('data', array("5\r\nhello\r\n"));
+
+        $this->assertEquals(array('abcdeabcdeabcdea', 'hello'), $buffer);
     }
 
     public function testOneUnfinished()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('bla', 'hello')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('close', $this->expectCallableNever());
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
@@ -167,6 +203,8 @@ class ChunkedDecoderTest extends TestCase
         $this->input->emit('data', array("3\r\n"));
         $this->input->emit('data', array("bla\r\n"));
         $this->input->emit('data', array("5\r\nhello"));
+
+        $this->assertEquals(array('bla', 'hello'), $buffer);
     }
 
     public function testChunkIsBiggerThenExpected()
@@ -326,7 +364,10 @@ class ChunkedDecoderTest extends TestCase
 
     public function testEmitSingleCharacter()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(4, array('t', 'e', 's', 't')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('error', $this->expectCallableNever());
@@ -336,6 +377,8 @@ class ChunkedDecoderTest extends TestCase
         foreach ($array as $character) {
             $this->input->emit('data', array($character));
         }
+
+        $this->assertEquals(array('t', 'e', 's', 't'), $buffer);
     }
 
     public function testHandleError()
@@ -402,13 +445,19 @@ class ChunkedDecoderTest extends TestCase
 
     public function testLeadingZerosWillBeIgnored()
     {
-        $this->parser->on('data', $this->expectCallableConsecutive(2, array('hello', 'hello world')));
+        $buffer = array();
+        $this->parser->on('data', function ($data) use (&$buffer) {
+            $buffer[] = $data;
+        });
+
         $this->parser->on('error', $this->expectCallableNever());
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
         $this->input->emit('data', array("00005\r\nhello\r\n"));
         $this->input->emit('data', array("0000b\r\nhello world\r\n"));
+
+        $this->assertEquals(array('hello', 'hello world'), $buffer);
     }
 
     public function testLeadingZerosInEndChunkWillBeIgnored()

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -523,18 +523,21 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithUserAgent
         $redirectResponse = new Response(301, array('Location' => 'http://redirect.com'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithUserAgent
         $okResponse = new Response(200);
         $that = $this;
-        $sender->expects($this->at(1))
-            ->method('send')
-            ->with($this->callback(function (RequestInterface $request) use ($that) {
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->callback(function (RequestInterface $request) use ($that) {
                 $that->assertEquals(array('Chrome'), $request->getHeader('User-Agent'));
                 return true;
-            }))->willReturn(Promise\resolve($okResponse));
+            }))
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            Promise\resolve($okResponse)
+        );
 
         $transaction = new Transaction($sender, $loop);
         $transaction->send($requestWithUserAgent);
@@ -551,18 +554,21 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
         $redirectResponse = new Response(301, array('Location' => 'http://redirect.com'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
         $that = $this;
-        $sender->expects($this->at(1))
-            ->method('send')
-            ->with($this->callback(function (RequestInterface $request) use ($that) {
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->callback(function (RequestInterface $request) use ($that) {
                 $that->assertFalse($request->hasHeader('Authorization'));
                 return true;
-            }))->willReturn(Promise\resolve($okResponse));
+            }))
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            Promise\resolve($okResponse)
+        );
 
         $transaction = new Transaction($sender, $loop);
         $transaction->send($requestWithAuthorization);
@@ -579,18 +585,21 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
         $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
         $that = $this;
-        $sender->expects($this->at(1))
-            ->method('send')
-            ->with($this->callback(function (RequestInterface $request) use ($that) {
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->callback(function (RequestInterface $request) use ($that) {
                 $that->assertEquals(array('secret'), $request->getHeader('Authorization'));
                 return true;
-            }))->willReturn(Promise\resolve($okResponse));
+            }))
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            Promise\resolve($okResponse)
+        );
 
         $transaction = new Transaction($sender, $loop);
         $transaction->send($requestWithAuthorization);
@@ -606,19 +615,22 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
         $redirectResponse = new Response(301, array('Location' => 'http://user:pass@example.com/new'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
         $that = $this;
-        $sender->expects($this->at(1))
-            ->method('send')
-            ->with($this->callback(function (RequestInterface $request) use ($that) {
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->callback(function (RequestInterface $request) use ($that) {
                 $that->assertEquals('user:pass', $request->getUri()->getUserInfo());
                 $that->assertFalse($request->hasHeader('Authorization'));
                 return true;
-            }))->willReturn(Promise\resolve($okResponse));
+            }))
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            Promise\resolve($okResponse)
+        );
 
         $transaction = new Transaction($sender, $loop);
         $transaction->send($request);
@@ -639,19 +651,22 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithCustomHeaders
         $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithCustomHeaders
         $okResponse = new Response(200);
         $that = $this;
-        $sender->expects($this->at(1))
-            ->method('send')
-            ->with($this->callback(function (RequestInterface $request) use ($that) {
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->callback(function (RequestInterface $request) use ($that) {
                 $that->assertFalse($request->hasHeader('Content-Type'));
                 $that->assertFalse($request->hasHeader('Content-Length'));
-                return true;
-            }))->willReturn(Promise\resolve($okResponse));
+                return true;;
+            }))
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            Promise\resolve($okResponse)
+        );
 
         $transaction = new Transaction($sender, $loop);
         $transaction->send($requestWithCustomHeaders);
@@ -706,12 +721,17 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $redirectResponse in
         $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         $pending = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
-        $sender->expects($this->at(1))->method('send')->willReturn($pending);
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->anything())
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            $pending
+        );
 
         $transaction = new Transaction($sender, $loop);
         $promise = $transaction->send($request);
@@ -728,12 +748,17 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $redirectResponse in
         $first = new Deferred();
-        $sender->expects($this->at(0))->method('send')->willReturn($first->promise());
 
         $second = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
-        $sender->expects($this->at(1))->method('send')->willReturn($second);
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->anything())
+        )->willReturnOnConsecutiveCalls(
+            $first->promise(),
+            $second
+        );
 
         $transaction = new Transaction($sender, $loop);
         $promise = $transaction->send($request);
@@ -794,12 +819,17 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $redirectResponse in
         $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
-        $sender->expects($this->at(0))->method('send')->willReturn(Promise\resolve($redirectResponse));
 
         $pending = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
-        $sender->expects($this->at(1))->method('send')->willReturn($pending);
+        $sender->expects($this->exactly(2))->method('send')->withConsecutive(
+            array($this->anything()),
+            array($this->anything())
+        )->willReturnOnConsecutiveCalls(
+            Promise\resolve($redirectResponse),
+            $pending
+        );
 
         $transaction = new Transaction($sender, $loop);
         $promise = $transaction->send($request);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,36 +37,6 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableConsecutive($numberOfCalls, array $with)
-    {
-        $mock = $this->createCallableMock();
-
-        if($numberOfCalls == 2){
-            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
-                array($this->equalTo($with[0])),
-                array($this->equalTo($with[1]))
-            );
-        }
-
-        if($numberOfCalls == 3){
-            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
-                array($this->equalTo($with[0])),
-                array($this->equalTo($with[1])),
-                array($this->equalTo($with[2]))
-            );
-        }
-
-        if($numberOfCalls == 4){
-            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
-                array($this->equalTo($with[0])),
-                array($this->equalTo($with[1])),
-                array($this->equalTo($with[2])),
-                array($this->equalTo($with[3]))
-            );
-        }
-        return $mock;
-    }
-
     protected function createCallableMock()
     {
         if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,13 +41,29 @@ class TestCase extends BaseTestCase
     {
         $mock = $this->createCallableMock();
 
-        for ($i = 0; $i < $numberOfCalls; $i++) {
-            $mock
-                ->expects($this->at($i))
-                ->method('__invoke')
-                ->with($this->equalTo($with[$i]));
+        if($numberOfCalls == 2){
+            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
+                array($this->equalTo($with[0])),
+                array($this->equalTo($with[1]))
+            );
         }
 
+        if($numberOfCalls == 3){
+            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
+                array($this->equalTo($with[0])),
+                array($this->equalTo($with[1])),
+                array($this->equalTo($with[2]))
+            );
+        }
+
+        if($numberOfCalls == 4){
+            $mock->expects($this->exactly($numberOfCalls))->method('__invoke')->withConsecutive(
+                array($this->equalTo($with[0])),
+                array($this->equalTo($with[1])),
+                array($this->equalTo($with[2])),
+                array($this->equalTo($with[3]))
+            );
+        }
         return $mock;
     }
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
I also had to update  some tests, because the `at()` matcher deprecated in PHPUnit 9.3 and will be removed in PHPUnit 10.

Together with the changes from https://github.com/reactphp/http/pull/391 by @clue it's possible to run this code with PHP 8 without any warnings in your output 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.3.8 by Sebastian Bergmann and contributors.

...............................................................  63 / 673 (  9%)
............................................................... 126 / 673 ( 18%)
............................................................... 189 / 673 ( 28%)
............................................................... 252 / 673 ( 37%)
............................................................... 315 / 673 ( 46%)
............................................................... 378 / 673 ( 56%)
............................................................... 441 / 673 ( 65%)
............................................................... 504 / 673 ( 74%)
............................................................... 567 / 673 ( 84%)
............................................................... 630 / 673 ( 93%)
...........................................                     673 / 673 (100%)

Time: 00:16.651, Memory: 20.00 MB

OK (673 tests, 1604 assertions)
```

For further details concerning this pull request look into [graphp/graphviz#46](https://github.com/graphp/graphviz/pull/46).
This pull request builds on top of [reactphp/http#364](https://github.com/reactphp/http/pull/364).