### PR TITLE
Don't run requests through configuration middleware

### DIFF
--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -247,6 +247,14 @@ final class HttpServer extends EventEmitter
 
         $middleware = \array_merge($middleware, $requestHandlers);
 
+        /**
+         * Filter out any configuration middleware, no need to run requests through something that isn't
+         * doing anything with the request.
+         */
+        $middleware = \array_filter($middleware, function ($handler) {
+            return !($handler instanceof StreamingRequestMiddleware);
+        });
+
         $this->streamingServer = new StreamingServer($loop, new MiddlewareRunner($middleware));
 
         $that = $this;

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -431,4 +431,27 @@ final class HttpServerTest extends TestCase
         $this->assertTrue(is_array($middleware));
         $this->assertInstanceOf('React\Http\Middleware\LimitConcurrentRequestsMiddleware', $middleware[0]);
     }
+
+    public function testConstructFiltersOutConfigurationMiddlewareBefore()
+    {
+        $http = new HttpServer(new StreamingRequestMiddleware(), function () { });
+
+        $ref = new \ReflectionProperty($http, 'streamingServer');
+        $ref->setAccessible(true);
+
+        $streamingServer = $ref->getValue($http);
+
+        $ref = new \ReflectionProperty($streamingServer, 'callback');
+        $ref->setAccessible(true);
+
+        $middlewareRunner = $ref->getValue($streamingServer);
+
+        $ref = new \ReflectionProperty($middlewareRunner, 'middleware');
+        $ref->setAccessible(true);
+
+        $middleware = $ref->getValue($middlewareRunner);
+
+        $this->assertTrue(is_array($middleware));
+        $this->assertCount(1, $middleware);
+    }
 }


### PR DESCRIPTION
While working on another PR that introduces another configuration middleware it dawned on me that we preferably don't requests through middleware that don't do anything.

This change will filter it out those middleware before they are passed into the MiddlewareRunner.

While running benchmarks I gained around a 10% requests per second gain when running it against example 63.