### PR TITLE
Internal refactoring and improvement to hold message body in memory

### DIFF
--- a/src/Io/BufferedBody.php
+++ b/src/Io/BufferedBody.php
@@ -15,6 +15,9 @@ class BufferedBody implements StreamInterface
     private $position = 0;
     private $closed = false;
 
+    /**
+     * @param string $buffer
+     */
     public function __construct($buffer)
     {
         $this->buffer = $buffer;

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -3,7 +3,6 @@
 namespace React\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
-use RingCentral\Psr7;
 
 /**
  * [Internal] Parses a string body with "Content-Type: multipart/form-data" into structured data
@@ -190,7 +189,7 @@ final class MultipartParser
             }
 
             return new UploadedFile(
-                Psr7\stream_for(),
+                new BufferedBody(''),
                 $size,
                 \UPLOAD_ERR_NO_FILE,
                 $filename,
@@ -206,7 +205,7 @@ final class MultipartParser
         // file exceeds "upload_max_filesize" ini setting
         if ($size > $this->uploadMaxFilesize) {
             return new UploadedFile(
-                Psr7\stream_for(),
+                new BufferedBody(''),
                 $size,
                 \UPLOAD_ERR_INI_SIZE,
                 $filename,
@@ -217,7 +216,7 @@ final class MultipartParser
         // file exceeds MAX_FILE_SIZE value
         if ($this->maxFileSize !== null && $size > $this->maxFileSize) {
             return new UploadedFile(
-                Psr7\stream_for(),
+                new BufferedBody(''),
                 $size,
                 \UPLOAD_ERR_FORM_SIZE,
                 $filename,
@@ -226,7 +225,7 @@ final class MultipartParser
         }
 
         return new UploadedFile(
-            Psr7\stream_for($contents),
+            new BufferedBody($contents),
             $size,
             \UPLOAD_ERR_OK,
             $filename,

--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -188,7 +188,7 @@ class Transaction
         $maximumSize = $this->maximumSize;
         $promise = \React\Promise\Stream\buffer($stream, $maximumSize)->then(
             function ($body) use ($response) {
-                return $response->withBody(\RingCentral\Psr7\stream_for($body));
+                return $response->withBody(new BufferedBody($body));
             },
             function ($e) use ($stream, $maximumSize) {
                 // try to close stream if buffering fails (or is cancelled)

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -2,10 +2,11 @@
 
 namespace React\Http\Message;
 
+use Psr\Http\Message\StreamInterface;
+use React\Http\Io\BufferedBody;
 use React\Http\Io\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
 use RingCentral\Psr7\Response as Psr7Response;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * Represents an outgoing server response message.
@@ -48,9 +49,11 @@ final class Response extends Psr7Response
         $version = '1.1',
         $reason = null
     ) {
-        if ($body instanceof ReadableStreamInterface && !$body instanceof StreamInterface) {
+        if (\is_string($body)) {
+            $body = new BufferedBody($body);
+        } elseif ($body instanceof ReadableStreamInterface && !$body instanceof StreamInterface) {
             $body = new HttpBodyStream($body, null);
-        } elseif (!\is_string($body) && !$body instanceof StreamInterface) {
+        } elseif (!$body instanceof StreamInterface) {
             throw new \InvalidArgumentException('Invalid response body given');
         }
 

--- a/src/Message/ServerRequest.php
+++ b/src/Message/ServerRequest.php
@@ -5,6 +5,7 @@ namespace React\Http\Message;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use React\Http\Io\BufferedBody;
 use React\Http\Io\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
 use RingCentral\Psr7\Request;
@@ -57,10 +58,12 @@ final class ServerRequest extends Request implements ServerRequestInterface
         $serverParams = array()
     ) {
         $stream = null;
-        if ($body instanceof ReadableStreamInterface && !$body instanceof StreamInterface) {
+        if (\is_string($body)) {
+            $body = new BufferedBody($body);
+        } elseif ($body instanceof ReadableStreamInterface && !$body instanceof StreamInterface) {
             $stream = $body;
             $body = null;
-        } elseif (!\is_string($body) && !$body instanceof StreamInterface) {
+        } elseif (!$body instanceof StreamInterface) {
             throw new \InvalidArgumentException('Invalid server request body given');
         }
 

--- a/tests/Io/UploadedFileTest.php
+++ b/tests/Io/UploadedFileTest.php
@@ -2,9 +2,9 @@
 
 namespace React\Tests\Http\Io;
 
+use React\Http\Io\BufferedBody;
 use React\Http\Io\UploadedFile;
 Use React\Tests\Http\TestCase;
-use RingCentral\Psr7\BufferStream;
 
 class UploadedFileTest extends TestCase
 {
@@ -23,7 +23,7 @@ class UploadedFileTest extends TestCase
      */
     public function testFailtyError($error)
     {
-        $stream = new BufferStream();
+        $stream = new BufferedBody('');
 
         $this->setExpectedException('InvalidArgumentException', 'Invalid error code, must be an UPLOAD_ERR_* constant');
         new UploadedFile($stream, 0, $error, 'foo.bar', 'foo/bar');
@@ -31,7 +31,7 @@ class UploadedFileTest extends TestCase
 
     public function testNoMoveFile()
     {
-        $stream = new BufferStream();
+        $stream = new BufferedBody('');
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
 
         $this->setExpectedException('RuntimeException', 'Not implemented');
@@ -40,7 +40,7 @@ class UploadedFileTest extends TestCase
 
     public function testGetters()
     {
-        $stream = new BufferStream();
+        $stream = new BufferedBody('');
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
         self::assertSame($stream,       $uploadedFile->getStream());
         self::assertSame(0,             $uploadedFile->getSize());
@@ -51,7 +51,7 @@ class UploadedFileTest extends TestCase
 
     public function testGetStreamOnFailedUpload()
     {
-        $stream = new BufferStream();
+        $stream = new BufferedBody('');
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_NO_FILE, 'foo.bar', 'foo/bar');
 
         $this->setExpectedException('RuntimeException', 'Cannot retrieve stream due to upload error');

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -9,18 +9,22 @@ use React\Tests\Http\TestCase;
 
 class ResponseTest extends TestCase
 {
-
-    public function testStringBodyWillBePsr7Stream()
+    public function testConstructWithStringBodyWillReturnStreamInstance()
     {
         $response = new Response(200, array(), 'hello');
-        $this->assertInstanceOf('RingCentral\Psr7\Stream', $response->getBody());
+        $body = $response->getBody();
+
+        /** @var \Psr\Http\Message\StreamInterface $body */
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertEquals('hello', (string) $body);
     }
 
     public function testConstructWithStreamingBodyWillReturnReadableBodyStream()
     {
         $response = new Response(200, array(), new ThroughStream());
-
         $body = $response->getBody();
+
+        /** @var \Psr\Http\Message\StreamInterface $body */
         $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
         $this->assertInstanceof('React\Stream\ReadableStreamInterface', $body);
         $this->assertInstanceOf('React\Http\Io\HttpBodyStream', $body);


### PR DESCRIPTION
This changeset only performs some internal refactoring and minor improvements to reuse the existing `BufferedBody` class (introduced via #395) to hold any message body in memory.

Prior to this change, it leaves this up to the underlying PSR-7 implementation which happens to use a temporary memory stream. With these changes, we no longer need to interface with streams and resources internally which happens to improve performance slightly (9200 req/s -> 9300 req/s). On top of this, dumping an HTTP message now shows the actual body contents instead of a resource, so this definitely makes debugging much easier.

This also makes us less dependent on the underlying PSR-7 implementation which allows us to possibly change this in the future (#331).

These changes do not otherwise affect the public API.

Builds on top of #395