### PR TITLE
Introduce using PSR-7 HTTP Status code constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "react/promise-stream": "^1.1",
         "react/socket": "^1.6",
         "react/stream": "^1.1",
-        "ringcentral/psr7": "^1.2"
+        "ringcentral/psr7": "^1.2",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -3,6 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -11,7 +12,7 @@ $loop = Factory::create();
 
 $server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -3,6 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -12,7 +13,7 @@ $loop = Factory::create();
 $counter = 0;
 $server = new Server($loop, function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -13,7 +14,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -20,7 +21,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/html'
         ),

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -3,6 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -16,7 +17,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
         $body = "Your cookie value is: " . $request->getCookieParams()[$key];
 
         return new Response(
-            200,
+            StatusCodeInterface::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -25,7 +26,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain',
             'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -14,7 +15,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     return new Promise(function ($resolve, $reject) use ($loop) {
         $loop->addTimer(1.5, function() use ($resolve) {
             $response = new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -3,6 +3,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 use React\Promise\Promise;
 
@@ -20,7 +21,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use (&$co
         }
 
         $response = new Response(
-            200,
+            StatusCodeInterface::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -12,7 +13,7 @@ $loop = Factory::create();
 
 $server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
-        return new Response(404);
+        return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
     }
 
     $stream = new ThroughStream();
@@ -33,7 +34,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     });
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -6,6 +6,7 @@
 // $ php examples/59-server-json-api.php 8080
 // $ curl -v http://localhost:8080/ -H 'Content-Type: application/json' -d '{"name":"Alice"}'
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -18,7 +19,7 @@ $loop = Factory::create();
 $server = new Server($loop, function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
-            415, // Unsupported Media Type
+            StatusCodeInterface::STATUS_UNSUPPORTED_MEDIA_TYPE,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -29,7 +30,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     $input = json_decode($request->getBody()->getContents());
     if (json_last_error() !== JSON_ERROR_NONE) {
         return new Response(
-            400, // Bad Request
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -39,7 +40,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
 
     if (!isset($input->name) || !is_string($input->name)) {
         return new Response(
-            422, // Unprocessable Entity
+            StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -48,7 +49,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'application/json'
         ),

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -11,7 +12,7 @@ $loop = Factory::create();
 
 $server = new Server($loop, function (ServerRequestInterface $request) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -7,6 +7,7 @@
 // $ curl --form name=test --form age=30 http://localhost:8080/
 // $ curl --form name=hi --form avatar=@avatar.png http://localhost:8080/
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use React\EventLoop\Factory;
@@ -114,7 +115,7 @@ $body
 HTML;
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/html; charset=UTF-8'
         ),

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -1,6 +1,7 @@
 <?php
 
 use React\EventLoop\Factory;
+use Fig\Http\Message\StatusCodeInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -25,7 +26,7 @@ $server = new React\Http\Server(
 
             $body->on('end', function () use ($resolve, &$bytes){
                 $resolve(new React\Http\Message\Response(
-                    200,
+                    StatusCodeInterface::STATUS_OK,
                     array(
                         'Content-Type' => 'text/plain'
                     ),
@@ -36,7 +37,7 @@ $server = new React\Http\Server(
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (\Exception $exception) use ($resolve, &$bytes) {
                 $resolve(new React\Http\Message\Response(
-                    400,
+                    StatusCodeInterface::STATUS_BAD_REQUEST,
                     array(
                         'Content-Type' => 'text/plain'
                     ),

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -3,6 +3,7 @@
 // $ php examples/71-server-http-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 http://reactphp.org/
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -20,7 +21,7 @@ $loop = Factory::create();
 $server = new Server($loop, function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -40,7 +41,7 @@ $server = new Server($loop, function (RequestInterface $request) {
     // left up as an exercise: use an HTTP client to send the outgoing request
     // and forward the incoming response to the original client request
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -6,6 +6,7 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
@@ -22,7 +23,7 @@ $connector = new Connector($loop);
 $server = new Server($loop, function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
-            405,
+            StatusCodeInterface::STATUS_METHOD_NOT_ALLOWED,
             array(
                 'Content-Type' => 'text/plain',
                 'Allow' => 'CONNECT'
@@ -36,14 +37,14 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($con
         function (ConnectionInterface $remote) {
             // connection established => forward data
             return new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(),
                 $remote
             );
         },
         function ($e) {
             return new Response(
-                502,
+                StatusCodeInterface::STATUS_BAD_GATEWAY,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -17,6 +17,7 @@ $ telnet localhost 1080
 < world
 */
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -33,7 +34,7 @@ $loop = Factory::create();
 $server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            426,
+            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'echo'
             ),
@@ -51,7 +52,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     });
 
     return new Response(
-        101,
+        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'echo'
         ),

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -22,6 +22,7 @@ Hint: try this with multiple connections :)
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Server;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
@@ -41,7 +42,7 @@ $chat = new ThroughStream();
 $server = new Server($loop, function (ServerRequestInterface $request) use ($loop, $chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            426,
+            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'chat'
             ),
@@ -79,7 +80,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     });
 
     return new Response(
-        101,
+        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'chat'
         ),

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -15,6 +15,7 @@
 // $ docker run -it --rm --net=host skandyla/wrk -t8 -c10 -d20 http://localhost:8080/
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Message\Response;
@@ -98,7 +99,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(
                     'Content-Type' => 'text/html'
                 ),
@@ -111,13 +112,13 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
             $stream = new ChunkRepeater(str_repeat('.', 1000000), 10000);
             break;
         default:
-            return new Response(404);
+            return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
     }
 
     $loop->addTimer(0, array($stream, 'resume'));
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'application/octet-data',
             'Content-Length' => $stream->getSize()

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -3,6 +3,7 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\ServerRequest;
 use React\Socket\ConnectionInterface;
@@ -39,7 +40,7 @@ class RequestHeaderParser extends EventEmitter
                 $fn = null;
 
                 $that->emit('error', array(
-                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", 431),
+                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", StatusCodeInterface::STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE),
                     $conn
                 ));
                 return;
@@ -127,7 +128,7 @@ class RequestHeaderParser extends EventEmitter
 
         // only support HTTP/1.1 and HTTP/1.0 requests
         if ($start['version'] !== '1.1' && $start['version'] !== '1.0') {
-            throw new \InvalidArgumentException('Received request with invalid protocol version', 505);
+            throw new \InvalidArgumentException('Received request with invalid protocol version', StatusCodeInterface::STATUS_VERSION_NOT_SUPPORTED);
         }
 
         // match all request header fields into array, thanks to @kelunik for checking the HTTP specs and coming up with this regex
@@ -256,20 +257,20 @@ class RequestHeaderParser extends EventEmitter
         // ensure message boundaries are valid according to Content-Length and Transfer-Encoding request headers
         if ($request->hasHeader('Transfer-Encoding')) {
             if (\strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
-                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', 501);
+                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', StatusCodeInterface::STATUS_NOT_IMPLEMENTED);
             }
 
             // Transfer-Encoding: chunked and Content-Length header MUST NOT be used at the same time
             // as per https://tools.ietf.org/html/rfc7230#section-3.3.3
             if ($request->hasHeader('Content-Length')) {
-                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', 400);
+                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', StatusCodeInterface::STATUS_BAD_REQUEST);
             }
         } elseif ($request->hasHeader('Content-Length')) {
             $string = $request->getHeaderLine('Content-Length');
 
             if ((string)(int)$string !== $string) {
                 // Content-Length value is not an integer or not a single integer
-                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', 400);
+                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', StatusCodeInterface::STATUS_BAD_REQUEST);
             }
         }
 

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -2,6 +2,7 @@
 
 namespace React\Http\Io;
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\EventLoop\LoopInterface;
@@ -110,7 +111,7 @@ class Sender
         $requestStream->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($deferred, $request) {
             $length = null;
             $code = $response->getStatusCode();
-            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == 204 || $code == 304) {
+            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == StatusCodeInterface::STATUS_NO_CONTENT || $code == StatusCodeInterface::STATUS_NOT_MODIFIED) {
                 $length = 0;
             } elseif (\strtolower($response->getHeaderLine('Transfer-Encoding')) === 'chunked') {
                 $body = new ChunkedDecoder($body);

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -3,6 +3,7 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
@@ -120,7 +121,7 @@ final class StreamingServer extends EventEmitter
             // parsing failed => assume dummy request and send appropriate error
             $that->writeError(
                 $conn,
-                $e->getCode() !== 0 ? $e->getCode() : 400,
+                $e->getCode() !== 0 ? $e->getCode() : StatusCodeInterface::STATUS_BAD_REQUEST,
                 new ServerRequest('GET', '/')
             );
         });
@@ -199,7 +200,7 @@ final class StreamingServer extends EventEmitter
                 $exception = new \RuntimeException($message, null, $previous);
 
                 $that->emit('error', array($exception));
-                return $that->writeError($conn, 500, $request);
+                return $that->writeError($conn, StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR, $request);
             }
         );
     }
@@ -262,7 +263,7 @@ final class StreamingServer extends EventEmitter
 
         // assign "Content-Length" and "Transfer-Encoding" headers automatically
         $chunked = false;
-        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === 204) {
+        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT) {
             // 2xx response to CONNECT and 1xx and 204 MUST NOT include Content-Length or Transfer-Encoding header
             $response = $response->withoutHeader('Content-Length')->withoutHeader('Transfer-Encoding');
         } elseif ($body->getSize() !== null) {
@@ -281,7 +282,7 @@ final class StreamingServer extends EventEmitter
 
         // assign "Connection" header automatically
         $persist = false;
-        if ($code === 101) {
+        if ($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS) {
             // 101 (Switching Protocols) response uses Connection: upgrade header
             // This implies that this stream now uses another protocol and we
             // may not persist this connection for additional requests.
@@ -303,7 +304,7 @@ final class StreamingServer extends EventEmitter
 
         // 101 (Switching Protocols) response (for Upgrade request) forwards upgraded data through duplex stream
         // 2xx (Successful) response to CONNECT forwards tunneled application data through duplex stream
-        if (($code === 101 || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
+        if (($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
             if ($request->getBody()->isReadable()) {
                 // request is still streaming => wait for request close before forwarding following data from connection
                 $request->getBody()->on('close', function () use ($connection, $body) {
@@ -329,7 +330,7 @@ final class StreamingServer extends EventEmitter
 
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling above
-        if ($method === 'HEAD' || $code === 100 || ($code > 101 && $code < 200) || $code === 204 || $code === 304) {
+        if ($method === 'HEAD' || $code === 100 || ($code > StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT || $code === StatusCodeInterface::STATUS_NOT_MODIFIED) {
             $body = '';
         }
 

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -2,6 +2,7 @@
 
 namespace React\Http\Message;
 
+use Fig\Http\Message\StatusCodeInterface;
 use React\Http\Io\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
 use RingCentral\Psr7\Response as Psr7Response;
@@ -42,7 +43,7 @@ final class Response extends Psr7Response
      * @throws \InvalidArgumentException for an invalid body
      */
     public function __construct(
-        $status = 200,
+        $status = StatusCodeInterface::STATUS_OK,
         array $headers = array(),
         $body = '',
         $version = '1.1',


### PR DESCRIPTION
Introducing using these constants makes it easier to identify a
specific HTTP status used in our code. And for our users to use
readable status codes in their own code.