### PR TITLE
Close inactive connections and requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     name: PHPUnit (PHP ${{ matrix.php }})
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         php:
           - 8.3

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ multiple concurrent HTTP requests without blocking.
         * [Uri](#uri)
         * [ResponseException](#responseexception)
     * [React\Http\Middleware](#reacthttpmiddleware)
+        * [InactiveConnectionTimeoutMiddleware](#inactiveconnectiontimeoutmiddleware)
         * [StreamingRequestMiddleware](#streamingrequestmiddleware)
         * [LimitConcurrentRequestsMiddleware](#limitconcurrentrequestsmiddleware)
         * [RequestBodyBufferMiddleware](#requestbodybuffermiddleware)
@@ -2691,6 +2692,25 @@ The `getResponse(): ResponseInterface` method can be used to
 access its underlying response object.
 
 ### React\Http\Middleware
+
+#### InactiveConnectionTimeoutMiddleware
+
+The `React\Http\Middleware\InactiveConnectionTimeoutMiddleware` is purely a configuration middleware to configure the
+`HttpServer` to close any inactive connections between requests to close the connection and not leave them needlessly 
+open. The default is `60` seconds of inactivity and should only be changed if you know what you are doing.
+
+The following example configures the `HttpServer` to close any inactive connections after one and a half second:
+
+```php
+$http = new React\Http\HttpServer(
+    new React\Http\Middleware\InactiveConnectionTimeoutMiddleware(1.5),
+    $handler
+);
+```
+> Internally, this class is used as a "value object" to override the default timeout of one minute.
+  As such it doesn't have any behavior internally, that is all in the internal "StreamingServer". 
+  This timeout is only in effect if we expect data from the client, not when we are writing data to
+  the client.
 
 #### StreamingRequestMiddleware
 

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -8,6 +8,7 @@ use React\EventLoop\LoopInterface;
 use React\Http\Io\IniUtil;
 use React\Http\Io\MiddlewareRunner;
 use React\Http\Io\StreamingServer;
+use React\Http\Middleware\InactiveConnectionTimeoutMiddleware;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
@@ -219,10 +220,13 @@ final class HttpServer extends EventEmitter
         }
 
         $streaming = false;
+        $idleConnectionTimeout = InactiveConnectionTimeoutMiddleware::DEFAULT_TIMEOUT;
         foreach ((array) $requestHandlers as $handler) {
             if ($handler instanceof StreamingRequestMiddleware) {
                 $streaming = true;
-                break;
+            }
+            if ($handler instanceof InactiveConnectionTimeoutMiddleware) {
+                $idleConnectionTimeout = $handler->getTimeout();
             }
         }
 
@@ -252,10 +256,10 @@ final class HttpServer extends EventEmitter
          * doing anything with the request.
          */
         $middleware = \array_filter($middleware, function ($handler) {
-            return !($handler instanceof StreamingRequestMiddleware);
+            return !($handler instanceof StreamingRequestMiddleware) && !($handler instanceof InactiveConnectionTimeoutMiddleware);
         });
 
-        $this->streamingServer = new StreamingServer($loop, new MiddlewareRunner($middleware));
+        $this->streamingServer = new StreamingServer($loop, new MiddlewareRunner($middleware), $idleConnectionTimeout);
 
         $that = $this;
         $this->streamingServer->on('error', function ($error) use ($that) {

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -87,6 +87,12 @@ final class StreamingServer extends EventEmitter
     /** @var Clock */
     private $clock;
 
+    /** @var LoopInterface */
+    private $loop;
+
+    /** @var int */
+    private $idleConnectionTimeout;
+
     /**
      * Creates an HTTP server that invokes the given callback for each incoming HTTP request
      *
@@ -95,19 +101,21 @@ final class StreamingServer extends EventEmitter
      * connections in order to then parse incoming data as HTTP.
      * See also [listen()](#listen) for more details.
      *
-     * @param LoopInterface $loop
      * @param callable $requestHandler
+     * @param int $idleConnectionTimeout
      * @see self::listen()
      */
-    public function __construct(LoopInterface $loop, $requestHandler)
+    public function __construct(LoopInterface $loop, $requestHandler, $idleConnectionTimeout)
     {
         if (!\is_callable($requestHandler)) {
             throw new \InvalidArgumentException('Invalid request handler given');
         }
 
+        $this->loop = $loop;
         $this->callback = $requestHandler;
         $this->clock = new Clock($loop);
         $this->parser = new RequestHeaderParser($this->clock);
+        $this->idleConnectionTimeout = $idleConnectionTimeout;
 
         $that = $this;
         $this->parser->on('headers', function (ServerRequestInterface $request, ConnectionInterface $conn) use ($that) {
@@ -134,7 +142,35 @@ final class StreamingServer extends EventEmitter
      */
     public function listen(ServerInterface $socket)
     {
-        $socket->on('connection', array($this->parser, 'handle'));
+        $socket->on('connection', array($this, 'handleConnection'));
+    }
+
+    /** @internal */
+    public function handleConnection(ConnectionInterface $connection)
+    {
+        $idleConnectionTimeout = $this->idleConnectionTimeout;
+        $loop = $this->loop;
+        $idleConnectionTimeoutHandler = function () use ($connection, &$closeEventHandler, &$dataEventHandler) {
+            $connection->removeListener('close', $closeEventHandler);
+            $connection->removeListener('data', $dataEventHandler);
+
+            $connection->close();
+        };
+        $timer = $this->loop->addTimer($idleConnectionTimeout, $idleConnectionTimeoutHandler);
+        $closeEventHandler = function () use ($connection, &$closeEventHandler, &$dataEventHandler, $loop, &$timer) {
+            $connection->removeListener('close', $closeEventHandler);
+            $connection->removeListener('data', $dataEventHandler);
+
+            $loop->cancelTimer($timer);
+        };
+        $dataEventHandler = function () use ($loop, $idleConnectionTimeout, $idleConnectionTimeoutHandler, &$timer) {
+            $loop->cancelTimer($timer);
+            $timer = $loop->addTimer($idleConnectionTimeout, $idleConnectionTimeoutHandler);
+        };
+        $connection->on('close', $closeEventHandler);
+        $connection->on('data', $dataEventHandler);
+
+        $this->parseRequest($connection);
     }
 
     /** @internal */
@@ -372,7 +408,7 @@ final class StreamingServer extends EventEmitter
 
             // either wait for next request over persistent connection or end connection
             if ($persist) {
-                $this->parser->handle($connection);
+                $this->parseRequest($connection);
             } else {
                 $connection->end();
             }
@@ -393,13 +429,67 @@ final class StreamingServer extends EventEmitter
         // write streaming body and then wait for next request over persistent connection
         if ($persist) {
             $body->pipe($connection, array('end' => false));
-            $parser = $this->parser;
-            $body->on('end', function () use ($connection, $parser, $body) {
+            $that = $this;
+            $body->on('end', function () use ($connection, $body, &$that) {
                 $connection->removeListener('close', array($body, 'close'));
-                $parser->handle($connection);
+                $that->parseRequest($connection);
             });
         } else {
             $body->pipe($connection);
         }
+    }
+
+    /**
+     * @internal
+     */
+    public function parseRequest(ConnectionInterface $connection)
+    {
+        $idleConnectionTimeout = $this->idleConnectionTimeout;
+        $loop = $this->loop;
+        $parser = $this->parser;
+        $idleConnectionTimeoutHandler = function () use ($connection, $parser, &$removeTimerHandler) {
+            $parser->removeListener('headers', $removeTimerHandler);
+            $parser->removeListener('error', $removeTimerHandler);
+
+            $parser->emit('error', array(
+                new \RuntimeException('Request timed out', Response::STATUS_REQUEST_TIMEOUT),
+                $connection
+            ));
+        };
+        $timer = $this->loop->addTimer($idleConnectionTimeout, $idleConnectionTimeoutHandler);
+        $removeTimerHandler = function ($requestOrError, $conn) use ($loop, &$timer, $parser, $connection, &$removeTimerHandler, $idleConnectionTimeout, $idleConnectionTimeoutHandler) {
+            if ($conn !== $connection) {
+                return;
+            }
+
+            $loop->cancelTimer($timer);
+            $parser->removeListener('headers', $removeTimerHandler);
+            $parser->removeListener('error', $removeTimerHandler);
+
+            if (!($requestOrError instanceof ServerRequestInterface)) {
+                return;
+            }
+
+            $requestBody = $requestOrError->getBody();
+            if (!($requestBody instanceof HttpBodyStream)) {
+                return;
+            }
+
+            $timer = $loop->addTimer($idleConnectionTimeout, $idleConnectionTimeoutHandler);
+            $requestBody->on('data', function () use (&$timer, $loop, $idleConnectionTimeout, $idleConnectionTimeoutHandler) {
+                $loop->cancelTimer($timer);
+                $timer = $loop->addTimer($idleConnectionTimeout, $idleConnectionTimeoutHandler);
+            });
+            $requestBody->on('end', function () use (&$timer, $loop) {
+                $loop->cancelTimer($timer);
+            });
+            $requestBody->on('close', function () use (&$timer, $loop) {
+                $loop->cancelTimer($timer);
+            });
+        };
+        $this->parser->on('headers', $removeTimerHandler);
+        $this->parser->on('error', $removeTimerHandler);
+
+        $this->parser->handle($connection);
     }
 }

--- a/src/Middleware/InactiveConnectionTimeoutMiddleware.php
+++ b/src/Middleware/InactiveConnectionTimeoutMiddleware.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace React\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\HttpBodyStream;
+use React\Http\Io\PauseBufferStream;
+use React\Promise;
+use React\Promise\PromiseInterface;
+use React\Promise\Deferred;
+use React\Stream\ReadableStreamInterface;
+
+/**
+ * Closes any inactive connection after the specified amount of seconds since last activity.
+ *
+ * This allows you to set an alternative timeout to the default one minute (60 seconds). For example
+ * thirteen and a half seconds:
+ *
+ * ```php
+ * $http = new React\Http\HttpServer(
+ *     new React\Http\Middleware\InactiveConnectionTimeoutMiddleware(13.5),
+ *     $handler
+ * );
+ *
+ * > Internally, this class is used as a "value object" to override the default timeout of one minute.
+ *   As such it doesn't have any behavior internally, that is all in the internal "StreamingServer".
+ */
+final class InactiveConnectionTimeoutMiddleware
+{
+    /**
+     * @internal
+     */
+    const DEFAULT_TIMEOUT = 60;
+
+    /**
+     * @var float
+     */
+    private $timeout;
+
+    /**
+     * @param float $timeout
+     */
+    public function __construct($timeout = self::DEFAULT_TIMEOUT)
+    {
+        $this->timeout = $timeout;
+    }
+
+    public function __invoke(ServerRequestInterface $request, $next)
+    {
+        return $next($request);
+    }
+
+    /**
+     * @return float
+     * @internal
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+}

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -9,6 +9,7 @@ use React\Http\Browser;
 use React\Http\HttpServer;
 use React\Http\Message\Response;
 use React\Http\Message\ResponseException;
+use React\Http\Middleware\InactiveConnectionTimeoutMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Promise\Promise;
 use React\Promise\Stream;
@@ -32,7 +33,7 @@ class FunctionalBrowserTest extends TestCase
     {
         $this->browser = new Browser();
 
-        $http = new HttpServer(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
+        $http = new HttpServer(new InactiveConnectionTimeoutMiddleware(0.2), new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
             $path = $request->getUri()->getPath();
 
             $headers = array();
@@ -687,7 +688,7 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testPostStreamWillStartSendingRequestEvenWhenBodyDoesNotEmitData()
     {
-        $http = new HttpServer(new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
+        $http = new HttpServer(new InactiveConnectionTimeoutMiddleware(0.1), new StreamingRequestMiddleware(), function (ServerRequestInterface $request) {
             return new Response(200);
         });
         $socket = new SocketServer('127.0.0.1:0');
@@ -714,7 +715,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsHttp11ByDefault()
     {
-        $http = new HttpServer(function (ServerRequestInterface $request) {
+        $http = new HttpServer(new InactiveConnectionTimeoutMiddleware(0.1), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -734,7 +735,7 @@ class FunctionalBrowserTest extends TestCase
 
     public function testSendsExplicitHttp10Request()
     {
-        $http = new HttpServer(function (ServerRequestInterface $request) {
+        $http = new HttpServer(new InactiveConnectionTimeoutMiddleware(0.1), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\HttpServer;
 use React\Http\Message\Response;
+use React\Http\Middleware\InactiveConnectionTimeoutMiddleware;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
@@ -23,7 +24,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -48,7 +49,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(
+        $http = $this->createServer(
             function () {
                 return new Response(404);
             }
@@ -74,7 +75,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -99,7 +100,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -130,7 +131,7 @@ class FunctionalHttpServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -159,7 +160,7 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -201,7 +202,7 @@ class FunctionalHttpServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -233,7 +234,7 @@ class FunctionalHttpServerTest extends TestCase
         }
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -262,7 +263,7 @@ class FunctionalHttpServerTest extends TestCase
         }
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -300,7 +301,7 @@ class FunctionalHttpServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -338,7 +339,7 @@ class FunctionalHttpServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -367,7 +368,7 @@ class FunctionalHttpServerTest extends TestCase
         }
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -405,7 +406,7 @@ class FunctionalHttpServerTest extends TestCase
             'tls' => array('verify_peer' => false)
         ));
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri() . 'x' . $request->getHeaderLine('Host'));
         });
 
@@ -432,7 +433,7 @@ class FunctionalHttpServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $http = new HttpServer(function (RequestInterface $request) use ($stream) {
+        $http = $this->createServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -458,7 +459,7 @@ class FunctionalHttpServerTest extends TestCase
         $connector = new Connector();
 
         $once = $this->expectCallableOnce();
-        $http = new HttpServer(
+        $http = $this->createServer(
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($once) {
                 $request->getBody()->on('close', $once);
@@ -487,7 +488,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $stream = new ThroughStream();
 
-        $http = new HttpServer(
+        $http = $this->createServer(
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($stream) {
                 return new Response(200, array(), $stream);
@@ -519,7 +520,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $stream = new ThroughStream();
 
-        $http = new HttpServer(function (RequestInterface $request) use ($stream) {
+        $http = $this->createServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
@@ -546,7 +547,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
             Loop::addTimer(0.1, function () use ($stream) {
@@ -582,7 +583,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
             Loop::addTimer(0.1, function () use ($stream) {
@@ -619,7 +620,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
             Loop::addTimer(0.1, function () use ($stream) {
@@ -655,7 +656,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
             Loop::addTimer(0.1, function () use ($stream) {
@@ -695,7 +696,7 @@ class FunctionalHttpServerTest extends TestCase
     {
         $connector = new Connector();
 
-        $http = new HttpServer(function (RequestInterface $request) {
+        $http = $this->createServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
             $stream->close();
 
@@ -732,7 +733,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $connector = new Connector();
 
-        $http = new HttpServer(
+        $http = $this->createServer(
             new LimitConcurrentRequestsMiddleware(5),
             new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
             function (ServerRequestInterface $request, $next) {
@@ -773,6 +774,14 @@ class FunctionalHttpServerTest extends TestCase
         $socket->close();
     }
 
+    private function createServer()
+    {
+        $args = \func_get_args();
+        array_unshift($args, new InactiveConnectionTimeoutMiddleware(1));
+        $serverReflection = new \ReflectionClass('React\Http\HttpServer');
+
+        return $serverReflection->newInstanceArgs($args);
+    }
 }
 
 function noScheme($uri)

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -6,6 +6,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\HttpServer;
 use React\Http\Io\IniUtil;
+use React\Http\Io\StreamingServer;
+use React\Http\Middleware\InactiveConnectionTimeoutMiddleware;
 use React\Http\Middleware\StreamingRequestMiddleware;
 use React\Promise;
 use React\Promise\Deferred;
@@ -50,7 +52,7 @@ final class HttpServerTest extends TestCase
 
     public function testConstructWithoutLoopAssignsLoopAutomatically()
     {
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
         $ref->setAccessible(true);
@@ -59,6 +61,10 @@ final class HttpServerTest extends TestCase
         $ref = new \ReflectionProperty($streamingServer, 'clock');
         $ref->setAccessible(true);
         $clock = $ref->getValue($streamingServer);
+
+        $ref = new \ReflectionProperty($streamingServer, 'parser');
+        $ref->setAccessible(true);
+        $parser = $ref->getValue($streamingServer);
 
         $ref = new \ReflectionProperty($clock, 'loop');
         $ref->setAccessible(true);
@@ -70,13 +76,13 @@ final class HttpServerTest extends TestCase
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        new HttpServer('invalid');
+        $this->createServer('invalid');
     }
 
     public function testSimpleRequestCallsRequestHandlerOnce()
     {
         $called = null;
-        $http = new HttpServer(function (ServerRequestInterface $request) use (&$called) {
+        $http = $this->createServer(function (ServerRequestInterface $request) use (&$called) {
             ++$called;
         });
 
@@ -93,7 +99,7 @@ final class HttpServerTest extends TestCase
     public function testSimpleRequestCallsArrayRequestHandlerOnce()
     {
         $this->called = null;
-        $http = new HttpServer(array($this, 'helperCallableOnce'));
+        $http = $this->createServer(array($this, 'helperCallableOnce'));
 
         $http->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -110,7 +116,7 @@ final class HttpServerTest extends TestCase
     public function testSimpleRequestWithMiddlewareArrayProcessesMiddlewareStack()
     {
         $called = null;
-        $http = new HttpServer(
+        $http = $this->createServer(
             function (ServerRequestInterface $request, $next) use (&$called) {
                 $called = 'before';
                 $ret = $next($request->withHeader('Demo', 'ok'));
@@ -133,7 +139,7 @@ final class HttpServerTest extends TestCase
     public function testPostFormData()
     {
         $deferred = new Deferred();
-        $http = new HttpServer(function (ServerRequestInterface $request) use ($deferred) {
+        $http = $this->createServer(function (ServerRequestInterface $request) use ($deferred) {
             $deferred->resolve($request);
         });
 
@@ -161,7 +167,7 @@ final class HttpServerTest extends TestCase
     public function testPostFileUpload()
     {
         $deferred = new Deferred();
-        $http = new HttpServer(function (ServerRequestInterface $request) use ($deferred) {
+        $http = $this->createServer(function (ServerRequestInterface $request) use ($deferred) {
             $deferred->resolve($request);
         });
 
@@ -204,7 +210,7 @@ final class HttpServerTest extends TestCase
     public function testPostJsonWillNotBeParsedByDefault()
     {
         $deferred = new Deferred();
-        $http = new HttpServer(function (ServerRequestInterface $request) use ($deferred) {
+        $http = $this->createServer(function (ServerRequestInterface $request) use ($deferred) {
             $deferred->resolve($request);
         });
 
@@ -229,7 +235,7 @@ final class HttpServerTest extends TestCase
     public function testServerReceivesBufferedRequestByDefault()
     {
         $streaming = null;
-        $http = new HttpServer(function (ServerRequestInterface $request) use (&$streaming) {
+        $http = $this->createServer(function (ServerRequestInterface $request) use (&$streaming) {
             $streaming = $request->getBody() instanceof ReadableStreamInterface;
         });
 
@@ -243,7 +249,7 @@ final class HttpServerTest extends TestCase
     public function testServerWithStreamingRequestMiddlewareReceivesStreamingRequest()
     {
         $streaming = null;
-        $http = new HttpServer(
+        $http = $this->createServer(
             new StreamingRequestMiddleware(),
             function (ServerRequestInterface $request) use (&$streaming) {
                 $streaming = $request->getBody() instanceof ReadableStreamInterface;
@@ -257,11 +263,27 @@ final class HttpServerTest extends TestCase
         $this->assertEquals(true, $streaming);
     }
 
+    public function testIdleConnectionWillBeClosedAfterConfiguredTimeout()
+    {
+        $startTime = time();
+        $this->connection->expects($this->once())->method('close');
+
+        $http = $this->createServer($this->expectCallableNever());
+
+        $http->listen($this->socket);
+
+        $this->socket->emit('connection', array($this->connection));
+
+        Loop::run();
+
+        $this->assertLessThan(1.2, time() - $startTime);
+    }
+
     public function testForwardErrors()
     {
         $exception = new \Exception();
         $capturedException = null;
-        $http = new HttpServer(function () use ($exception) {
+        $http = $this->createServer(function () use ($exception) {
             return Promise\reject($exception);
         });
         $http->on('error', function ($error) use (&$capturedException) {
@@ -329,7 +351,7 @@ final class HttpServerTest extends TestCase
      */
     public function testServerConcurrency($memory_limit, $post_max_size, $expectedConcurrency)
     {
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getConcurrentRequestsLimit');
         $ref->setAccessible(true);
@@ -341,7 +363,7 @@ final class HttpServerTest extends TestCase
 
     public function testServerGetPostMaxSizeReturnsSizeFromGivenIniSetting()
     {
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
         $ref->setAccessible(true);
@@ -353,7 +375,7 @@ final class HttpServerTest extends TestCase
 
     public function testServerGetPostMaxSizeReturnsSizeCappedFromGivenIniSetting()
     {
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
         $ref->setAccessible(true);
@@ -369,7 +391,7 @@ final class HttpServerTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
         $ref->setAccessible(true);
@@ -384,7 +406,7 @@ final class HttpServerTest extends TestCase
         $old = ini_get('memory_limit');
         ini_set('memory_limit', '-1');
 
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         ini_set('memory_limit', $old);
 
@@ -414,7 +436,7 @@ final class HttpServerTest extends TestCase
             $this->markTestSkipped('Unable to change memory limit');
         }
 
-        $http = new HttpServer(function () { });
+        $http = $this->createServer(function () { });
 
         ini_set('memory_limit', $old);
 
@@ -439,7 +461,7 @@ final class HttpServerTest extends TestCase
 
     public function testConstructFiltersOutConfigurationMiddlewareBefore()
     {
-        $http = new HttpServer(new StreamingRequestMiddleware(), function () { });
+        $http = $this->createServer(new InactiveConnectionTimeoutMiddleware(0), new StreamingRequestMiddleware(), function () { });
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
         $ref->setAccessible(true);
@@ -458,5 +480,14 @@ final class HttpServerTest extends TestCase
 
         $this->assertTrue(is_array($middleware));
         $this->assertCount(1, $middleware);
+    }
+
+    private function createServer()
+    {
+        $args = \func_get_args();
+        array_unshift($args, new InactiveConnectionTimeoutMiddleware(1));
+        $serverReflection = new \ReflectionClass('React\Http\HttpServer');
+
+        return $serverReflection->newInstanceArgs($args);
     }
 }

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -864,7 +864,7 @@ class RequestHeaderParserTest extends TestCase
         $this->assertEquals(array(), $ref->getValue($parser));
     }
 
-    public function testQueryParmetersWillBeSet()
+    public function testQueryParametersWillBeSet()
     {
         $request = null;
 

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -61,7 +61,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -73,7 +73,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnce());
+        $server = $this->createStreamingServer($this->expectCallableOnce());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -88,7 +88,7 @@ class StreamingServerTest extends TestCase
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
-        $server = new StreamingServer(Loop::get(), array($this, 'helperCallableOnce'));
+        $server = $this->createStreamingServer(array($this, 'helperCallableOnce'));
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -108,7 +108,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -141,7 +141,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -173,7 +173,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -195,7 +195,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -217,7 +217,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -239,7 +239,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetHttp10WithoutHostWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -261,7 +261,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestGetHttp11WithoutHostWillReject()
     {
-        $server = new StreamingServer(Loop::get(), 'var_dump');
+        $server = $this->createStreamingServer('var_dump');
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -274,7 +274,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -294,7 +294,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -307,7 +307,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -329,7 +329,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectWithoutHostWillBePassesAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -351,7 +351,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -373,7 +373,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -394,7 +394,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -406,7 +406,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -420,7 +420,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -446,7 +446,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -468,7 +468,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -488,7 +488,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestAbsoluteWithoutHostWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -502,7 +502,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -524,7 +524,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -544,7 +544,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->pause();
         });
 
@@ -564,7 +564,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->resume();
         });
 
@@ -584,7 +584,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCloseWillNotCloseConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
         });
 
@@ -599,7 +599,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();
         });
@@ -616,7 +616,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
         });
@@ -635,7 +635,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
         });
 
@@ -650,7 +650,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -670,7 +670,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -691,7 +691,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsServerHeader()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -721,7 +721,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -751,7 +751,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -783,7 +783,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -812,13 +812,15 @@ class StreamingServerTest extends TestCase
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertStringEndsWith("\r\n\r\n0\r\n\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseBodyStreamEndingWillSendEmptyBodyChunkedEncoded()
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -849,6 +851,8 @@ class StreamingServerTest extends TestCase
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertStringEndsWith("\r\n\r\n0\r\n\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseBodyStreamAlreadyClosedWillSendEmptyBodyPlainHttp10()
@@ -856,7 +860,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -892,7 +896,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -947,7 +951,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -965,7 +969,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -997,11 +1001,13 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', array($data));
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nUpgrade: demo\r\nContent-Length: 3\r\n\r\nfoo", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -1032,11 +1038,13 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', array($data));
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 101,
                 array(
@@ -1076,7 +1084,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
                 array(
@@ -1117,7 +1125,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1155,7 +1163,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1174,7 +1182,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1203,11 +1211,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("bye", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1241,7 +1251,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1270,6 +1280,8 @@ class StreamingServerTest extends TestCase
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
         $this->assertNotContainsString("bye", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoResponseBodyForHeadRequestWithStreamingResponse()
@@ -1277,7 +1289,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array('Content-Length' => '3'),
@@ -1305,11 +1317,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 204,
                 array(),
@@ -1338,6 +1352,8 @@ class StreamingServerTest extends TestCase
         $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
         $this->assertNotContainsString("bye", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatusResponseWithStreamingBody()
@@ -1345,7 +1361,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 204,
                 array('Content-Length' => '3'),
@@ -1373,11 +1389,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1405,11 +1423,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 0\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsExplicitContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array('Content-Length' => 3),
@@ -1437,11 +1457,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsExplicitContentLengthHeaderForHeadRequests()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Content-Length' => 3),
@@ -1469,11 +1491,13 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1502,6 +1526,8 @@ class StreamingServerTest extends TestCase
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
         $this->assertNotContainsString("bye", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatusWithStreamingBody()
@@ -1509,7 +1535,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 304,
                 array('Content-Length' => '3'),
@@ -1537,12 +1563,14 @@ class StreamingServerTest extends TestCase
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+
+        Loop::run();
     }
 
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1576,7 +1604,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1610,7 +1638,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1647,7 +1675,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1675,7 +1703,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1706,7 +1734,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1735,7 +1763,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1763,7 +1791,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1793,7 +1821,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1820,7 +1848,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1851,7 +1879,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1883,7 +1911,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1909,7 +1937,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1936,7 +1964,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1962,7 +1990,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1987,7 +2015,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2009,7 +2037,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2032,7 +2060,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2054,7 +2082,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2081,7 +2109,7 @@ class StreamingServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -2105,7 +2133,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -2124,7 +2152,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -2158,7 +2186,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2199,7 +2227,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2228,6 +2256,8 @@ class StreamingServerTest extends TestCase
         $this->assertContainsString("Transfer-Encoding: chunked", $buffer);
         $this->assertNotContainsString("Content-Length:", $buffer);
         $this->assertContainsString("body", $buffer);
+
+        Loop::run();
     }
 
     public function testResponseContainsResponseBodyWithPlainBodyWithUnknownSizeForLegacyHttp10()
@@ -2236,7 +2266,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2270,7 +2300,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(
@@ -2307,7 +2337,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDateFromClock()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2345,7 +2375,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithCustomDateHeaderOverwritesDefault()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
@@ -2378,7 +2408,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Date' => '')
@@ -2411,7 +2441,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseCanContainMultipleCookieHeaders()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2449,7 +2479,7 @@ class StreamingServerTest extends TestCase
 
     public function testReponseWithExpectContinueRequestContainsContinueWithLaterResponse()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2481,7 +2511,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2512,14 +2542,14 @@ class StreamingServerTest extends TestCase
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        new StreamingServer(Loop::get(), 'invalid');
+        $this->createStreamingServer('invalid');
     }
 
     public function testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding()
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array(),
@@ -2558,7 +2588,7 @@ class StreamingServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array('Content-Length' => 5),
@@ -2596,7 +2626,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithResponsePromise()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2624,7 +2654,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseReturnInvalidTypeWillResultInError()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2658,7 +2688,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2686,7 +2716,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2717,7 +2747,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2748,7 +2778,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Transfer-Encoding' => 'chunked'),
@@ -2784,7 +2814,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWillBeHandled()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2812,7 +2842,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2850,7 +2880,7 @@ class StreamingServerTest extends TestCase
      */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             throw new \Error('hello');
         });
 
@@ -2893,7 +2923,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2980,7 +3010,7 @@ class StreamingServerTest extends TestCase
      */
     public function testInvalidResponseObjectWillResultInErrorMessage(ResponseInterface $response)
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($response) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($response) {
             return $response;
         });
 
@@ -3015,7 +3045,7 @@ class StreamingServerTest extends TestCase
     public function testRequestServerRequestParams()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3049,7 +3079,7 @@ class StreamingServerTest extends TestCase
     public function testRequestQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3069,7 +3099,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3090,7 +3120,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3111,7 +3141,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3131,7 +3161,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithCommaValueWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3150,7 +3180,7 @@ class StreamingServerTest extends TestCase
 
     public function testNewConnectionWillInvokeParserOnce()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3167,7 +3197,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array(), '', '1.0');
 
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
+        $server = $this->createStreamingServer($this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3190,7 +3220,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'close'));
 
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
+        $server = $this->createStreamingServer($this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3213,7 +3243,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response(200, array('Connection' => 'close'));
         });
 
@@ -3238,7 +3268,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response();
         });
 
@@ -3263,7 +3293,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'keep-alive'), '', '1.0');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response();
         });
 
@@ -3289,7 +3319,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function () use ($body) {
+        $server = $this->createStreamingServer(function () use ($body) {
             return new Response(200, array(), $body);
         });
 
@@ -3315,7 +3345,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function () use ($body) {
+        $server = $this->createStreamingServer(function () use ($body) {
             return new Response(200, array(), $body);
         });
 
@@ -3335,9 +3365,9 @@ class StreamingServerTest extends TestCase
         // pretend parser just finished parsing
         $server->handleRequest($this->connection, $request);
 
-        $this->assertCount(2, $this->connection->listeners('close'));
+        $this->assertCount(3, $this->connection->listeners('close'));
         $body->end();
-        $this->assertCount(1, $this->connection->listeners('close'));
+        $this->assertCount(2, $this->connection->listeners('close'));
     }
 
     public function testCompletingARequestWillRemoveConnectionOnCloseListener()
@@ -3346,7 +3376,7 @@ class StreamingServerTest extends TestCase
 
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return \React\Promise\resolve(new Response());
         });
 
@@ -3359,6 +3389,89 @@ class StreamingServerTest extends TestCase
         $server->handleRequest($connection, $request);
     }
 
+    public function testIdleConnectionWillBeClosedAfterConfiguredTimeout()
+    {
+        $startTime = time();
+
+        $this->connection->expects($this->once())->method('close');
+
+        $server = $this->createStreamingServer($this->expectCallableNever(), 0.1);
+
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
+
+        Loop::run();
+
+        $this->assertLessThan(1.2, time() - $startTime);
+    }
+
+    public function testIdleConnectionWillBeClosedAfterConfiguredTimeoutWhileParsingHeadersReturnsA408()
+    {
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+        $this->connection->expects($this->once())->method('close');
+
+        $server = $this->createStreamingServer($this->expectCallableNever(), 0.1);
+
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
+        $this->connection->emit('data', array('GET / HTTP/1.1'));
+
+        Loop::run();
+
+        $this->assertStringStartsWith("HTTP/1.1 408 Request Timeout\r\n", $buffer);
+        $this->assertStringEndsWith("\r\n\r\nError 408: Request Timeout", $buffer);
+    }
+
+    public function testIdleConnectionWillBeClosedAfterConfiguredTimeoutAfterParsingHeadersButBeforeFullBodyHasBeenSentReturnsA408()
+    {
+        $buffer = '';
+
+        $this->connection
+            ->expects($this->any())
+            ->method('write')
+            ->will(
+                $this->returnCallback(
+                    function ($data) use (&$buffer) {
+                        $buffer .= $data;
+                    }
+                )
+            );
+        $this->connection->expects($this->once())->method('close');
+
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
+            $body = $request->getBody();
+
+            return new Promise(function () {});
+        }, 0.1);
+
+        $server->listen($this->socket);
+        $this->socket->emit('connection', array($this->connection));
+
+        $data = '';
+        $data .= "POST / HTTP/1.1\r\n";
+        $data .= "Host: localhost\r\n";
+        $data .= "Content-Length: 100\r\n";
+        $data .= "\r\n";
+        $data .= "incomplete";
+        $this->connection->emit('data', array($data));
+
+        Loop::run();
+
+        $this->assertStringStartsWith("HTTP/1.1 408 Request Timeout\r\n", $buffer);
+        $this->assertStringEndsWith("\r\n\r\nError 408: Request Timeout", $buffer);
+    }
+
     private function createGetRequest()
     {
         $data = "GET / HTTP/1.1\r\n";
@@ -3367,5 +3480,10 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
 
         return $data;
+    }
+
+    private function createStreamingServer($requestHandler, $requestTimeout = 1)
+    {
+        return new StreamingServer(Loop::get(), $requestHandler, $requestTimeout);
     }
 }


### PR DESCRIPTION
This builds on top of #405 and further builds out #423 by also
close connections with inactive requests.

Closes: #423