### PR TITLE
Require Host request header for HTTP/1.1 requests

### DIFF
--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -257,7 +257,7 @@ class RequestHeaderParserTest extends TestCase
         $connection->emit('data', array("GET /foo HTTP/1.0\r\n\r\n"));
 
         $this->assertEquals('http://127.1.1.1:8000/foo', $request->getUri());
-        $this->assertEquals('127.1.1.1:8000', $request->getHeaderLine('Host'));
+        $this->assertFalse($request->hasHeader('Host'));
     }
 
     public function testHeaderEventViaHttpsShouldApplyHttpsSchemeFromLocalTlsConnectionAddress()
@@ -550,7 +550,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nContent-Length: foo\r\n\r\n"));
+        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: foo\r\n\r\n"));
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -570,7 +570,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\n"));
+        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\n"));
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -590,7 +590,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nTransfer-Encoding: foo\r\n\r\n"));
+        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: foo\r\n\r\n"));
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(501, $error->getCode());
@@ -610,7 +610,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n"));
+        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n"));
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -762,7 +762,7 @@ class RequestHeaderParserTest extends TestCase
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";
-        $data .= "Host: example.com:80\r\n";
+        $data .= "Host: example.com\r\n";
         $data .= "Connection: close\r\n";
         $data .= "\r\n";
 
@@ -772,7 +772,7 @@ class RequestHeaderParserTest extends TestCase
     private function createAdvancedPostRequest()
     {
         $data = "POST /foo?bar=baz HTTP/1.1\r\n";
-        $data .= "Host: example.com:80\r\n";
+        $data .= "Host: example.com\r\n";
         $data .= "User-Agent: react/alpha\r\n";
         $data .= "Connection: close\r\n";
         $data .= "\r\n";

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -269,6 +269,7 @@ final class ServerTest extends TestCase
 
         $data = array();
         $data[] = "POST / HTTP/1.1\r\n";
+        $data[] = "Host: localhost\r\n";
         $data[] = "Content-Type: multipart/form-data; boundary=" . $boundary . "\r\n";
         $data[] = "Content-Length: 220\r\n";
         $data[] = "\r\n";


### PR DESCRIPTION
All HTTP/1.1 requests require a Host request header as per RFC 7230. The
proxy CONNECT method is an exception to this rule because we do not want
to break compatibility with common HTTP proxy clients that do not
strictly follow the RFCs.

This does not affect valid HTTP/1.1 requests and has no effect on
HTTP/1.0 requests.

Additionally, make sure we do not include a default Host request header
in the parsed request object if the incoming request does not make use
of the Host request header.

I've stumbled upon this when writing integration tests for https://twitter.com/x_framework that test common HTTP server behavior. With this changeset applied, this project now behaves just like nginx, Apache and PHP's built-in web server:

```bash
$ curl -v http://localhost:8080/headers -H User-Agent: -H Accept: -H Host: -10
```

I've also checked benchmark results and I'm seeing a consistent, but minor improvement from ~11k rps to ~12k rps on my machine (#162).

Builds on top of #201
Refs #208, https://github.com/golang/go/issues/18215 and others