### PR TITLE
Update example 63 to support v1.0.0+

### DIFF
--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -9,7 +9,8 @@ $loop = Factory::create();
 // Note how this example uses the advanced `StreamingRequestMiddleware` to allow streaming
 // the incoming HTTP request. This very simple example merely counts the size
 // of the streaming body, it does not otherwise buffer its contents in memory.
-$server = new React\Http\Server(array(
+$server = new React\Http\Server(
+    $loop,
     new React\Http\Middleware\StreamingRequestMiddleware(),
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $body = $request->getBody();
@@ -44,7 +45,7 @@ $server = new React\Http\Server(array(
             });
         });
     }
-));
+);
 
 $server->on('error', 'printf');
 


### PR DESCRIPTION
Add LoopInterface as first constructor argument to Server and change Server to accept variadic middleware handlers instead of array.