### PR TITLE
Explicitly close streaming response body when body MUST be empty

### DIFF
--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -330,6 +330,7 @@ final class StreamingServer extends EventEmitter
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling above
         if ($method === 'HEAD' || $code === 100 || ($code > 101 && $code < 200) || $code === 204 || $code === 304) {
+            $body->close();
             $body = '';
         }
 


### PR DESCRIPTION
This changeset ensures we explicitly close any streaming response body when the response body MUST be empty, such as for `HEAD` requests, `204 No Content` and `304 Not Modified`.

Builds on top of #188 and #156