### PR TITLE
Simplify usage by supporting new Socket API without nullable loop arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\Server(8080);
+$socket = new React\Socket\SocketServer('127.0.0.1:8080');
 $http->listen($socket);
 ```
 
@@ -260,7 +260,6 @@ like this:
 ```php
 $browser = new React\Http\Browser(
     new React\Socket\Connector(
-        null,
         array(
             'timeout' => 5
         )
@@ -604,7 +603,7 @@ $proxy = new Clue\React\HttpProxy\ProxyConnector(
     new React\Socket\Connector()
 );
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -631,7 +630,7 @@ $proxy = new Clue\React\Socks\Client(
     new React\Socket\Connector()
 );
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -660,7 +659,7 @@ plain HTTP and TLS-encrypted HTTPS.
 ```php
 $proxy = new Clue\React\SshProxy\SshSocksConnector('me@localhost:22', Loop::get());
 
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));
@@ -741,13 +740,13 @@ to be attached to an instance of
 [`React\Socket\ServerInterface`](https://github.com/reactphp/socket#serverinterface)
 through the [`listen()`](#listen) method as described in the following
 chapter. In its most simple form, you can attach this to a
-[`React\Socket\Server`](https://github.com/reactphp/socket#server) in order
-to start a plaintext HTTP server like this:
+[`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
+in order to start a plaintext HTTP server like this:
 
 ```php
 $http = new React\Http\HttpServer($handler);
 
-$socket = new React\Socket\Server('0.0.0.0:8080');
+$socket = new React\Socket\SocketServer('0.0.0.0:8080');
 $http->listen($socket);
 ```
 
@@ -869,13 +868,13 @@ is responsible for emitting the underlying streaming connections. This
 HTTP server needs to be attached to it in order to process any
 connections and pase incoming streaming data as incoming HTTP request
 messages. In its most common form, you can attach this to a
-[`React\Socket\Server`](https://github.com/reactphp/socket#server) in
-order to start a plaintext HTTP server like this:
+[`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
+in order to start a plaintext HTTP server like this:
 
 ```php
 $http = new React\Http\HttpServer($handler);
 
-$socket = new React\Socket\Server('0.0.0.0:8080');
+$socket = new React\Socket\SocketServer('0.0.0.0:8080');
 $http->listen($socket);
 ```
 
@@ -894,15 +893,17 @@ Likewise, it's usually recommended to use a reverse proxy setup to accept
 secure HTTPS requests on default HTTPS port `443` (TLS termination) and
 only route plaintext requests to this HTTP server. As an alternative, you
 can also accept secure HTTPS requests with this HTTP server by attaching
-this to a [`React\Socket\Server`](https://github.com/reactphp/socket#server)
+this to a [`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
 using a secure TLS listen address, a certificate file and optional
 `passphrase` like this:
 
 ```php
 $http = new React\Http\HttpServer($handler);
 
-$socket = new React\Socket\Server('tls://0.0.0.0:8443', null, array(
-    'local_cert' => __DIR__ . '/localhost.pem'
+$socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', array(
+    'tls' => array(
+        'local_cert' => __DIR__ . '/localhost.pem'
+    )
 ));
 $http->listen($socket);
 ```
@@ -1889,7 +1890,7 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^2.3 || ^1.2.1",
         "react/promise-stream": "^1.1",
-        "react/socket": "^1.8",
+        "react/socket": "^1.9",
         "react/stream": "^1.2",
         "ringcentral/psr7": "^1.2"
     },

--- a/examples/11-client-http-connect-proxy.php
+++ b/examples/11-client-http-connect-proxy.php
@@ -17,7 +17,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new HttpConnectClient('127.0.0.1:8080', new Connector());
 
 // create a Browser object that uses the HTTP CONNECT proxy client for connections
-$connector = new Connector(null, array(
+$connector = new Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -14,7 +14,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new SocksClient('127.0.0.1:1080', new Connector());
 
 // create a Browser object that uses the SOCKS proxy client for connections
-$connector = new Connector(null, array(
+$connector = new Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new SshSocksConnector(isset($argv[1]) ? $argv[1] : 'localhost:22', Loop::get());
 
 // create a Browser object that uses the SSH proxy client for connections
-$connector = new Connector(null, array(
+$connector = new Connector(array(
     'tcp' => $proxy,
     'dns' => false
 ));

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -15,7 +15,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -16,7 +16,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -17,7 +17,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -24,7 +24,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -30,7 +30,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -22,7 +22,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     });
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -27,7 +27,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     });
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -38,7 +38,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -52,7 +52,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -15,12 +15,14 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$socket = new React\Socket\SecureServer($socket, null, array(
-    'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
+$uri = 'tls://' . (isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($uri, array(
+    'tls' => array(
+        'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
+    )
 ));
 $http->listen($socket);
 
-//$socket->on('error', 'printf');
+$socket->on('error', 'printf');
 
 echo 'Listening on ' . str_replace('tls:', 'https:', $socket->getAddress()) . PHP_EOL;

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -128,7 +128,7 @@ $http = new React\Http\HttpServer(
     $handler
 );
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -44,7 +44,7 @@ $http = new React\Http\HttpServer(
 
 $http->on('error', 'printf');
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -44,7 +44,7 @@ $http = new React\Http\HttpServer(function (RequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -50,7 +50,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -56,7 +56,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -84,7 +84,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -122,7 +122,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     );
 });
 
-$socket = new React\Socket\Server(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -47,7 +47,7 @@ class Browser
      * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
      *
      * ```php
-     * $connector = new React\Socket\Connector(null, array(
+     * $connector = new React\Socket\Connector(array(
      *     'dns' => '127.0.0.1',
      *     'tcp' => array(
      *         'bindto' => '192.168.10.1:0'

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -16,7 +16,7 @@ class Client
     public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
     {
         if ($connector === null) {
-            $connector = new Connector($loop);
+            $connector = new Connector(array(), $loop);
         }
 
         $this->connector = $connector;

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -54,13 +54,13 @@ use React\Socket\ServerInterface;
  * [`React\Socket\ServerInterface`](https://github.com/reactphp/socket#serverinterface)
  * through the [`listen()`](#listen) method as described in the following
  * chapter. In its most simple form, you can attach this to a
- * [`React\Socket\Server`](https://github.com/reactphp/socket#server) in order
- * to start a plaintext HTTP server like this:
+ * [`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
+ * in order to start a plaintext HTTP server like this:
  *
  * ```php
  * $http = new React\Http\HttpServer($handler);
  *
- * $socket = new React\Socket\Server('0.0.0.0:8080');
+ * $socket = new React\Socket\SocketServer('0.0.0.0:8080');
  * $http->listen($socket);
  * ```
  *
@@ -263,13 +263,13 @@ final class HttpServer extends EventEmitter
      * HTTP server needs to be attached to it in order to process any
      * connections and pase incoming streaming data as incoming HTTP request
      * messages. In its most common form, you can attach this to a
-     * [`React\Socket\Server`](https://github.com/reactphp/socket#server) in
-     * order to start a plaintext HTTP server like this:
+     * [`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
+     * in order to start a plaintext HTTP server like this:
      *
      * ```php
      * $http = new React\Http\HttpServer($handler);
      *
-     * $socket = new React\Socket\Server(8080);
+     * $socket = new React\Socket\SocketServer('0.0.0.0:8080');
      * $http->listen($socket);
      * ```
      *
@@ -288,15 +288,17 @@ final class HttpServer extends EventEmitter
      * secure HTTPS requests on default HTTPS port `443` (TLS termination) and
      * only route plaintext requests to this HTTP server. As an alternative, you
      * can also accept secure HTTPS requests with this HTTP server by attaching
-     * this to a [`React\Socket\Server`](https://github.com/reactphp/socket#server)
+     * this to a [`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
      * using a secure TLS listen address, a certificate file and optional
      * `passphrase` like this:
      *
      * ```php
      * $http = new React\Http\HttpServer($handler);
      *
-     * $socket = new React\Socket\Server('tls://0.0.0.0:8443', null, array(
-     *     'local_cert' => __DIR__ . '/localhost.pem'
+     * $socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', array(
+     *     'tls' => array(
+     *         'local_cert' => __DIR__ . '/localhost.pem'
+     *     )
      * ));
      * $http->listen($socket);
      * ```

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -39,7 +39,7 @@ class Sender
      * settings. You can use this method manually like this:
      *
      * ```php
-     * $connector = new \React\Socket\Connector($loop);
+     * $connector = new \React\Socket\Connector(array(), $loop);
      * $sender = \React\Http\Io\Sender::createFromLoop($loop, $connector);
      * ```
      *

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -20,7 +20,7 @@ use React\Stream\WritableStreamInterface;
  * The internal `StreamingServer` class is responsible for handling incoming connections and then
  * processing each incoming HTTP request.
  *
- * Unlike the [`HttpServer`](#server) class, it does not buffer and parse the incoming
+ * Unlike the [`HttpServer`](#httpserver) class, it does not buffer and parse the incoming
  * HTTP request body by default. This means that the request handler will be
  * invoked with a streaming request body. Once the request headers have been
  * received, it will invoke the request handler function. This request handler
@@ -50,13 +50,13 @@ use React\Stream\WritableStreamInterface;
  * In order to process any connections, the server needs to be attached to an
  * instance of `React\Socket\ServerInterface` through the [`listen()`](#listen) method
  * as described in the following chapter. In its most simple form, you can attach
- * this to a [`React\Socket\Server`](https://github.com/reactphp/socket#server)
+ * this to a [`React\Socket\SocketServer`](https://github.com/reactphp/socket#socketserver)
  * in order to start a plaintext HTTP server like this:
  *
  * ```php
  * $server = new StreamingServer($loop, $handler);
  *
- * $socket = new React\Socket\Server('0.0.0.0:8080', $loop);
+ * $socket = new React\Socket\SocketServer('0.0.0.0:8080', array(), $loop);
  * $server->listen($socket);
  * ```
  *

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -14,6 +14,7 @@ use React\Http\Message\Response;
 use React\Promise\Promise;
 use React\Promise\Stream;
 use React\Socket\Connector;
+use React\Socket\SocketServer;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use RingCentral\Psr7\Request;
@@ -141,7 +142,7 @@ class FunctionalBrowserTest extends TestCase
 
             var_dump($path);
         });
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
@@ -392,11 +393,11 @@ class FunctionalBrowserTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $connector = new Connector($this->loop, array(
+        $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => true
             )
-        ));
+        ), $this->loop);
 
         $browser = new Browser($connector, $this->loop);
 
@@ -414,11 +415,11 @@ class FunctionalBrowserTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $connector = new Connector($this->loop, array(
+        $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => false
             )
-        ));
+        ), $this->loop);
 
         $browser = new Browser($connector, $this->loop);
 
@@ -497,7 +498,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testRequestStreamReturnsResponseWithResponseBodyUndecodedWhenResponseHasDoubleTransferEncoding()
     {
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $socket->on('connection', function (\React\Socket\ConnectionInterface $connection) {
             $connection->on('data', function () use ($connection) {
                 $connection->end("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked, chunked\r\nConnection: close\r\n\r\nhello");
@@ -517,7 +518,7 @@ class FunctionalBrowserTest extends TestCase
     public function testReceiveStreamAndExplicitlyCloseConnectionEvenWhenServerKeepsConnectionOpen()
     {
         $closed = new \React\Promise\Deferred();
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $socket->on('connection', function (\React\Socket\ConnectionInterface $connection) use ($closed) {
             $connection->on('data', function () use ($connection) {
                 $connection->write("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello");
@@ -576,7 +577,7 @@ class FunctionalBrowserTest extends TestCase
         $http = new HttpServer($this->loop, new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
             return new Response(200);
         });
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
@@ -607,7 +608,7 @@ class FunctionalBrowserTest extends TestCase
                 $request->getProtocolVersion()
             );
         });
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
@@ -627,7 +628,7 @@ class FunctionalBrowserTest extends TestCase
                 $request->getProtocolVersion()
             );
         });
-        $socket = new \React\Socket\Server(0, $this->loop);
+        $socket = new SocketServer('127.0.0.1:0', array(), $this->loop);
         $http->listen($socket);
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';


### PR DESCRIPTION
This changeset simplifies usage by supporting the new Socket API without nullable loop arguments.

```php
// old
$http = new React\Http\HttpServer($handler);
$http->listen(new React\Socket\Server(8080));

// new
$http = new React\Http\HttpServer($handler);
$http->listen(new React\Socket\SocketServer('127.0.0.1:8080'));
```

Note that this doesn't affect the API of this package at all, but does use the improved API of the referenced Socket component. Existing code continues to work as is.

Together with #418, #417 and #410, this means we can now fully rely on the [default loop](https://github.com/reactphp/event-loop#loop) and no longer need to skip any arguments with `null` values. Additionally, this now consistently uses the `HttpServer` and `SocketServer` class names to avoid class name collisions and ambiguities.

Builds on top of https://github.com/reactphp/socket/pull/264 and https://github.com/reactphp/socket/pull/263