### PR TITLE
Close inactive connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ multiple concurrent HTTP requests without blocking.
         * [ServerRequest](#serverrequest)
         * [ResponseException](#responseexception)
     * [React\Http\Middleware](#reacthttpmiddleware)
+        * [InactiveConnectionTimeoutMiddleware](#inactiveconnectiontimeoutmiddleware)
         * [StreamingRequestMiddleware](#streamingrequestmiddleware)
         * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
         * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
@@ -2497,6 +2498,22 @@ The `getResponse(): ResponseInterface` method can be used to
 access its underlying response object.
 
 ### React\Http\Middleware
+
+#### InactiveConnectionTimeoutMiddleware
+
+The `React\Http\Middleware\InactiveConnectionTimeoutMiddleware` is purely a configuration middleware to configure the
+`HttpServer` to close any inactive connections between requests to close the connection and not leave them needlessly open.
+
+The following example configures the `HttpServer` to close any inactive connections after one and a half second:
+
+```php
+$http = new React\Http\HttpServer(
+    new React\Http\Middleware\InactiveConnectionTimeoutMiddleware(1.5),
+    $handler
+);
+```
+> Internally, this class is used as a "value object" to override the default timeout of one minute.
+  As such it doesn't have any behavior internally, that is all in the internal "StreamingServer". 
 
 #### StreamingRequestMiddleware
 

--- a/src/Middleware/InactiveConnectionTimeoutMiddleware.php
+++ b/src/Middleware/InactiveConnectionTimeoutMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace React\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\HttpBodyStream;
+use React\Http\Io\PauseBufferStream;
+use React\Promise;
+use React\Promise\PromiseInterface;
+use React\Promise\Deferred;
+use React\Stream\ReadableStreamInterface;
+
+/**
+ * Closes any inactive connection after the specified amount of seconds since last activity.
+ *
+ * This allows you to set an alternative timeout to the default one minute (60 seconds). For example
+ * thirteen and a half seconds:
+ *
+ * ```php
+ * $http = new React\Http\HttpServer(
+ *     new React\Http\Middleware\InactiveConnectionTimeoutMiddleware(13.5),
+ *     $handler
+ * );
+ *
+ * > Internally, this class is used as a "value object" to override the default timeout of one minute.
+ *   As such it doesn't have any behavior internally, that is all in the internal "StreamingServer".
+ */
+final class InactiveConnectionTimeoutMiddleware
+{
+    const DEFAULT_TIMEOUT = 60;
+
+    /**
+     * @var float
+     */
+    private $timeout;
+
+    /**
+     * @param float $timeout
+     */
+    public function __construct($timeout = self::DEFAULT_TIMEOUT)
+    {
+        $this->timeout = $timeout;
+    }
+
+    public function __invoke(ServerRequestInterface $request, $next)
+    {
+        return $next($request);
+    }
+
+    /**
+     * @return float
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+}


### PR DESCRIPTION
This new middleware introduces a timeout of closing inactive 
connections between connections after a configured amount of seconds.

This builds on top of #405 and partially on #422

This PR very specifically doesn't deal with inactivity while handling requests, which will be proposed in a different PR.