### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -39,7 +37,6 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
-    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -37,6 +39,7 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
+    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,12 @@
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "psr/http-message": "^1.0",
-        "react/event-loop": "^1.0 || ^0.5",
+        "react/dns": "dev-default-loop#28e5df1 as 1.8.0",
+        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
         "react/promise": "^2.3 || ^1.2.1",
         "react/promise-stream": "^1.1",
-        "react/socket": "^1.6",
-        "react/stream": "^1.1",
+        "react/socket": "dev-default-loop#b471dc7 as 1.8.0",
+        "react/stream": "dev-default-loop#e617d63 as 1.2.0",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
@@ -48,5 +49,19 @@
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Http\\": "tests" }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/dns"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/socket"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/stream"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,11 @@
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "psr/http-message": "^1.0",
-        "react/dns": "dev-default-loop#28e5df1 as 1.8.0",
-        "react/event-loop": "dev-master#78f7f43 as 1.2.0",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.3 || ^1.2.1",
         "react/promise-stream": "^1.1",
-        "react/socket": "dev-default-loop#b471dc7 as 1.8.0",
-        "react/stream": "dev-default-loop#e617d63 as 1.2.0",
+        "react/socket": "^1.8",
+        "react/stream": "^1.2",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
@@ -49,19 +48,5 @@
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Http\\": "tests" }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/dns"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/socket"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/stream"
-        }
-    ]
+    }
 }

--- a/examples/01-client-get-request.php
+++ b/examples/01-client-get-request.php
@@ -5,11 +5,8 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 $client->get('http://google.com/')->then(function (ResponseInterface $response) {
     var_dump($response->getHeaders(), (string)$response->getBody());
 });
-
-$loop->run();

--- a/examples/02-client-concurrent-requests.php
+++ b/examples/02-client-concurrent-requests.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 $client->head('http://www.github.com/clue/http-react')->then(function (ResponseInterface $response) {
     var_dump($response->getHeaders(), (string)$response->getBody());
@@ -19,5 +18,3 @@ $client->get('http://google.com/')->then(function (ResponseInterface $response) 
 $client->get('http://www.lueck.tv/psocksd')->then(function (ResponseInterface $response) {
     var_dump($response->getHeaders(), (string)$response->getBody());
 });
-
-$loop->run();

--- a/examples/03-client-request-any.php
+++ b/examples/03-client-request-any.php
@@ -8,8 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 $promises = array(
     $client->head('http://www.github.com/clue/http-react'),
@@ -28,5 +27,3 @@ React\Promise\any($promises)->then(function (ResponseInterface $response) use ($
     var_dump($response->getHeaders());
     echo PHP_EOL . $response->getBody();
 });
-
-$loop->run();

--- a/examples/04-client-post-json.php
+++ b/examples/04-client-post-json.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 $data = array(
     'name' => array(
@@ -25,5 +24,3 @@ $client->post(
 )->then(function (ResponseInterface $response) {
     echo (string)$response->getBody();
 }, 'printf');
-
-$loop->run();

--- a/examples/05-client-put-xml.php
+++ b/examples/05-client-put-xml.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 $xml = new SimpleXMLElement('<users></users>');
 $child = $xml->addChild('user');
@@ -22,5 +21,3 @@ $client->put(
 )->then(function (ResponseInterface $response) {
     echo (string)$response->getBody();
 }, 'printf');
-
-$loop->run();

--- a/examples/11-client-http-connect-proxy.php
+++ b/examples/11-client-http-connect-proxy.php
@@ -6,29 +6,24 @@
 // $ php examples/72-server-http-connect-proxy.php 8080
 // $ php examples/11-client-http-connect-proxy.php
 
-use React\Http\Browser;
 use Clue\React\HttpProxy\ProxyConnector as HttpConnectClient;
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Factory as LoopFactory;
+use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = LoopFactory::create();
-
 // create a new HTTP CONNECT proxy client which connects to a HTTP CONNECT proxy server listening on localhost:8080
-$proxy = new HttpConnectClient('127.0.0.1:8080', new Connector($loop));
+$proxy = new HttpConnectClient('127.0.0.1:8080', new Connector());
 
 // create a Browser object that uses the HTTP CONNECT proxy client for connections
-$connector = new Connector($loop, array(
+$connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser($loop, $connector);
+$browser = new Browser(null, $connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
     echo RingCentral\Psr7\str($response);
 }, 'printf');
-
-$loop->run();

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -3,29 +3,24 @@
 // not already running a SOCKS proxy server?
 // Try LeProxy.org or this: `ssh -D 1080 localhost`
 
-use React\Http\Browser;
 use Clue\React\Socks\Client as SocksClient;
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Factory as LoopFactory;
+use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = LoopFactory::create();
-
 // create a new SOCKS proxy client which connects to a SOCKS proxy server listening on localhost:1080
-$proxy = new SocksClient('127.0.0.1:1080', new Connector($loop));
+$proxy = new SocksClient('127.0.0.1:1080', new Connector());
 
 // create a Browser object that uses the SOCKS proxy client for connections
-$connector = new Connector($loop, array(
+$connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser($loop, $connector);
+$browser = new Browser(null, $connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
     echo RingCentral\Psr7\str($response);
 }, 'printf');
-
-$loop->run();

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -1,29 +1,25 @@
 <?php
 
-use React\Http\Browser;
 use Clue\React\SshProxy\SshSocksConnector;
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Factory as LoopFactory;
+use React\EventLoop\Loop;
+use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = LoopFactory::create();
-
 // create a new SSH proxy client which connects to a SSH server listening on localhost:22
 // You can pass any SSH server address as first argument, e.g. user@example.com
-$proxy = new SshSocksConnector(isset($argv[1]) ? $argv[1] : 'localhost:22', $loop);
+$proxy = new SshSocksConnector(isset($argv[1]) ? $argv[1] : 'localhost:22', Loop::get());
 
 // create a Browser object that uses the SSH proxy client for connections
-$connector = new Connector($loop, array(
+$connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser($loop, $connector);
+$browser = new Browser(null, $connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
     echo RingCentral\Psr7\str($response);
 }, 'printf');
-
-$loop->run();

--- a/examples/14-client-unix-domain-sockets.php
+++ b/examples/14-client-unix-domain-sockets.php
@@ -1,27 +1,22 @@
 <?php
 
-use React\Http\Browser;
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Factory as LoopFactory;
+use React\Http\Browser;
 use React\Socket\FixedUriConnector;
 use React\Socket\UnixConnector;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = LoopFactory::create();
-
 // create a Browser object that uses the a Unix Domain Sockets (UDS) path for all requests
 $connector = new FixedUriConnector(
     'unix:///var/run/docker.sock',
-    new UnixConnector($loop)
+    new UnixConnector()
 );
 
-$browser = new Browser($loop, $connector);
+$browser = new Browser(null, $connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('http://localhost/info')->then(function (ResponseInterface $response) {
     echo Psr7\str($response);
 }, 'printf');
-
-$loop->run();

--- a/examples/21-client-request-streaming-to-stdout.php
+++ b/examples/21-client-request-streaming-to-stdout.php
@@ -13,11 +13,10 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
-$out = new WritableResourceStream(STDOUT, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$out = new WritableResourceStream(STDOUT);
+$info = new WritableResourceStream(STDERR);
 
 $url = isset($argv[1]) ? $argv[1] : 'http://google.com/';
 $info->write('Requesting ' . $url . '…' . PHP_EOL);
@@ -29,5 +28,3 @@ $client->requestStreaming('GET', $url)->then(function (ResponseInterface $respon
     assert($body instanceof ReadableStreamInterface);
     $body->pipe($out);
 }, 'printf');
-
-$loop->run();

--- a/examples/22-client-stream-upload-from-stdin.php
+++ b/examples/22-client-stream-upload-from-stdin.php
@@ -1,7 +1,7 @@
 <?php
 
-use React\Http\Browser;
 use Psr\Http\Message\ResponseInterface;
+use React\Http\Browser;
 use React\Stream\ReadableResourceStream;
 use RingCentral\Psr7;
 
@@ -12,10 +12,9 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
-$in = new ReadableResourceStream(STDIN, $loop);
+$in = new ReadableResourceStream(STDIN);
 
 $url = isset($argv[1]) ? $argv[1] : 'https://httpbin.org/post';
 echo 'Sending STDIN as POST to ' . $url . '…' . PHP_EOL;
@@ -23,5 +22,3 @@ echo 'Sending STDIN as POST to ' . $url . '…' . PHP_EOL;
 $client->post($url, array(), $in)->then(function (ResponseInterface $response) {
     echo 'Received' . PHP_EOL . Psr7\str($response);
 }, 'printf');
-
-$loop->run();

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -1,15 +1,12 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -19,9 +16,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -1,16 +1,13 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $counter = 0;
-$server = new Server($loop, function (ServerRequestInterface $request) use (&$counter) {
+$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array(
@@ -20,9 +17,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use (&$co
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -1,15 +1,12 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
@@ -21,9 +18,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -1,15 +1,12 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -28,9 +25,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -1,15 +1,12 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -34,9 +31,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -1,18 +1,16 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Http\Message\Response;
 use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
-    return new Promise(function ($resolve, $reject) use ($loop) {
-        $loop->addTimer(1.5, function() use ($resolve) {
+$server = new Server(function (ServerRequestInterface $request) {
+    return new Promise(function ($resolve, $reject) {
+        Loop::addTimer(1.5, function() use ($resolve) {
             $response = new Response(
                 200,
                 array(
@@ -25,9 +23,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     });
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -1,17 +1,14 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $count = 0;
-$server = new Server($loop, function (ServerRequestInterface $request) use (&$count) {
+$server = new Server(function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 
@@ -31,9 +28,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use (&$co
     });
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -1,16 +1,14 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Http\Message\Response;
 use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) use ($loop) {
+$server = new Server(function (ServerRequestInterface $request) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }
@@ -18,18 +16,18 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     $stream = new ThroughStream();
 
     // send some data every once in a while with periodic timer
-    $timer = $loop->addPeriodicTimer(0.5, function () use ($stream) {
+    $timer = Loop::addPeriodicTimer(0.5, function () use ($stream) {
         $stream->write(microtime(true) . PHP_EOL);
     });
 
     // demo for ending stream after a few seconds
-    $loop->addTimer(5.0, function() use ($stream) {
+    Loop::addTimer(5.0, function() use ($stream) {
         $stream->end();
     });
 
     // stop timer if stream is closed (such as when connection is closed)
-    $stream->on('close', function () use ($loop, $timer) {
-        $loop->cancelTimer($timer);
+    $stream->on('close', function () use ($timer) {
+        Loop::cancelTimer($timer);
     });
 
     return new Response(
@@ -41,9 +39,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($loo
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -7,15 +7,12 @@
 // $ curl -v http://localhost:8080/ -H 'Content-Type: application/json' -d '{"name":"Alice"}'
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
             415, // Unsupported Media Type
@@ -56,9 +53,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -1,15 +1,12 @@
 <?php
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$server = new Server($loop, function (ServerRequestInterface $request) {
+$server = new Server(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -19,8 +16,8 @@ $server = new Server($loop, function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
-$socket = new \React\Socket\SecureServer($socket, $loop, array(
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new \React\Socket\SecureServer($socket, null, array(
     'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
 ));
 $server->listen($socket);
@@ -28,5 +25,3 @@ $server->listen($socket);
 //$socket->on('error', 'printf');
 
 echo 'Listening on ' . str_replace('tls:', 'https:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -9,7 +9,6 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
@@ -18,8 +17,6 @@ use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 $handler = function (ServerRequestInterface $request) {
     if ($request->getMethod() === 'POST') {
@@ -125,7 +122,6 @@ HTML;
 // Note how this example explicitly uses the advanced `StreamingRequestMiddleware` to apply
 // custom request buffering limits below before running our request handler.
 $server = new Server(
-    $loop,
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
@@ -133,9 +129,7 @@ $server = new Server(
     $handler
 );
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', null);
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -1,16 +1,11 @@
 <?php
 
-use React\EventLoop\Factory;
-
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 // Note how this example uses the advanced `StreamingRequestMiddleware` to allow streaming
 // the incoming HTTP request. This very simple example merely counts the size
 // of the streaming body, it does not otherwise buffer its contents in memory.
 $server = new React\Http\Server(
-    $loop,
     new React\Http\Middleware\StreamingRequestMiddleware(),
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $body = $request->getBody();
@@ -49,9 +44,7 @@ $server = new React\Http\Server(
 
 $server->on('error', 'printf');
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -11,13 +11,11 @@ use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 // Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // This means that this proxy buffers the whole request before "processing" it.
 // As such, this is store-and-forward proxy. This could also use the advanced
 // `StreamingRequestMiddleware` to forward the incoming request as it comes in.
-$server = new Server($loop, function (RequestInterface $request) {
+$server = new Server(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,
@@ -48,9 +46,7 @@ $server = new Server($loop, function (RequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -4,7 +4,6 @@
 // $ curl -v --proxy http://localhost:8080 https://reactphp.org/
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
 use React\Http\Server;
 use React\Socket\Connector;
@@ -12,14 +11,13 @@ use React\Socket\ConnectionInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$connector = new Connector($loop);
+$connector = new Connector();
 
 // Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
 // Unlike the plain HTTP proxy, the CONNECT method does not contain a body
 // and we establish an end-to-end connection over the stream object, so this
 // doesn't have to store any payload data in memory at all.
-$server = new Server($loop, function (ServerRequestInterface $request) use ($connector) {
+$server = new Server(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,
@@ -53,9 +51,7 @@ $server = new Server($loop, function (ServerRequestInterface $request) use ($con
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', $loop);
+$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $server->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;
-
-$loop->run();

--- a/examples/91-client-benchmark-download.php
+++ b/examples/91-client-benchmark-download.php
@@ -11,8 +11,9 @@
 // b2) run HTTP client receiving a 10 GB download:
 // $ php examples/91-client-benchmark-download.php http://localhost:8080/10g.bin
 
-use React\Http\Browser;
 use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Loop;
+use React\Http\Browser;
 use React\Stream\ReadableStreamInterface;
 
 $url = isset($argv[1]) ? $argv[1] : 'http://google.com/';
@@ -23,12 +24,11 @@ if (extension_loaded('xdebug')) {
     echo 'NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL;
 }
 
-$loop = React\EventLoop\Factory::create();
-$client = new Browser($loop);
+$client = new Browser();
 
 echo 'Requesting ' . $url . '…' . PHP_EOL;
 
-$client->requestStreaming('GET', $url)->then(function (ResponseInterface $response) use ($loop) {
+$client->requestStreaming('GET', $url)->then(function (ResponseInterface $response) {
     echo 'Headers received' . PHP_EOL;
     echo RingCentral\Psr7\str($response);
 
@@ -42,19 +42,17 @@ $client->requestStreaming('GET', $url)->then(function (ResponseInterface $respon
     });
 
     // report progress every 0.1s
-    $timer = $loop->addPeriodicTimer(0.1, function () use (&$bytes) {
+    $timer = Loop::addPeriodicTimer(0.1, function () use (&$bytes) {
         echo "\rDownloaded " . $bytes . " bytes…";
     });
 
     // report results once the stream closes
     $time = microtime(true);
-    $stream->on('close', function() use (&$bytes, $timer, $loop, $time) {
-        $loop->cancelTimer($timer);
+    $stream->on('close', function() use (&$bytes, $timer, $time) {
+        Loop::cancelTimer($timer);
 
         $time = microtime(true) - $time;
 
         echo "\r" . 'Downloaded ' . $bytes . ' bytes in ' . round($time, 3) . 's => ' . round($bytes / $time / 1000000, 1) . ' MB/s' . PHP_EOL;
     });
 }, 'printf');
-
-$loop->run();

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -5,6 +5,7 @@ namespace React\Http;
 use Psr\Http\Message\ResponseInterface;
 use RingCentral\Psr7\Request;
 use RingCentral\Psr7\Uri;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
@@ -26,20 +27,23 @@ class Browser
     /**
      * The `Browser` is responsible for sending HTTP requests to your HTTP server
      * and keeps track of pending incoming HTTP responses.
-     * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
      *
      * ```php
-     * $loop = React\EventLoop\Factory::create();
-     *
-     * $browser = new React\Http\Browser($loop);
+     * $browser = new React\Http\Browser();
      * ```
+     *
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
      *
      * If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
      * proxy servers etc.), you can explicitly pass a custom instance of the
      * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
      *
      * ```php
-     * $connector = new React\Socket\Connector($loop, array(
+     * $connector = new React\Socket\Connector(null, array(
      *     'dns' => '127.0.0.1',
      *     'tcp' => array(
      *         'bindto' => '192.168.10.1:0'
@@ -50,15 +54,16 @@ class Browser
      *     )
      * ));
      *
-     * $browser = new React\Http\Browser($loop, $connector);
+     * $browser = new React\Http\Browser(null, $connector);
      * ```
      *
-     * @param LoopInterface $loop
-     * @param ConnectorInterface|null $connector [optional] Connector to use.
+     * @param ?LoopInterface $loop
+     * @param ?ConnectorInterface $connector [optional] Connector to use.
      *     Should be `null` in order to use default Connector.
      */
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
+    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null)
     {
+        $loop = $loop ?: Loop::get();
         $this->transaction = new Transaction(
             Sender::createFromLoop($loop, $connector),
             $loop
@@ -127,7 +132,7 @@ class Browser
      *
      * ```php
      * $body = new React\Stream\ThroughStream();
-     * $loop->addTimer(1.0, function () use ($body) {
+     * Loop::addTimer(1.0, function () use ($body) {
      *     $body->end("hello world");
      * });
      *
@@ -185,7 +190,7 @@ class Browser
      *
      * ```php
      * $body = new React\Stream\ThroughStream();
-     * $loop->addTimer(1.0, function () use ($body) {
+     * Loop::addTimer(1.0, function () use ($body) {
      *     $body->end("hello world");
      * });
      *
@@ -227,7 +232,7 @@ class Browser
      *
      * ```php
      * $body = new React\Stream\ThroughStream();
-     * $loop->addTimer(1.0, function () use ($body) {
+     * Loop::addTimer(1.0, function () use ($body) {
      *     $body->end("hello world");
      * });
      *
@@ -291,7 +296,7 @@ class Browser
      *
      * ```php
      * $body = new React\Stream\ThroughStream();
-     * $loop->addTimer(1.0, function () use ($body) {
+     * Loop::addTimer(1.0, function () use ($body) {
      *     $body->end("hello world");
      * });
      *
@@ -362,7 +367,7 @@ class Browser
      *
      * ```php
      * $body = new React\Stream\ThroughStream();
-     * $loop->addTimer(1.0, function () use ($body) {
+     * Loop::addTimer(1.0, function () use ($body) {
      *     $body->end("hello world");
      * });
      *

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -30,7 +30,6 @@ use React\Stream\ReadableStreamInterface;
  *
  * ```php
  * $server = new React\Http\Server(
- *     $loop,
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(10),
  *     $handler
@@ -43,7 +42,6 @@ use React\Stream\ReadableStreamInterface;
  *
  * ```php
  * $server = new React\Http\Server(
- *     $loop,
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -58,7 +56,6 @@ use React\Stream\ReadableStreamInterface;
  *
  * ```php
  * $server = new React\Http\Server(
- *     $loop,
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -28,6 +28,21 @@ class BrowserTest extends TestCase
         $ref->setValue($this->browser, $this->sender);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $browser = new Browser();
+
+        $ref = new \ReflectionProperty($browser, 'transaction');
+        $ref->setAccessible(true);
+        $transaction = $ref->getValue($browser);
+
+        $ref = new \ReflectionProperty($transaction, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($transaction);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testGetSendsGetRequest()
     {
         $that = $this;

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -83,6 +83,9 @@ class FunctionalIntegrationTest extends TestCase
     /** @group internet */
     public function testSuccessfulResponseEmitsEnd()
     {
+        // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
+        ini_set('xdebug.max_nesting_level', 256);
+
         $loop = Factory::create();
         $client = new Client($loop);
 
@@ -105,6 +108,9 @@ class FunctionalIntegrationTest extends TestCase
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('Not supported on HHVM');
         }
+
+        // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
+        ini_set('xdebug.max_nesting_level', 256);
 
         $loop = Factory::create();
         $client = new Client($loop);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -46,6 +46,21 @@ final class ServerTest extends TestCase
         $this->socket = new SocketServerStub();
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $server = new Server(function () { });
+
+        $ref = new \ReflectionProperty($server, 'streamingServer');
+        $ref->setAccessible(true);
+        $streamingServer = $ref->getValue($server);
+
+        $ref = new \ReflectionProperty($streamingServer, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($streamingServer);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$browser = new React\Http\Browser($loop);
$server = new React\Http\Server($loop, $handler);

// new (using default loop)
$browser = new React\Http\Browser();
$server = new React\Http\Server($handler);
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229, https://github.com/reactphp/event-loop/pull/232, https://github.com/reactphp/stream/pull/159, https://github.com/reactphp/dns/pull/182 and https://github.com/reactphp/socket/pull/260