### PR TITLE
Update `Browser` signature to take `$connector` as first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ like this:
 
 ```php
 $browser = new React\Http\Browser(
-    null,
     new React\Socket\Connector(
         null,
         array(
@@ -610,7 +609,7 @@ $connector = new React\Socket\Connector(null, array(
     'dns' => false
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 ```
 
 See also the [HTTP CONNECT proxy example](examples/11-client-http-connect-proxy.php).
@@ -637,7 +636,7 @@ $connector = new React\Socket\Connector(null, array(
     'dns' => false
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 ```
 
 See also the [SOCKS proxy example](examples/12-client-socks-proxy.php).
@@ -666,7 +665,7 @@ $connector = new React\Socket\Connector(null, array(
     'dns' => false
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 ```
 
 See also the [SSH proxy example](examples/13-client-ssh-proxy.php).
@@ -687,7 +686,7 @@ $connector = new React\Socket\FixedUriConnector(
     new React\Socket\UnixConnector()
 );
 
-$browser = new Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 
 $client->get('http://localhost/info')->then(function (Psr\Http\Message\ResponseInterface $response) {
     var_dump($response->getHeaders(), (string)$response->getBody());
@@ -1869,11 +1868,15 @@ and keeps track of pending incoming HTTP responses.
 $browser = new React\Http\Browser();
 ```
 
-This class takes an optional `LoopInterface|null $loop` parameter that can be used to
-pass the event loop instance to use for this object. You can use a `null` value
-here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
-This value SHOULD NOT be given unless you're sure you want to explicitly use a
-given event loop instance.
+This class takes two optional arguments for more advanced usage:
+
+```php
+// constructor signature as of v1.5.0
+$browser = new React\Http\Browser(?ConnectorInterface $connector = null, ?LoopInterface $loop = null);
+
+// legacy constructor signature before v1.5.0
+$browser = new React\Http\Browser(?LoopInterface $loop = null, ?ConnectorInterface $connector = null);
+```
 
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
 proxy servers etc.), you can explicitly pass a custom instance of the
@@ -1891,8 +1894,14 @@ $connector = new React\Socket\Connector(null, array(
     )
 ));
 
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 > Note that the browser class is final and shouldn't be extended, it is likely to be marked final in a future release.
 

--- a/examples/11-client-http-connect-proxy.php
+++ b/examples/11-client-http-connect-proxy.php
@@ -21,7 +21,8 @@ $connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser(null, $connector);
+
+$browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -18,7 +18,8 @@ $connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser(null, $connector);
+
+$browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -17,7 +17,8 @@ $connector = new Connector(null, array(
     'tcp' => $proxy,
     'dns' => false
 ));
-$browser = new Browser(null, $connector);
+
+$browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {

--- a/examples/14-client-unix-domain-sockets.php
+++ b/examples/14-client-unix-domain-sockets.php
@@ -14,7 +14,7 @@ $connector = new FixedUriConnector(
     new UnixConnector()
 );
 
-$browser = new Browser(null, $connector);
+$browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('http://localhost/info')->then(function (ResponseInterface $response) {

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -30,7 +30,7 @@ class FunctionalBrowserTest extends TestCase
     public function setUpBrowserAndServer()
     {
         $this->loop = $loop = Factory::create();
-        $this->browser = new Browser($this->loop);
+        $this->browser = new Browser(null, $this->loop);
 
         $server = new Server($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) use ($loop) {
             $path = $request->getUri()->getPath();
@@ -398,7 +398,7 @@ class FunctionalBrowserTest extends TestCase
             )
         ));
 
-        $browser = new Browser($this->loop, $connector);
+        $browser = new Browser($connector, $this->loop);
 
         $this->setExpectedException('RuntimeException');
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
@@ -420,7 +420,7 @@ class FunctionalBrowserTest extends TestCase
             )
         ));
 
-        $browser = new Browser($this->loop, $connector);
+        $browser = new Browser($connector, $this->loop);
 
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
     }


### PR DESCRIPTION
This changeset updates the `Browser` signature to take the `$connector` as first argument.

```php
// unchanged
$browser = new React\Http\Browser();

 // deprecated
$browser = new React\Http\Browser(null, $connector);
$browser = new React\Http\Browser($loop, $connector);

// new
$browser = new React\Http\Browser($connector);
$browser = new React\Http\Browser($connector, $loop);
```

The new signature has been added to match the new `SocketServer` (https://github.com/reactphp/socket/pull/264) and consistently move the now commonly unneeded loop argument (#410) to the last argument. The previous signature has been deprecated and should not be used anymore. In its most basic form, both signatures are compatible. Existing code continues to work as-is.

Builds on top of https://github.com/reactphp/socket/pull/264, #410, https://github.com/reactphp/socket/pull/263 and #417