### PR TITLE
Support PHP 8.1

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,8 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheResult="false">
+         cacheResult="false"
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React Test Suite">
             <directory>./tests/</directory>

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -160,7 +160,7 @@ class RequestHeaderParser extends EventEmitter
         );
 
         // scheme is `http` unless TLS is used
-        $localParts = \parse_url($localSocketUri);
+        $localParts = $localSocketUri === null ? array() : \parse_url($localSocketUri);
         if (isset($localParts['scheme']) && $localParts['scheme'] === 'tls') {
             $scheme = 'https://';
             $serverParams['HTTPS'] = 'on';
@@ -242,7 +242,9 @@ class RequestHeaderParser extends EventEmitter
             }
 
             // make sure value does not contain any other URI component
-            unset($parts['scheme'], $parts['host'], $parts['port']);
+            if (\is_array($parts)) {
+                unset($parts['scheme'], $parts['host'], $parts['port']);
+            }
             if ($parts === false || $parts) {
                 throw new \InvalidArgumentException('Invalid Host header value');
             }

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -196,7 +196,7 @@ final class StreamingServer extends EventEmitter
                     $previous = $error;
                 }
 
-                $exception = new \RuntimeException($message, null, $previous);
+                $exception = new \RuntimeException($message, 0, $previous);
 
                 $that->emit('error', array($exception));
                 return $that->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);

--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -63,7 +63,6 @@ class IniUtilTest extends TestCase
         return array(
             array('-1G'),
             array('0G'),
-            array(null),
             array('foo'),
             array('fooK'),
             array('1ooL'),


### PR DESCRIPTION
This changeset adds support for PHP 8.1.

Builds on top of #433
(Unlike the other PRs I've filed today, this one does not depends on https://github.com/reactphp/promise-timer/pull/50)