### PR TITLE
Keep request body in memory also after consuming request body

### DIFF
--- a/src/Io/BufferedBody.php
+++ b/src/Io/BufferedBody.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace React\Http\Io;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * [Internal] PSR-7 message body implementation using an in-memory buffer
+ *
+ * @internal
+ */
+class BufferedBody implements StreamInterface
+{
+    private $buffer = '';
+    private $position = 0;
+    private $closed = false;
+
+    public function __construct($buffer)
+    {
+        $this->buffer = $buffer;
+    }
+
+    public function __toString()
+    {
+        if ($this->closed) {
+            return '';
+        }
+
+        $this->seek(0);
+
+        return $this->getContents();
+    }
+
+    public function close()
+    {
+        $this->buffer = '';
+        $this->position = 0;
+        $this->closed = true;
+    }
+
+    public function detach()
+    {
+        $this->close();
+
+        return null;
+    }
+
+    public function getSize()
+    {
+        return $this->closed ? null : \strlen($this->buffer);
+    }
+
+    public function tell()
+    {
+        if ($this->closed) {
+            throw new \RuntimeException('Unable to tell position of closed stream');
+        }
+
+        return $this->position;
+    }
+
+    public function eof()
+    {
+        return $this->position >= \strlen($this->buffer);
+    }
+
+    public function isSeekable()
+    {
+        return !$this->closed;
+    }
+
+    public function seek($offset, $whence = \SEEK_SET)
+    {
+        if ($this->closed) {
+            throw new \RuntimeException('Unable to seek on closed stream');
+        }
+
+        $old = $this->position;
+
+        if ($whence === \SEEK_SET) {
+            $this->position = $offset;
+        } elseif ($whence === \SEEK_CUR) {
+            $this->position += $offset;
+        } elseif ($whence === \SEEK_END) {
+            $this->position = \strlen($this->buffer) + $offset;
+        } else {
+            throw new \InvalidArgumentException('Invalid seek mode given');
+        }
+
+        if (!\is_int($this->position) || $this->position < 0) {
+            $this->position = $old;
+            throw new \RuntimeException('Unable to seek to position');
+        }
+    }
+
+    public function rewind()
+    {
+        $this->seek(0);
+    }
+
+    public function isWritable()
+    {
+        return !$this->closed;
+    }
+
+    public function write($string)
+    {
+        if ($this->closed) {
+            throw new \RuntimeException('Unable to write to closed stream');
+        }
+
+        if ($string === '') {
+            return 0;
+        }
+
+        if ($this->position > 0 && !isset($this->buffer[$this->position - 1])) {
+            $this->buffer = \str_pad($this->buffer, $this->position, "\0");
+        }
+
+        $len = \strlen($string);
+        $this->buffer = \substr($this->buffer, 0, $this->position) . $string . \substr($this->buffer, $this->position + $len);
+        $this->position += $len;
+
+        return $len;
+    }
+
+    public function isReadable()
+    {
+        return !$this->closed;
+    }
+
+    public function read($length)
+    {
+        if ($this->closed) {
+            throw new \RuntimeException('Unable to read from closed stream');
+        }
+
+        if ($length < 1) {
+            throw new \InvalidArgumentException('Invalid read length given');
+        }
+
+        if ($this->position + $length > \strlen($this->buffer)) {
+            $length = \strlen($this->buffer) - $this->position;
+        }
+
+        if (!isset($this->buffer[$this->position])) {
+            return '';
+        }
+
+        $pos = $this->position;
+        $this->position += $length;
+
+        return \substr($this->buffer, $pos, $length);
+    }
+
+    public function getContents()
+    {
+        if ($this->closed) {
+            throw new \RuntimeException('Unable to read from closed stream');
+        }
+
+        if (!isset($this->buffer[$this->position])) {
+            return '';
+        }
+
+        $pos = $this->position;
+        $this->position = \strlen($this->buffer);
+
+        return \substr($this->buffer, $pos);
+    }
+
+    public function getMetadata($key = null)
+    {
+        return $key === null ? array() : null;
+    }
+}

--- a/tests/Io/BufferedBodyTest.php
+++ b/tests/Io/BufferedBodyTest.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use React\Tests\Http\TestCase;
+use React\Http\Io\BufferedBody;
+
+class BufferedBodyTest extends TestCase
+{
+    public function testEmpty()
+    {
+        $stream = new BufferedBody('');
+
+        $this->assertTrue($stream->isReadable());
+        $this->assertTrue($stream->isWritable());
+        $this->assertTrue($stream->isSeekable());
+        $this->assertSame(0, $stream->getSize());
+        $this->assertSame('', $stream->getContents());
+        $this->assertSame('', (string) $stream);
+    }
+
+    public function testClose()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->assertFalse($stream->isReadable());
+        $this->assertFalse($stream->isWritable());
+        $this->assertFalse($stream->isSeekable());
+        $this->assertTrue($stream->eof());
+        $this->assertNull($stream->getSize());
+        $this->assertSame('', (string) $stream);
+    }
+
+    public function testDetachReturnsNullAndCloses()
+    {
+        $stream = new BufferedBody('hello');
+        $this->assertNull($stream->detach());
+
+        $this->assertFalse($stream->isReadable());
+        $this->assertFalse($stream->isWritable());
+        $this->assertFalse($stream->isSeekable());
+        $this->assertTrue($stream->eof());
+        $this->assertNull($stream->getSize());
+        $this->assertSame('', (string) $stream);
+    }
+
+    public function testSeekAndTellPosition()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertSame(0, $stream->tell());
+        $this->assertFalse($stream->eof());
+
+        $stream->seek(1);
+        $this->assertSame(1, $stream->tell());
+        $this->assertFalse($stream->eof());
+
+        $stream->seek(2, SEEK_CUR);
+        $this->assertSame(3, $stream->tell());
+        $this->assertFalse($stream->eof());
+
+        $stream->seek(-1, SEEK_END);
+        $this->assertSame(4, $stream->tell());
+        $this->assertFalse($stream->eof());
+
+        $stream->seek(0, SEEK_END);
+        $this->assertSame(5, $stream->tell());
+        $this->assertTrue($stream->eof());
+    }
+
+    public function testSeekAfterEndIsPermitted()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(1000);
+        $this->assertSame(1000, $stream->tell());
+        $this->assertTrue($stream->eof());
+
+        $stream->seek(0, SEEK_END);
+        $this->assertSame(5, $stream->tell());
+        $this->assertTrue($stream->eof());
+    }
+
+    public function testSeekBeforeStartThrows()
+    {
+        $stream = new BufferedBody('hello');
+
+        try {
+            $stream->seek(-10, SEEK_CUR);
+        } catch (\RuntimeException $e) {
+            $this->assertSame(0, $stream->tell());
+
+            $this->setExpectedException('RuntimeException');
+            throw $e;
+        }
+    }
+
+    public function testSeekWithInvalidModeThrows()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $stream->seek(1, 12345);
+    }
+
+    public function testSeekAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->seek(0);
+    }
+
+    public function testTellAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->tell();
+    }
+
+    public function testRewindSeeksToStartPosition()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(1);
+        $stream->rewind();
+        $this->assertSame(0, $stream->tell());
+    }
+
+    public function testRewindAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->rewind();
+    }
+
+    public function testGetContentsMultipleTimesReturnsBodyOnlyOnce()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertSame(5, $stream->getSize());
+        $this->assertSame('hello', $stream->getContents());
+        $this->assertSame('', $stream->getContents());
+    }
+
+    public function testReadReturnsChunkAndAdvancesPosition()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertSame('he', $stream->read(2));
+        $this->assertSame(2, $stream->tell());
+
+        $this->assertSame('ll', $stream->read(2));
+        $this->assertSame(4, $stream->tell());
+
+        $this->assertSame('o', $stream->read(2));
+        $this->assertSame(5, $stream->tell());
+
+        $this->assertSame('', $stream->read(2));
+        $this->assertSame(5, $stream->tell());
+    }
+
+    public function testReadAfterEndReturnsEmptyStringWithoutChangingPosition()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(1000);
+
+        $this->assertSame('', $stream->read(2));
+        $this->assertSame(1000, $stream->tell());
+    }
+
+    public function testReadZeroThrows()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->setExpectedException('InvalidArgumentException');
+        $stream->read(0);
+    }
+
+    public function testReadAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->read(10);
+    }
+
+    public function testGetContentsReturnsWholeBufferAndAdvancesPositionToEof()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertSame('hello', $stream->getContents());
+        $this->assertSame(5, $stream->tell());
+        $this->assertTrue($stream->eof());
+    }
+
+    public function testGetContentsAfterEndsReturnsEmptyStringWithoutChangingPosition()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(100);
+
+        $this->assertSame('', $stream->getContents());
+        $this->assertSame(100, $stream->tell());
+        $this->assertTrue($stream->eof());
+    }
+
+    public function testGetContentsAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->getContents();
+    }
+
+    public function testWriteAdvancesPosition()
+    {
+        $stream = new BufferedBody('');
+
+        $this->assertSame(2, $stream->write('he'));
+        $this->assertSame(2, $stream->tell());
+
+        $this->assertSame(2, $stream->write('ll'));
+        $this->assertSame(4, $stream->tell());
+
+        $this->assertSame(1, $stream->write('o'));
+        $this->assertSame(5, $stream->tell());
+
+        $this->assertSame(0, $stream->write(''));
+        $this->assertSame(5, $stream->tell());
+    }
+
+    public function testWriteInMiddleOfBufferOverwrites()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(1);
+        $this->assertSame(1, $stream->write('a'));
+
+        $this->assertSame(2, $stream->tell());
+        $this->assertsame(5, $stream->getSize());
+        $this->assertSame('hallo', (string) $stream);
+    }
+
+    public function testWriteOverEndOverwritesAndAppends()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(4);
+        $this->assertSame(2, $stream->write('au'));
+
+        $this->assertSame(6, $stream->tell());
+        $this->assertsame(6, $stream->getSize());
+        $this->assertSame('hellau', (string) $stream);
+    }
+
+    public function testWriteAfterEndAppendsAndFillsWithNullBytes()
+    {
+        $stream = new BufferedBody('hello');
+
+        $stream->seek(6);
+        $this->assertSame(6, $stream->write('binary'));
+
+        $this->assertSame(12, $stream->tell());
+        $this->assertsame(12, $stream->getSize());
+        $this->assertSame('hello' . "\0" . 'binary', (string) $stream);
+    }
+
+    public function testWriteAfterCloseThrows()
+    {
+        $stream = new BufferedBody('hello');
+        $stream->close();
+
+        $this->setExpectedException('RuntimeException');
+        $stream->write('foo');
+    }
+
+    public function testGetMetadataWithoutKeyReturnsEmptyArray()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertEquals(array(), $stream->getMetadata());
+    }
+
+    public function testGetMetadataWithKeyReturnsNull()
+    {
+        $stream = new BufferedBody('hello');
+
+        $this->assertNull($stream->getMetadata('key'));
+    }
+}


### PR DESCRIPTION
The `Server` will always buffer the incoming request body (unless the `StreamingRequestMiddleware` is used). Previously, this  buffer would be cleared when the request body has been parsed successfully. This means that the request body was only present for some requests.

This changeset ensures we keep the request body in memory also after consuming the request body. This means consumers can now always access the complete request body as detailed in the documentation. This allows building custom parsers and more advanced processing models without having to mess with the default parsers.

This shouldn't have a significant effect on memory consumption because the default buffer size is limited as per #371.

This also makes us less dependent on the underlying PSR-7 implementation which allows us to possibly change this in the future (#331).

Resolves #386, #387, #390 and others.