### PR TITLE
Expose all status code constants via `Response` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -735,7 +735,7 @@ object and expects a [response](#server-response) object in return:
 ```php
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -953,7 +953,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $body .= "The requested path is: " . $request->getUri()->getPath();
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -995,7 +995,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -1027,7 +1027,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     }
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/html'
         ),
@@ -1074,7 +1074,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $name = $request->getParsedBody()['name'] ?? 'anonymous';
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(),
         "Hello $name!\n"
     );
@@ -1099,7 +1099,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $name = $data->name ?? 'anonymous';
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array('Content-Type' => 'application/json'),
         json_encode(['message' => "Hello $name!"])
     );
@@ -1122,7 +1122,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $name = isset($files['avatar']) ? $files['avatar']->getClientFilename() : 'nothing';
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(),
         "Uploaded $name\n"
     );
@@ -1205,7 +1205,7 @@ $http = new React\Http\HttpServer(
 
             $body->on('end', function () use ($resolve, &$bytes){
                 $resolve(new React\Http\Message\Response(
-                    200,
+                    React\Http\Message\Response::STATUS_OK,
                     array(
                         'Content-Type' => 'text/plain'
                     ),
@@ -1216,7 +1216,7 @@ $http = new React\Http\HttpServer(
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (Exception $e) use ($resolve, &$bytes) {
                 $resolve(new React\Http\Message\Response(
-                    400,
+                    React\Http\Message\Response::STATUS_BAD_REQUEST,
                     array(
                         'Content-Type' => 'text/plain'
                     ),
@@ -1272,7 +1272,7 @@ $http = new React\Http\HttpServer(
             $body .= 'This example does not accept chunked transfer encoding.';
 
             return new React\Http\Message\Response(
-                411,
+                React\Http\Message\Response::STATUS_LENGTH_REQUIRED,
                 array(
                     'Content-Type' => 'text/plain'
                 ),
@@ -1281,7 +1281,7 @@ $http = new React\Http\HttpServer(
         }
 
         return new React\Http\Message\Response(
-            200,
+            React\Http\Message\Response::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -1343,7 +1343,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
         $body = "Your cookie value is: " . $request->getCookieParams()[$key];
 
         return new React\Http\Message\Response(
-            200,
+            React\Http\Message\Response::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -1352,7 +1352,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     }
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain',
             'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')
@@ -1410,7 +1410,7 @@ In its most simple form, you can use it like this:
 ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -1440,7 +1440,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     return new Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
             $response = new React\Http\Message\Response(
-                200,
+                React\Http\Message\Response::STATUS_OK,
                 array(
                     'Content-Type' => 'text/plain'
                 ),
@@ -1487,7 +1487,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     });
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -1568,7 +1568,7 @@ a `string` response body like this:
 ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),
@@ -1593,7 +1593,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     });
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Length' => '13',
             'Content-Type' => 'text/plain',
@@ -1663,7 +1663,7 @@ a custom `Server` response header like this:
 ```php
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Server' => 'PHP/3'
         )
@@ -1678,7 +1678,7 @@ string value like this:
 ```php
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Server' => ''
         )
@@ -1693,7 +1693,7 @@ like this:
 ```php
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Date' => gmdate('D, d M Y H:i:s \G\M\T')
         )
@@ -1708,7 +1708,7 @@ like this:
 ```php
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Date' => ''
         )
@@ -1786,7 +1786,7 @@ encourages [Third-Party Middleware](#third-party-middleware) implementations.
 In order to use middleware request handlers, simply pass a list of all
 callables as defined above to the [`HttpServer`](#httpserver).
 The following example adds a middleware request handler that adds the current time to the request as a 
-header (`Request-Time`) and a final request handler that always returns a 200 code without a body: 
+header (`Request-Time`) and a final request handler that always returns a `200 OK` status code without a body: 
 
 ```php
 $http = new React\Http\HttpServer(
@@ -1795,7 +1795,7 @@ $http = new React\Http\HttpServer(
         return $next($request);
     },
     function (Psr\Http\Message\ServerRequestInterface $request) {
-        return new React\Http\Message\Response(200);
+        return new React\Http\Message\Response(React\Http\Message\Response::STATUS_OK);
     }
 );
 ```
@@ -1821,7 +1821,7 @@ $http = new React\Http\HttpServer(
         });
     },
     function (Psr\Http\Message\ServerRequestInterface $request) {
-        return new React\Http\Message\Response(200);
+        return new React\Http\Message\Response(React\Http\Message\Response::STATUS_OK);
     }
 );
 ```
@@ -1842,7 +1842,7 @@ $http = new React\Http\HttpServer(
         });
         return $promise->then(null, function (Exception $e) {
             return new React\Http\Message\Response(
-                500,
+                React\Http\Message\Response::STATUS_INTERNAL_SERVER_ERROR,
                 array(),
                 'Internal error: ' . $e->getMessage()
             );
@@ -1852,7 +1852,7 @@ $http = new React\Http\HttpServer(
         if (mt_rand(0, 1) === 1) {
             throw new RuntimeException('Database error');
         }
-        return new React\Http\Message\Response(200);
+        return new React\Http\Message\Response(React\Http\Message\Response::STATUS_OK);
     }
 );
 ```
@@ -2439,7 +2439,7 @@ represent an outgoing server response message.
 
 ```php
 $response = new React\Http\Message\Response(
-    200,
+    React\Http\Message\Response::STATUS_OK,
     array(
         'Content-Type' => 'text/html'
     ),
@@ -2451,6 +2451,13 @@ This class implements the
 [PSR-7 `ResponseInterface`](https://www.php-fig.org/psr/psr-7/#33-psrhttpmessageresponseinterface)
 which in turn extends the
 [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
+
+On top of this, this class implements the
+[PSR-7 Message Util `StatusCodeInterface`](https://github.com/php-fig/http-message-util/blob/master/src/StatusCodeInterface.php)
+which means that most common HTTP status codes are available as class
+constants with the `STATUS_*` prefix. For instance, the `200 OK` and
+`404 Not Found` status codes can used as `Response::STATUS_OK` and
+`Response::STATUS_NOT_FOUND` respectively.
 
 > Internally, this implementation builds on top of an existing incoming
   response message and only adds required streaming support. This base class is
@@ -2516,7 +2523,7 @@ $http = new React\Http\HttpServer(
             });
             $body->on('close', function () use (&$bytes, $resolve) {
                 $resolve(new React\Http\Message\Response(
-                    200,
+                    React\Http\Message\Response::STATUS_OK,
                     [],
                     "Received $bytes bytes\n"
                 ));
@@ -2653,7 +2660,7 @@ $http = new React\Http\HttpServer(
     new React\Http\Middleware\RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
     function (Psr\Http\Message\ServerRequestInterface $request) {
         // The body from $request->getBody() is now fully available without the need to stream it 
-        return new React\Http\Message\Response(200);
+        return new React\Http\Message\Response(React\Http\Message\Response::STATUS_OK);
     },
 );
 ```
@@ -2700,7 +2707,7 @@ $handler = function (Psr\Http\Message\ServerRequestInterface $request) {
     }
 
     return new React\Http\Message\Response(
-        200,
+        React\Http\Message\Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
     "require": {
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+        "fig/http-message-util": "^1.1",
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.2",
         "react/promise": "^2.3 || ^1.2.1",
         "react/promise-stream": "^1.1",
         "react/socket": "^1.9",
         "react/stream": "^1.2",
-        "ringcentral/psr7": "^1.2",
-        "fig/http-message-util": "^1.1"
+        "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "react/promise-stream": "^1.1",
         "react/socket": "^1.9",
         "react/stream": "^1.2",
-        "ringcentral/psr7": "^1.2"
+        "ringcentral/psr7": "^1.2",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -7,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -8,7 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -9,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $counter = 0;
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -8,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $counter = 0;
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$counter) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -10,7 +9,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -9,7 +10,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -16,7 +17,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/html'
         ),

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -17,7 +16,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/html'
         ),

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -13,7 +12,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
         $body = "Your cookie value is: " . $request->getCookieParams()[$key];
 
         return new Response(
-            StatusCodeInterface::STATUS_OK,
+            Response::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -22,7 +21,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain',
             'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -12,7 +13,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
         $body = "Your cookie value is: " . $request->getCookieParams()[$key];
 
         return new Response(
-            200,
+            StatusCodeInterface::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -21,7 +22,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain',
             'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -11,7 +12,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
             $response = new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -12,7 +11,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
             $response = new Response(
-                StatusCodeInterface::STATUS_OK,
+                Response::STATUS_OK,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Promise\Promise;
@@ -16,7 +17,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
         }
 
         $response = new Response(
-            200,
+            StatusCodeInterface::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Promise\Promise;
@@ -17,7 +16,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
         }
 
         $response = new Response(
-            StatusCodeInterface::STATUS_OK,
+            Response::STATUS_OK,
             array(
                 'Content-Type' => 'text/plain'
             ),

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -9,7 +10,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
-        return new Response(404);
+        return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
     }
 
     $stream = new ThroughStream();
@@ -30,7 +31,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     });
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -10,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
-        return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
+        return new Response(Response::STATUS_NOT_FOUND);
     }
 
     $stream = new ThroughStream();
@@ -31,7 +30,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     });
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -6,7 +6,6 @@
 // $ php examples/59-server-json-api.php 8080
 // $ curl -v http://localhost:8080/ -H 'Content-Type: application/json' -d '{"name":"Alice"}'
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -15,7 +14,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
-            StatusCodeInterface::STATUS_UNSUPPORTED_MEDIA_TYPE,
+            Response::STATUS_UNSUPPORTED_MEDIA_TYPE,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -26,7 +25,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $input = json_decode($request->getBody()->getContents());
     if (json_last_error() !== JSON_ERROR_NONE) {
         return new Response(
-            StatusCodeInterface::STATUS_BAD_REQUEST,
+            Response::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -36,7 +35,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
 
     if (!isset($input->name) || !is_string($input->name)) {
         return new Response(
-            StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY,
+            Response::STATUS_UNPROCESSABLE_ENTITY,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -45,7 +44,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'application/json'
         ),

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -6,6 +6,7 @@
 // $ php examples/59-server-json-api.php 8080
 // $ curl -v http://localhost:8080/ -H 'Content-Type: application/json' -d '{"name":"Alice"}'
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -14,7 +15,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
         return new Response(
-            415, // Unsupported Media Type
+            StatusCodeInterface::STATUS_UNSUPPORTED_MEDIA_TYPE,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -25,7 +26,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     $input = json_decode($request->getBody()->getContents());
     if (json_last_error() !== JSON_ERROR_NONE) {
         return new Response(
-            400, // Bad Request
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -35,7 +36,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
 
     if (!isset($input->name) || !is_string($input->name)) {
         return new Response(
-            422, // Unprocessable Entity
+            StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY,
             array(
                 'Content-Type' => 'application/json'
             ),
@@ -44,7 +45,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     }
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'application/json'
         ),

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -7,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
@@ -8,7 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -7,7 +7,6 @@
 // $ curl --form name=test --form age=30 http://localhost:8080/
 // $ curl --form name=hi --form avatar=@avatar.png http://localhost:8080/
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use React\Http\Message\Response;
@@ -111,7 +110,7 @@ $body
 HTML;
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/html; charset=UTF-8'
         ),

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -7,6 +7,7 @@
 // $ curl --form name=test --form age=30 http://localhost:8080/
 // $ curl --form name=hi --form avatar=@avatar.png http://localhost:8080/
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use React\Http\Message\Response;
@@ -110,7 +111,7 @@ $body
 HTML;
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/html; charset=UTF-8'
         ),

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -1,7 +1,5 @@
 <?php
 
-use Fig\Http\Message\StatusCodeInterface;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 // Note how this example uses the advanced `StreamingRequestMiddleware` to allow streaming
@@ -22,7 +20,7 @@ $http = new React\Http\HttpServer(
 
             $body->on('end', function () use ($resolve, &$bytes){
                 $resolve(new React\Http\Message\Response(
-                    StatusCodeInterface::STATUS_OK,
+                    React\Http\Message\Response::STATUS_OK,
                     array(
                         'Content-Type' => 'text/plain'
                     ),
@@ -33,7 +31,7 @@ $http = new React\Http\HttpServer(
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (Exception $e) use ($resolve, &$bytes) {
                 $resolve(new React\Http\Message\Response(
-                    StatusCodeInterface::STATUS_BAD_REQUEST,
+                    React\Http\Message\Response::STATUS_BAD_REQUEST,
                     array(
                         'Content-Type' => 'text/plain'
                     ),

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -1,5 +1,7 @@
 <?php
 
+use Fig\Http\Message\StatusCodeInterface;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 // Note how this example uses the advanced `StreamingRequestMiddleware` to allow streaming
@@ -20,7 +22,7 @@ $http = new React\Http\HttpServer(
 
             $body->on('end', function () use ($resolve, &$bytes){
                 $resolve(new React\Http\Message\Response(
-                    200,
+                    StatusCodeInterface::STATUS_OK,
                     array(
                         'Content-Type' => 'text/plain'
                     ),
@@ -31,7 +33,7 @@ $http = new React\Http\HttpServer(
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (Exception $e) use ($resolve, &$bytes) {
                 $resolve(new React\Http\Message\Response(
-                    400,
+                    StatusCodeInterface::STATUS_BAD_REQUEST,
                     array(
                         'Content-Type' => 'text/plain'
                     ),

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -3,6 +3,7 @@
 // $ php examples/71-server-http-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 http://reactphp.org/
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use React\Http\Message\Response;
 use RingCentral\Psr7;
@@ -16,7 +17,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
-            400,
+            StatusCodeInterface::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -36,7 +37,7 @@ $http = new React\Http\HttpServer(function (RequestInterface $request) {
     // left up as an exercise: use an HTTP client to send the outgoing request
     // and forward the incoming response to the original client request
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -3,7 +3,6 @@
 // $ php examples/71-server-http-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 http://reactphp.org/
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use React\Http\Message\Response;
 use RingCentral\Psr7;
@@ -17,7 +16,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (RequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
         return new Response(
-            StatusCodeInterface::STATUS_BAD_REQUEST,
+            Response::STATUS_BAD_REQUEST,
             array(
                 'Content-Type' => 'text/plain'
             ),
@@ -37,7 +36,7 @@ $http = new React\Http\HttpServer(function (RequestInterface $request) {
     // left up as an exercise: use an HTTP client to send the outgoing request
     // and forward the incoming response to the original client request
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'text/plain'
         ),

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -3,7 +3,6 @@
 // $ php examples/72-server-http-connect-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 https://reactphp.org/
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Socket\Connector;
@@ -20,7 +19,7 @@ $connector = new Connector();
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
-            StatusCodeInterface::STATUS_METHOD_NOT_ALLOWED,
+            Response::STATUS_METHOD_NOT_ALLOWED,
             array(
                 'Content-Type' => 'text/plain',
                 'Allow' => 'CONNECT'
@@ -34,14 +33,14 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
         function (ConnectionInterface $remote) {
             // connection established => forward data
             return new Response(
-                StatusCodeInterface::STATUS_OK,
+                Response::STATUS_OK,
                 array(),
                 $remote
             );
         },
         function (Exception $e) {
             return new Response(
-                StatusCodeInterface::STATUS_BAD_GATEWAY,
+                Response::STATUS_BAD_GATEWAY,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -3,6 +3,7 @@
 // $ php examples/72-server-http-connect-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 https://reactphp.org/
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Socket\Connector;
@@ -19,7 +20,7 @@ $connector = new Connector();
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($connector) {
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
-            405,
+            StatusCodeInterface::STATUS_METHOD_NOT_ALLOWED,
             array(
                 'Content-Type' => 'text/plain',
                 'Allow' => 'CONNECT'
@@ -33,14 +34,14 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
         function (ConnectionInterface $remote) {
             // connection established => forward data
             return new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(),
                 $remote
             );
         },
         function (Exception $e) {
             return new Response(
-                502,
+                StatusCodeInterface::STATUS_BAD_GATEWAY,
                 array(
                     'Content-Type' => 'text/plain'
                 ),

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -17,7 +17,6 @@ $ telnet localhost 1080
 < world
 */
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -31,7 +30,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
+            Response::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'echo'
             ),
@@ -49,7 +48,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     });
 
     return new Response(
-        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
+        Response::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'echo'
         ),

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -17,6 +17,7 @@ $ telnet localhost 1080
 < world
 */
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -30,7 +31,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            426,
+            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'echo'
             ),
@@ -48,7 +49,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     });
 
     return new Response(
-        101,
+        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'echo'
         ),

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -19,6 +19,7 @@ $ telnet localhost 1080
 Hint: try this with multiple connections :)
 */
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -38,7 +39,7 @@ $chat = new ThroughStream();
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            426,
+            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'chat'
             ),
@@ -76,7 +77,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     });
 
     return new Response(
-        101,
+        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'chat'
         ),

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -19,7 +19,6 @@ $ telnet localhost 1080
 Hint: try this with multiple connections :)
 */
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
@@ -39,7 +38,7 @@ $chat = new ThroughStream();
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use ($chat) {
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
-            StatusCodeInterface::STATUS_UPGRADE_REQUIRED,
+            Response::STATUS_UPGRADE_REQUIRED,
             array(
                 'Upgrade' => 'chat'
             ),
@@ -77,7 +76,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     });
 
     return new Response(
-        StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS,
+        Response::STATUS_SWITCHING_PROTOCOLS,
         array(
             'Upgrade' => 'chat'
         ),

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -15,6 +15,7 @@
 // $ docker run -it --rm --net=host skandyla/wrk -t8 -c10 -d20 http://localhost:8080/
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Stream\ReadableStreamInterface;
@@ -94,7 +95,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
-                200,
+                StatusCodeInterface::STATUS_OK,
                 array(
                     'Content-Type' => 'text/html'
                 ),
@@ -107,13 +108,13 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
             $stream = new ChunkRepeater(str_repeat('.', 1000000), 10000);
             break;
         default:
-            return new Response(404);
+            return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
     }
 
     React\EventLoop\Loop::addTimer(0, array($stream, 'resume'));
 
     return new Response(
-        200,
+        StatusCodeInterface::STATUS_OK,
         array(
             'Content-Type' => 'application/octet-data',
             'Content-Length' => $stream->getSize()

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -15,7 +15,6 @@
 // $ docker run -it --rm --net=host skandyla/wrk -t8 -c10 -d20 http://localhost:8080/
 
 use Evenement\EventEmitter;
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 use React\Stream\ReadableStreamInterface;
@@ -95,7 +94,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     switch ($request->getUri()->getPath()) {
         case '/':
             return new Response(
-                StatusCodeInterface::STATUS_OK,
+                Response::STATUS_OK,
                 array(
                     'Content-Type' => 'text/html'
                 ),
@@ -108,13 +107,13 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
             $stream = new ChunkRepeater(str_repeat('.', 1000000), 10000);
             break;
         default:
-            return new Response(StatusCodeInterface::STATUS_NOT_FOUND);
+            return new Response(Response::STATUS_NOT_FOUND);
     }
 
     React\EventLoop\Loop::addTimer(0, array($stream, 'resume'));
 
     return new Response(
-        StatusCodeInterface::STATUS_OK,
+        Response::STATUS_OK,
         array(
             'Content-Type' => 'application/octet-data',
             'Content-Length' => $stream->getSize()

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -26,7 +26,7 @@ use React\Socket\ServerInterface;
  * ```php
  * $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
  *     return new React\Http\Message\Response(
- *         200,
+ *         React\Http\Message\Response::STATUS_OK,
  *         array(
  *             'Content-Type' => 'text/plain'
  *         ),

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -3,8 +3,8 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
 use React\Socket\ConnectionInterface;
 use Exception;
@@ -40,7 +40,7 @@ class RequestHeaderParser extends EventEmitter
                 $fn = null;
 
                 $that->emit('error', array(
-                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", StatusCodeInterface::STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE),
+                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", Response::STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE),
                     $conn
                 ));
                 return;
@@ -128,7 +128,7 @@ class RequestHeaderParser extends EventEmitter
 
         // only support HTTP/1.1 and HTTP/1.0 requests
         if ($start['version'] !== '1.1' && $start['version'] !== '1.0') {
-            throw new \InvalidArgumentException('Received request with invalid protocol version', StatusCodeInterface::STATUS_VERSION_NOT_SUPPORTED);
+            throw new \InvalidArgumentException('Received request with invalid protocol version', Response::STATUS_VERSION_NOT_SUPPORTED);
         }
 
         // match all request header fields into array, thanks to @kelunik for checking the HTTP specs and coming up with this regex
@@ -257,20 +257,20 @@ class RequestHeaderParser extends EventEmitter
         // ensure message boundaries are valid according to Content-Length and Transfer-Encoding request headers
         if ($request->hasHeader('Transfer-Encoding')) {
             if (\strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
-                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', StatusCodeInterface::STATUS_NOT_IMPLEMENTED);
+                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', Response::STATUS_NOT_IMPLEMENTED);
             }
 
             // Transfer-Encoding: chunked and Content-Length header MUST NOT be used at the same time
             // as per https://tools.ietf.org/html/rfc7230#section-3.3.3
             if ($request->hasHeader('Content-Length')) {
-                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', StatusCodeInterface::STATUS_BAD_REQUEST);
+                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', Response::STATUS_BAD_REQUEST);
             }
         } elseif ($request->hasHeader('Content-Length')) {
             $string = $request->getHeaderLine('Content-Length');
 
             if ((string)(int)$string !== $string) {
                 // Content-Length value is not an integer or not a single integer
-                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', StatusCodeInterface::STATUS_BAD_REQUEST);
+                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', Response::STATUS_BAD_REQUEST);
             }
         }
 

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -3,6 +3,7 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\ServerRequest;
 use React\Socket\ConnectionInterface;
@@ -39,7 +40,7 @@ class RequestHeaderParser extends EventEmitter
                 $fn = null;
 
                 $that->emit('error', array(
-                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", 431),
+                    new \OverflowException("Maximum header size of {$maxSize} exceeded.", StatusCodeInterface::STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE),
                     $conn
                 ));
                 return;
@@ -127,7 +128,7 @@ class RequestHeaderParser extends EventEmitter
 
         // only support HTTP/1.1 and HTTP/1.0 requests
         if ($start['version'] !== '1.1' && $start['version'] !== '1.0') {
-            throw new \InvalidArgumentException('Received request with invalid protocol version', 505);
+            throw new \InvalidArgumentException('Received request with invalid protocol version', StatusCodeInterface::STATUS_VERSION_NOT_SUPPORTED);
         }
 
         // match all request header fields into array, thanks to @kelunik for checking the HTTP specs and coming up with this regex
@@ -256,20 +257,20 @@ class RequestHeaderParser extends EventEmitter
         // ensure message boundaries are valid according to Content-Length and Transfer-Encoding request headers
         if ($request->hasHeader('Transfer-Encoding')) {
             if (\strtolower($request->getHeaderLine('Transfer-Encoding')) !== 'chunked') {
-                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', 501);
+                throw new \InvalidArgumentException('Only chunked-encoding is allowed for Transfer-Encoding', StatusCodeInterface::STATUS_NOT_IMPLEMENTED);
             }
 
             // Transfer-Encoding: chunked and Content-Length header MUST NOT be used at the same time
             // as per https://tools.ietf.org/html/rfc7230#section-3.3.3
             if ($request->hasHeader('Content-Length')) {
-                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', 400);
+                throw new \InvalidArgumentException('Using both `Transfer-Encoding: chunked` and `Content-Length` is not allowed', StatusCodeInterface::STATUS_BAD_REQUEST);
             }
         } elseif ($request->hasHeader('Content-Length')) {
             $string = $request->getHeaderLine('Content-Length');
 
             if ((string)(int)$string !== $string) {
                 // Content-Length value is not an integer or not a single integer
-                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', 400);
+                throw new \InvalidArgumentException('The value of `Content-Length` is not valid', StatusCodeInterface::STATUS_BAD_REQUEST);
             }
         }
 

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -2,11 +2,11 @@
 
 namespace React\Http\Io;
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Client\Client as HttpClient;
+use React\Http\Message\Response;
 use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
 use React\Socket\ConnectorInterface;
@@ -111,7 +111,7 @@ class Sender
         $requestStream->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($deferred, $request) {
             $length = null;
             $code = $response->getStatusCode();
-            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == StatusCodeInterface::STATUS_NO_CONTENT || $code == StatusCodeInterface::STATUS_NOT_MODIFIED) {
+            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == Response::STATUS_NO_CONTENT || $code == Response::STATUS_NOT_MODIFIED) {
                 $length = 0;
             } elseif (\strtolower($response->getHeaderLine('Transfer-Encoding')) === 'chunked') {
                 $body = new ChunkedDecoder($body);

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -2,6 +2,7 @@
 
 namespace React\Http\Io;
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\EventLoop\LoopInterface;
@@ -110,7 +111,7 @@ class Sender
         $requestStream->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($deferred, $request) {
             $length = null;
             $code = $response->getStatusCode();
-            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == 204 || $code == 304) {
+            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == StatusCodeInterface::STATUS_NO_CONTENT || $code == StatusCodeInterface::STATUS_NOT_MODIFIED) {
                 $length = 0;
             } elseif (\strtolower($response->getHeaderLine('Transfer-Encoding')) === 'chunked') {
                 $body = new ChunkedDecoder($body);

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -3,6 +3,7 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
@@ -120,7 +121,7 @@ final class StreamingServer extends EventEmitter
             // parsing failed => assume dummy request and send appropriate error
             $that->writeError(
                 $conn,
-                $e->getCode() !== 0 ? $e->getCode() : 400,
+                $e->getCode() !== 0 ? $e->getCode() : StatusCodeInterface::STATUS_BAD_REQUEST,
                 new ServerRequest('GET', '/')
             );
         });
@@ -199,7 +200,7 @@ final class StreamingServer extends EventEmitter
                 $exception = new \RuntimeException($message, null, $previous);
 
                 $that->emit('error', array($exception));
-                return $that->writeError($conn, 500, $request);
+                return $that->writeError($conn, StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR, $request);
             }
         );
     }
@@ -262,7 +263,7 @@ final class StreamingServer extends EventEmitter
 
         // assign "Content-Length" header automatically
         $chunked = false;
-        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === 204) {
+        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT) {
             // 2xx response to CONNECT and 1xx and 204 MUST NOT include Content-Length or Transfer-Encoding header
             $response = $response->withoutHeader('Content-Length');
         } elseif ($code === 304 && ($response->hasHeader('Content-Length') || $body->getSize() === 0)) {
@@ -285,7 +286,7 @@ final class StreamingServer extends EventEmitter
 
         // assign "Connection" header automatically
         $persist = false;
-        if ($code === 101) {
+        if ($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS) {
             // 101 (Switching Protocols) response uses Connection: upgrade header
             // This implies that this stream now uses another protocol and we
             // may not persist this connection for additional requests.
@@ -307,7 +308,7 @@ final class StreamingServer extends EventEmitter
 
         // 101 (Switching Protocols) response (for Upgrade request) forwards upgraded data through duplex stream
         // 2xx (Successful) response to CONNECT forwards tunneled application data through duplex stream
-        if (($code === 101 || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
+        if (($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
             if ($request->getBody()->isReadable()) {
                 // request is still streaming => wait for request close before forwarding following data from connection
                 $request->getBody()->on('close', function () use ($connection, $body) {
@@ -333,7 +334,7 @@ final class StreamingServer extends EventEmitter
 
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling above
-        if ($method === 'HEAD' || $code === 100 || ($code > 101 && $code < 200) || $code === 204 || $code === 304) {
+        if ($method === 'HEAD' || $code === 100 || ($code > StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT || $code === StatusCodeInterface::STATUS_NOT_MODIFIED) {
             $body->close();
             $body = '';
         }

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -3,7 +3,6 @@
 namespace React\Http\Io;
 
 use Evenement\EventEmitter;
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
@@ -32,7 +31,7 @@ use React\Stream\WritableStreamInterface;
  * ```php
  * $server = new StreamingServer($loop, function (ServerRequestInterface $request) {
  *     return new Response(
- *         200,
+ *         Response::STATUS_OK,
  *         array(
  *             'Content-Type' => 'text/plain'
  *         ),
@@ -121,7 +120,7 @@ final class StreamingServer extends EventEmitter
             // parsing failed => assume dummy request and send appropriate error
             $that->writeError(
                 $conn,
-                $e->getCode() !== 0 ? $e->getCode() : StatusCodeInterface::STATUS_BAD_REQUEST,
+                $e->getCode() !== 0 ? $e->getCode() : Response::STATUS_BAD_REQUEST,
                 new ServerRequest('GET', '/')
             );
         });
@@ -183,7 +182,7 @@ final class StreamingServer extends EventEmitter
                     $exception = new \RuntimeException($message);
 
                     $that->emit('error', array($exception));
-                    return $that->writeError($conn, 500, $request);
+                    return $that->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
                 }
                 $that->handleResponse($conn, $request, $response);
             },
@@ -200,7 +199,7 @@ final class StreamingServer extends EventEmitter
                 $exception = new \RuntimeException($message, null, $previous);
 
                 $that->emit('error', array($exception));
-                return $that->writeError($conn, StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR, $request);
+                return $that->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
             }
         );
     }
@@ -263,10 +262,10 @@ final class StreamingServer extends EventEmitter
 
         // assign "Content-Length" header automatically
         $chunked = false;
-        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT) {
+        if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === Response::STATUS_NO_CONTENT) {
             // 2xx response to CONNECT and 1xx and 204 MUST NOT include Content-Length or Transfer-Encoding header
             $response = $response->withoutHeader('Content-Length');
-        } elseif ($code === 304 && ($response->hasHeader('Content-Length') || $body->getSize() === 0)) {
+        } elseif ($code === Response::STATUS_NOT_MODIFIED && ($response->hasHeader('Content-Length') || $body->getSize() === 0)) {
             // 304 Not Modified: preserve explicit Content-Length and preserve missing header if body is empty
         } elseif ($body->getSize() !== null) {
             // assign Content-Length header when using a "normal" buffered body string
@@ -286,7 +285,7 @@ final class StreamingServer extends EventEmitter
 
         // assign "Connection" header automatically
         $persist = false;
-        if ($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS) {
+        if ($code === Response::STATUS_SWITCHING_PROTOCOLS) {
             // 101 (Switching Protocols) response uses Connection: upgrade header
             // This implies that this stream now uses another protocol and we
             // may not persist this connection for additional requests.
@@ -308,7 +307,7 @@ final class StreamingServer extends EventEmitter
 
         // 101 (Switching Protocols) response (for Upgrade request) forwards upgraded data through duplex stream
         // 2xx (Successful) response to CONNECT forwards tunneled application data through duplex stream
-        if (($code === StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
+        if (($code === Response::STATUS_SWITCHING_PROTOCOLS || ($method === 'CONNECT' && $code >= 200 && $code < 300)) && $body instanceof HttpBodyStream && $body->input instanceof WritableStreamInterface) {
             if ($request->getBody()->isReadable()) {
                 // request is still streaming => wait for request close before forwarding following data from connection
                 $request->getBody()->on('close', function () use ($connection, $body) {
@@ -334,7 +333,7 @@ final class StreamingServer extends EventEmitter
 
         // response to HEAD and 1xx, 204 and 304 responses MUST NOT include a body
         // exclude status 101 (Switching Protocols) here for Upgrade request handling above
-        if ($method === 'HEAD' || $code === 100 || ($code > StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS && $code < 200) || $code === StatusCodeInterface::STATUS_NO_CONTENT || $code === StatusCodeInterface::STATUS_NOT_MODIFIED) {
+        if ($method === 'HEAD' || ($code >= 100 && $code < 200 && $code !== Response::STATUS_SWITCHING_PROTOCOLS) || $code === Response::STATUS_NO_CONTENT || $code === Response::STATUS_NOT_MODIFIED) {
             $body->close();
             $body = '';
         }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -2,6 +2,7 @@
 
 namespace React\Http\Message;
 
+use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\StreamInterface;
 use React\Http\Io\BufferedBody;
 use React\Http\Io\HttpBodyStream;
@@ -43,7 +44,7 @@ final class Response extends Psr7Response
      * @throws \InvalidArgumentException for an invalid body
      */
     public function __construct(
-        $status = 200,
+        $status = StatusCodeInterface::STATUS_OK,
         array $headers = array(),
         $body = '',
         $version = '1.1',

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -14,7 +14,7 @@ use RingCentral\Psr7\Response as Psr7Response;
  *
  * ```php
  * $response = new React\Http\Message\Response(
- *     200,
+ *     React\Http\Message\Response::STATUS_OK,
  *     array(
  *         'Content-Type' => 'text/html'
  *     ),
@@ -27,16 +27,23 @@ use RingCentral\Psr7\Response as Psr7Response;
  * which in turn extends the
  * [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
  *
+ * On top of this, this class implements the
+ * [PSR-7 Message Util `StatusCodeInterface`](https://github.com/php-fig/http-message-util/blob/master/src/StatusCodeInterface.php)
+ * which means that most common HTTP status codes are available as class
+ * constants with the `STATUS_*` prefix. For instance, the `200 OK` and
+ * `404 Not Found` status codes can used as `Response::STATUS_OK` and
+ * `Response::STATUS_NOT_FOUND` respectively.
+ *
  * > Internally, this implementation builds on top of an existing incoming
  *   response message and only adds required streaming support. This base class is
  *   considered an implementation detail that may change in the future.
  *
  * @see \Psr\Http\Message\ResponseInterface
  */
-final class Response extends Psr7Response
+final class Response extends Psr7Response implements StatusCodeInterface
 {
     /**
-     * @param int                                            $status  HTTP status code (e.g. 200/404)
+     * @param int                                            $status  HTTP status code (e.g. 200/404), see `self::STATUS_*` constants
      * @param array<string,string|string[]>                  $headers additional response headers
      * @param string|ReadableStreamInterface|StreamInterface $body    response body
      * @param string                                         $version HTTP protocol version (e.g. 1.1/1.0)
@@ -44,7 +51,7 @@ final class Response extends Psr7Response
      * @throws \InvalidArgumentException for an invalid body
      */
     public function __construct(
-        $status = StatusCodeInterface::STATUS_OK,
+        $status = self::STATUS_OK,
         array $headers = array(),
         $body = '',
         $version = '1.1',


### PR DESCRIPTION
With this changeset, we now expose all status code constants via `Response` class. This is done by implementing the [PSR-7 Message Util `StatusCodeInterface`](https://github.com/php-fig/http-message-util/blob/master/src/StatusCodeInterface.php) which means that most common HTTP status codes are now available as class constants with the `STATUS_*` prefix. For instance, the `200 OK` and `404 Not Found` status codes can used as `Response::STATUS_OK` and `Response::STATUS_NOT_FOUND` respectively.

Using status code constants is entirely optional and using status codes as integers remains supported of course, but we now use these constants throughout our documentation and examples to make them more readable. Accordingly, this does not affect backwards compatibility.

This builds on top of #406 (thank you @WyriHaximus!), but instead of exposing a new interface, this changeset simply ensures the existing `Response` class implements this very interface. This makes it much easier to use these constants in application code because no separate import is required.

Supersedes / closes #406