### PR TITLE
Rename `Server` to `HttpServer` to avoid class name collisions and ambiguities

### DIFF
--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -2,11 +2,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -16,7 +15,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -2,12 +2,11 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $counter = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$counter) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
         200,
         array(
@@ -17,7 +16,7 @@ $server = new Server(function (ServerRequestInterface $request) use (&$counter) 
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -2,11 +2,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
@@ -18,7 +17,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -2,11 +2,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -25,7 +24,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -2,11 +2,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
@@ -31,7 +30,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -3,12 +3,11 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
             $response = new Response(
@@ -23,7 +22,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     });
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -2,13 +2,12 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $count = 0;
-$server = new Server(function (ServerRequestInterface $request) use (&$count) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$count) {
     return new Promise(function ($resolve, $reject) use (&$count) {
         $count++;
 
@@ -28,7 +27,7 @@ $server = new Server(function (ServerRequestInterface $request) use (&$count) {
     });
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -3,12 +3,11 @@
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(404);
     }
@@ -39,7 +38,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -8,11 +8,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
             415, // Unsupported Media Type
@@ -53,7 +52,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -2,11 +2,10 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
         200,
         array(
@@ -16,11 +15,11 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$socket = new \React\Socket\SecureServer($socket, null, array(
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SecureServer($socket, null, array(
     'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
 ));
-$server->listen($socket);
+$http->listen($socket);
 
 //$socket->on('error', 'printf');
 

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -14,7 +14,6 @@ use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\RequestBodyParserMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
-use React\Http\Server;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -121,7 +120,7 @@ HTML;
 
 // Note how this example explicitly uses the advanced `StreamingRequestMiddleware` to apply
 // custom request buffering limits below before running our request handler.
-$server = new Server(
+$http = new React\Http\HttpServer(
     new StreamingRequestMiddleware(),
     new LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers, queue otherwise
     new RequestBodyBufferMiddleware(8 * 1024 * 1024), // 8 MiB max, ignore body otherwise
@@ -129,7 +128,7 @@ $server = new Server(
     $handler
 );
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0', null);
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../vendor/autoload.php';
 // Note how this example uses the advanced `StreamingRequestMiddleware` to allow streaming
 // the incoming HTTP request. This very simple example merely counts the size
 // of the streaming body, it does not otherwise buffer its contents in memory.
-$server = new React\Http\Server(
+$http = new React\Http\HttpServer(
     new React\Http\Middleware\StreamingRequestMiddleware(),
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $body = $request->getBody();
@@ -42,9 +42,9 @@ $server = new React\Http\Server(
     }
 );
 
-$server->on('error', 'printf');
+$http->on('error', 'printf');
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -4,18 +4,16 @@
 // $ curl -v --proxy http://localhost:8080 http://reactphp.org/
 
 use Psr\Http\Message\RequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Message\Response;
-use React\Http\Server;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
+// Note how this example uses the `HttpServer` without the `StreamingRequestMiddleware`.
 // This means that this proxy buffers the whole request before "processing" it.
 // As such, this is store-and-forward proxy. This could also use the advanced
 // `StreamingRequestMiddleware` to forward the incoming request as it comes in.
-$server = new Server(function (RequestInterface $request) {
+$http = new React\Http\HttpServer(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
             400,
@@ -46,7 +44,7 @@ $server = new Server(function (RequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -5,7 +5,6 @@
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Socket\Connector;
 use React\Socket\ConnectionInterface;
 
@@ -13,11 +12,11 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $connector = new Connector();
 
-// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
+// Note how this example uses the `HttpServer` without the `StreamingRequestMiddleware`.
 // Unlike the plain HTTP proxy, the CONNECT method does not contain a body
 // and we establish an end-to-end connection over the stream object, so this
 // doesn't have to store any payload data in memory at all.
-$server = new Server(function (ServerRequestInterface $request) use ($connector) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             405,
@@ -51,7 +50,7 @@ $server = new Server(function (ServerRequestInterface $request) use ($connector)
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -20,15 +20,14 @@ $ telnet localhost 1080
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
+// Note how this example uses the `HttpServer` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             426,
@@ -57,7 +56,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -22,7 +22,6 @@ Hint: try this with multiple connections :)
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
 
@@ -33,10 +32,10 @@ require __DIR__ . '/../vendor/autoload.php';
 // this means that any Upgraded data will simply be sent back to the client
 $chat = new ThroughStream();
 
-// Note how this example uses the `Server` without the `StreamingRequestMiddleware`.
+// Note how this example uses the `HttpServer` without the `StreamingRequestMiddleware`.
 // The initial incoming request does not contain a body and we upgrade to a
 // stream object below.
-$server = new Server(function (ServerRequestInterface $request) use ($chat) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             426,
@@ -85,7 +84,7 @@ $server = new Server(function (ServerRequestInterface $request) use ($chat) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -17,7 +17,6 @@
 use Evenement\EventEmitter;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 
@@ -91,7 +90,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
     }
 }
 
-$server = new Server(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
@@ -123,7 +122,7 @@ $server = new Server(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new \React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$server->listen($socket);
+$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -15,7 +15,7 @@ use React\Http\Middleware\RequestBodyParserMiddleware;
 use React\Socket\ServerInterface;
 
 /**
- * The `React\Http\Server` class is responsible for handling incoming connections and then
+ * The `React\Http\HttpServer` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
  * When a complete HTTP request has been received, it will invoke the given
@@ -24,7 +24,7 @@ use React\Socket\ServerInterface;
  * object and expects a [response](#server-response) object in return:
  *
  * ```php
- * $server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
+ * $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
  *     return new React\Http\Message\Response(
  *         200,
  *         array(
@@ -49,7 +49,7 @@ use React\Socket\ServerInterface;
  * This value SHOULD NOT be given unless you're sure you want to explicitly use a
  * given event loop instance.
  *
- * In order to start listening for any incoming connections, the `Server` needs
+ * In order to start listening for any incoming connections, the `HttpServer` needs
  * to be attached to an instance of
  * [`React\Socket\ServerInterface`](https://github.com/reactphp/socket#serverinterface)
  * through the [`listen()`](#listen) method as described in the following
@@ -58,17 +58,17 @@ use React\Socket\ServerInterface;
  * to start a plaintext HTTP server like this:
  *
  * ```php
- * $server = new React\Http\Server($handler);
+ * $http = new React\Http\HttpServer($handler);
  *
  * $socket = new React\Socket\Server('0.0.0.0:8080');
- * $server->listen($socket);
+ * $http->listen($socket);
  * ```
  *
  * See also the [`listen()`](#listen) method and
  * [hello world server example](../examples/51-server-hello-world.php)
  * for more details.
  *
- * By default, the `Server` buffers and parses the complete incoming HTTP
+ * By default, the `HttpServer` buffers and parses the complete incoming HTTP
  * request in memory. It will invoke the given request handler function when the
  * complete request headers and request body has been received. This means the
  * [request](#server-request) object passed to your request handler function will be
@@ -121,14 +121,14 @@ use React\Socket\ServerInterface;
  * or explicitly limit concurrency.
  *
  * In order to override the above buffering defaults, you can configure the
- * `Server` explicitly. You can use the
+ * `HttpServer` explicitly. You can use the
  * [`LimitConcurrentRequestsMiddleware`](#limitconcurrentrequestsmiddleware) and
  * [`RequestBodyBufferMiddleware`](#requestbodybuffermiddleware) (see below)
  * to explicitly configure the total number of requests that can be handled at
  * once like this:
  *
  * ```php
- * $server = new React\Http\Server(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -153,7 +153,7 @@ use React\Socket\ServerInterface;
  * in memory:
  *
  * ```php
- * $server = new React\Http\Server(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     $handler
  * );
@@ -167,8 +167,12 @@ use React\Socket\ServerInterface;
  * have full control over consuming the incoming HTTP request body and
  * concurrency settings. See also [streaming incoming request](#streaming-incoming-request)
  * below for more details.
+ *
+ * > Changelog v1.5.0: This class has been renamed to `HttpServer` from the
+ *   previous `Server` class in order to avoid any ambiguities.
+ *   The previous name has been deprecated and should not be used anymore.
  */
-final class Server extends EventEmitter
+final class HttpServer extends EventEmitter
 {
     /**
      * The maximum buffer size used for each request.
@@ -263,10 +267,10 @@ final class Server extends EventEmitter
      * order to start a plaintext HTTP server like this:
      *
      * ```php
-     * $server = new React\Http\Server($handler);
+     * $http = new React\Http\HttpServer($handler);
      *
      * $socket = new React\Socket\Server(8080);
-     * $server->listen($socket);
+     * $http->listen($socket);
      * ```
      *
      * See also [hello world server example](../examples/51-server-hello-world.php)
@@ -289,12 +293,12 @@ final class Server extends EventEmitter
      * `passphrase` like this:
      *
      * ```php
-     * $server = new React\Http\Server($handler);
+     * $http = new React\Http\HttpServer($handler);
      *
      * $socket = new React\Socket\Server('tls://0.0.0.0:8443', null, array(
      *     'local_cert' => __DIR__ . '/localhost.pem'
      * ));
-     * $server->listen($socket);
+     * $http->listen($socket);
      * ```
      *
      * See also [hello world HTTPS example](../examples/61-server-hello-world-https.php)

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -20,7 +20,7 @@ use React\Stream\WritableStreamInterface;
  * The internal `StreamingServer` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
- * Unlike the [`Server`](#server) class, it does not buffer and parse the incoming
+ * Unlike the [`HttpServer`](#server) class, it does not buffer and parse the incoming
  * HTTP request body by default. This means that the request handler will be
  * invoked with a streaming request body. Once the request headers have been
  * received, it will invoke the request handler function. This request handler
@@ -63,7 +63,7 @@ use React\Stream\WritableStreamInterface;
  * See also the [`listen()`](#listen) method and the [first example](examples) for more details.
  *
  * The `StreamingServer` class is considered advanced usage and unless you know
- * what you're doing, you're recommended to use the [`Server`](#server) class
+ * what you're doing, you're recommended to use the [`HttpServer`](#httpserver) class
  * instead. The `StreamingServer` class is specifically designed to help with
  * more advanced use cases where you want to have full control over consuming
  * the incoming HTTP request body and concurrency settings.
@@ -75,7 +75,7 @@ use React\Stream\WritableStreamInterface;
  * handler function may not be fully compatible with PSR-7. See also
  * [streaming request](#streaming-request) below for more details.
  *
- * @see \React\Http\Server
+ * @see \React\Http\HttpServer
  * @see \React\Http\Message\Response
  * @see self::listen()
  * @internal
@@ -130,7 +130,7 @@ final class StreamingServer extends EventEmitter
      * Starts listening for HTTP requests on the given socket server instance
      *
      * @param ServerInterface $socket
-     * @see \React\Http\Server::listen()
+     * @see \React\Http\HttpServer::listen()
      */
     public function listen(ServerInterface $socket)
     {

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -29,7 +29,7 @@ use React\Stream\ReadableStreamInterface;
  * than 10 handlers will be invoked at once:
  *
  * ```php
- * $server = new React\Http\Server(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(10),
  *     $handler
@@ -41,7 +41,7 @@ use React\Stream\ReadableStreamInterface;
  * to limit the total number of requests that can be buffered at once:
  *
  * ```php
- * $server = new React\Http\Server(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
@@ -55,7 +55,7 @@ use React\Stream\ReadableStreamInterface;
  * processes one request after another without any concurrency:
  *
  * ```php
- * $server = new React\Http\Server(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request

--- a/src/Middleware/StreamingRequestMiddleware.php
+++ b/src/Middleware/StreamingRequestMiddleware.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * that emit chunks of incoming data as it is received:
  *
  * ```php
- * $server = new React\Http\Server(array(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     function (Psr\Http\Message\ServerRequestInterface $request) {
  *         $body = $request->getBody();
@@ -34,7 +34,7 @@ use Psr\Http\Message\ServerRequestInterface;
  *             });
  *         });
  *     }
- * ));
+ * );
  * ```
  *
  * See also [streaming incoming request](../../README.md#streaming-incoming-request)
@@ -47,17 +47,17 @@ use Psr\Http\Message\ServerRequestInterface;
  * once:
  *
  * ```php
- * $server = new React\Http\Server(array(
+ * $http = new React\Http\HttpServer(
  *     new React\Http\Middleware\StreamingRequestMiddleware(),
  *     new React\Http\Middleware\LimitConcurrentRequestsMiddleware(100), // 100 concurrent buffering handlers
  *     new React\Http\Middleware\RequestBodyBufferMiddleware(2 * 1024 * 1024), // 2 MiB per request
  *     new React\Http\Middleware\RequestBodyParserMiddleware(),
  *     $handler
- * ));
+ * );
  * ```
  *
  * > Internally, this class is used as a "marker" to not trigger the default
- *   request buffering behavior in the `Server`. It does not implement any logic
+ *   request buffering behavior in the `HttpServer`. It does not implement any logic
  *   on its own.
  */
 final class StreamingRequestMiddleware

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace React\Http;
+
+// Deprecated `Server` is an alias for new `HttpServer` to ensure existing code continues to work as-is.
+\class_alias(__NAMESPACE__ . '\\HttpServer', __NAMESPACE__ . '\\Server', true);
+
+// Aid static analysis and IDE autocompletion about this deprecation,
+// but don't actually execute during runtime because `HttpServer` is final.
+if (!\class_exists(__NAMESPACE__ . '\\Server', false)) {
+    /**
+     * @deprecated 1.5.0 See HttpServer instead
+     * @see HttpServer
+     */
+    final class Server extends HttpServer
+    {
+    }
+}

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -7,10 +7,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Factory;
 use React\Http\Browser;
+use React\Http\HttpServer;
 use React\Http\Message\ResponseException;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Message\Response;
-use React\Http\Server;
 use React\Promise\Promise;
 use React\Promise\Stream;
 use React\Socket\Connector;
@@ -32,7 +32,7 @@ class FunctionalBrowserTest extends TestCase
         $this->loop = $loop = Factory::create();
         $this->browser = new Browser($this->loop);
 
-        $server = new Server($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) use ($loop) {
+        $http = new HttpServer($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) use ($loop) {
             $path = $request->getUri()->getPath();
 
             $headers = array();
@@ -142,7 +142,7 @@ class FunctionalBrowserTest extends TestCase
             var_dump($path);
         });
         $socket = new \React\Socket\Server(0, $this->loop);
-        $server->listen($socket);
+        $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
     }
@@ -573,11 +573,11 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testPostStreamWillStartSendingRequestEvenWhenBodyDoesNotEmitData()
     {
-        $server = new Server($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
+        $http = new HttpServer($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
             return new Response(200);
         });
         $socket = new \React\Socket\Server(0, $this->loop);
-        $server->listen($socket);
+        $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
 
@@ -600,7 +600,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsHttp11ByDefault()
     {
-        $server = new Server($this->loop, function (ServerRequestInterface $request) {
+        $http = new HttpServer($this->loop, function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -608,7 +608,7 @@ class FunctionalBrowserTest extends TestCase
             );
         });
         $socket = new \React\Socket\Server(0, $this->loop);
-        $server->listen($socket);
+        $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
 
@@ -620,7 +620,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsExplicitHttp10Request()
     {
-        $server = new Server($this->loop, function (ServerRequestInterface $request) {
+        $http = new HttpServer($this->loop, function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -628,7 +628,7 @@ class FunctionalBrowserTest extends TestCase
             );
         });
         $socket = new \React\Socket\Server(0, $this->loop);
-        $server->listen($socket);
+        $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace React\Tests\Http;
+
+use React\Http\Server;
+
+class ServerTest extends TestCase
+{
+    public function testDeprecatedServerIsInstanceOfNewHttpServer()
+    {
+        $http = new Server(function () { });
+
+        $this->assertInstanceOf('React\Http\HttpServer', $http);
+    }
+}


### PR DESCRIPTION
This changeset renames the `Server` class to `HttpServer` to avoid class name collisions and ambiguities.

```php
// deprecated
$server = new React\Http\Server($handler);
$server->listen(new React\Socket\Server($port));

// new
$http = new React\Http\HttpServer($handler);
$http->listen(new React\Socket\Server($port));
```

The deprecated `Server` is now an alias for new `HttpServer` to ensure existing code continues to work as-is.