### PR TITLE
Update proxy examples to use simplified APIs thanks to default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,10 +598,7 @@ to HTTPS port`443` only, this can technically be used to tunnel any TCP/IP-based
 protocol, such as plain HTTP and TLS-encrypted HTTPS.
 
 ```php
-$proxy = new Clue\React\HttpProxy\ProxyConnector(
-    'http://127.0.0.1:8080',
-    new React\Socket\Connector()
-);
+$proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
 $connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
@@ -611,7 +608,7 @@ $connector = new React\Socket\Connector(array(
 $browser = new React\Http\Browser($connector);
 ```
 
-See also the [HTTP CONNECT proxy example](examples/11-client-http-connect-proxy.php).
+See also the [HTTP proxy example](examples/11-client-http-proxy.php).
 
 ### SOCKS proxy
 
@@ -625,10 +622,7 @@ address (anonymity) or to circumvent address blocking (geoblocking). While many
 only, this can technically be used to tunnel any TCP/IP-based protocol.
 
 ```php
-$proxy = new Clue\React\Socks\Client(
-    'socks://127.0.0.1:1080',
-    new React\Socket\Connector()
-);
+$proxy = new Clue\React\Socks\Client('127.0.0.1:1080');
 
 $connector = new React\Socket\Connector(array(
     'tcp' => $proxy,
@@ -657,7 +651,7 @@ from the outside (database behind firewall) and as such can also be used for
 plain HTTP and TLS-encrypted HTTPS.
 
 ```php
-$proxy = new Clue\React\SshProxy\SshSocksConnector('me@localhost:22', Loop::get());
+$proxy = new Clue\React\SshProxy\SshSocksConnector('alice@example.com');
 
 $connector = new React\Socket\Connector(array(
     'tcp' => $proxy,

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,9 @@
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "clue/http-proxy-react": "^1.3",
-        "clue/reactphp-ssh-proxy": "^1.0",
-        "clue/socks-react": "^1.0",
+        "clue/http-proxy-react": "^1.7",
+        "clue/reactphp-ssh-proxy": "^1.3",
+        "clue/socks-react": "^1.3",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {

--- a/examples/11-client-http-proxy.php
+++ b/examples/11-client-http-proxy.php
@@ -3,18 +3,17 @@
 // not already running a HTTP CONNECT proxy server?
 // Try LeProxy.org or this:
 //
-// $ php examples/72-server-http-connect-proxy.php 8080
-// $ php examples/11-client-http-connect-proxy.php
+// $ php examples/72-server-http-connect-proxy.php 127.0.0.1:8080
+// $ http_proxy=127.0.0.1:8080 php examples/11-client-http-connect-proxy.php
 
-use Clue\React\HttpProxy\ProxyConnector as HttpConnectClient;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// create a new HTTP CONNECT proxy client which connects to a HTTP CONNECT proxy server listening on localhost:8080
-$proxy = new HttpConnectClient('127.0.0.1:8080', new Connector());
+// create a new HTTP CONNECT proxy client which connects to a HTTP CONNECT proxy server listening on 127.0.0.1:8080
+$proxy = new Clue\React\HttpProxy\ProxyConnector(getenv('http_proxy') ?: '127.0.0.1:8080');
 
 // create a Browser object that uses the HTTP CONNECT proxy client for connections
 $connector = new Connector(array(

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -1,17 +1,19 @@
 <?php
 
 // not already running a SOCKS proxy server?
-// Try LeProxy.org or this: `ssh -D 1080 localhost`
+// Try LeProxy.org or this:
+//
+// $ ssh -D 1080 alice@example.com
+// $ socks_proxy=127.0.0.1:1080 php examples/12-client-socks-proxy.php
 
-use Clue\React\Socks\Client as SocksClient;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// create a new SOCKS proxy client which connects to a SOCKS proxy server listening on localhost:1080
-$proxy = new SocksClient('127.0.0.1:1080', new Connector());
+// create a new SOCKS proxy client which connects to a SOCKS proxy server listening on 127.0.0.1:1080
+$proxy = new Clue\React\Socks\Client(getenv('socks_proxy') ?: '127.0.0.1:1080');
 
 // create a Browser object that uses the SOCKS proxy client for connections
 $connector = new Connector(array(

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -1,16 +1,15 @@
 <?php
 
-use Clue\React\SshProxy\SshSocksConnector;
+// $ ssh_proxy=alice@example.com php examples/13-client-ssh-proxy.php
+
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Loop;
 use React\Http\Browser;
 use React\Socket\Connector;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// create a new SSH proxy client which connects to a SSH server listening on localhost:22
-// You can pass any SSH server address as first argument, e.g. user@example.com
-$proxy = new SshSocksConnector(isset($argv[1]) ? $argv[1] : 'localhost:22', Loop::get());
+// create a new SSH proxy client which connects to a SSH server listening on alice@localhost
+$proxy = new Clue\React\SshProxy\SshSocksConnector(getenv('ssh_proxy') ?: 'alice@localhost');
 
 // create a Browser object that uses the SSH proxy client for connections
 $connector = new Connector(array(


### PR DESCRIPTION
Builds on top of https://github.com/clue/reactphp-http-proxy/pull/41, https://github.com/clue/reactphp-socks/pull/100, https://github.com/clue/reactphp-ssh-proxy/pull/27, #419 and #410