### PR TITLE
throws custom exception type for request timeouts

### DIFF
--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -9,6 +9,7 @@ use RingCentral\Psr7\Request;
 use RingCentral\Psr7\Uri;
 use React\EventLoop\LoopInterface;
 use React\Http\Message\ResponseException;
+use React\Http\Message\TimeoutException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Stream\ReadableStreamInterface;
@@ -127,7 +128,7 @@ class Transaction
     public function applyTimeout(Deferred $deferred, $timeout)
     {
         $deferred->timeout = $this->loop->addTimer($timeout, function () use ($timeout, $deferred) {
-            $deferred->reject(new \RuntimeException(
+            $deferred->reject(new TimeoutException(
                 'Request timed out after ' . $timeout . ' seconds'
             ));
             if (isset($deferred->pending)) {

--- a/src/Message/TimeoutException.php
+++ b/src/Message/TimeoutException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace React\Http\Message;
+
+/**
+ * The `React\Http\Message\TimeoutException` is an `Exception` sub-class that will be used to reject
+ * a request promise if the remote server does not respond in the configured time span
+ */
+
+final class TimeoutException extends \RuntimeException
+{
+    public function __construct($message = "", $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Browser;
 use React\Http\Message\ResponseException;
+use React\Http\Message\TimeoutException;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Message\Response;
 use React\Http\Server;
@@ -260,7 +261,7 @@ class FunctionalBrowserTest extends TestCase
     {
         $promise = $this->browser->withTimeout(0.1)->get($this->base . 'delay/10');
 
-        $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
+        $this->setExpectedException('\React\Http\Message\TimeoutException', 'Request timed out after 0.1 seconds');
         Block\await($promise, $this->loop);
     }
 
@@ -270,7 +271,7 @@ class FunctionalBrowserTest extends TestCase
         $promise = $this->browser->withTimeout(0.1)->post($this->base . 'delay/10', array(), $stream);
         $stream->end();
 
-        $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
+        $this->setExpectedException('\React\Http\Message\TimeoutException', 'Request timed out after 0.1 seconds');
         Block\await($promise, $this->loop);
     }
 


### PR DESCRIPTION
The transaction throws a custom exception type for responses that have a non-success status code, which can be handled by callers of the API. With this pull request we also add a custom exception type for request timeouts that might occur.