### PR TITLE
Update test suite to use default loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
-        "clue/block-react": "^1.1",
+        "clue/block-react": "^1.5",
         "clue/http-proxy-react": "^1.7",
         "clue/reactphp-ssh-proxy": "^1.3",
         "clue/socks-react": "^1.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
          cacheResult="false"
+         colors="true"
          convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="React Test Suite">

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -5,7 +5,7 @@ namespace React\Tests\Http;
 use Clue\React\Block;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Http\HttpServer;
 use React\Http\Message\Response;
 use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
@@ -22,14 +22,13 @@ class FunctionalHttpServerTest extends TestCase
 {
     public function testPlainHttpOnRandomPort()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -38,7 +37,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
@@ -48,17 +47,15 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnRandomPortWithSingleRequestHandlerArray()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $http = new HttpServer(
-            $loop,
             function () {
                 return new Response(404);
             }
         );
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -67,7 +64,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 404 Not Found", $response);
 
@@ -76,14 +73,13 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnRandomPortWithoutHostHeaderUsesSocketUri()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -92,7 +88,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
@@ -102,14 +98,13 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnRandomPortWithOtherHostHeaderTakesPrecedence()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -118,7 +113,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://localhost:1000/', $response);
@@ -132,18 +127,17 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
         $socket = new SocketServer('tls://127.0.0.1:0', array('tls' => array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
-        )), $loop);
+        )));
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -152,7 +146,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
@@ -166,9 +160,7 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
-
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -178,12 +170,12 @@ class FunctionalHttpServerTest extends TestCase
 
         $socket = new SocketServer('tls://127.0.0.1:0', array('tls' => array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
-        )), $loop);
+        )));
         $http->listen($socket);
 
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nHost: " . noScheme($conn->getRemoteAddress()) . "\r\n\r\n");
@@ -191,7 +183,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString("\r\nContent-Length: 33000\r\n", $response);
@@ -206,18 +198,17 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
         $socket = new SocketServer('tls://127.0.0.1:0', array('tls' => array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem'
-        )), $loop);
+        )));
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -226,7 +217,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
@@ -236,15 +227,14 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnStandardPortReturnsUriWithNoPort()
     {
-        $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:80', array(), $loop);
+            $socket = new SocketServer('127.0.0.1:80');
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 80 failed (root and unused?)');
         }
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -256,7 +246,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://127.0.0.1/', $response);
@@ -266,15 +256,14 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnStandardPortWithoutHostHeaderReturnsUriWithNoPort()
     {
-        $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:80', array(), $loop);
+            $socket = new SocketServer('127.0.0.1:80');
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 80 failed (root and unused?)');
         }
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -286,7 +275,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://127.0.0.1/', $response);
@@ -300,20 +289,19 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
         try {
             $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
-            )), $loop);
+            )));
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 443 failed (root and unused?)');
         }
 
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -325,7 +313,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('https://127.0.0.1/', $response);
@@ -339,20 +327,19 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
         try {
             $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
-            )), $loop);
+            )));
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 443 failed (root and unused?)');
         }
 
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -364,7 +351,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('https://127.0.0.1/', $response);
@@ -374,15 +361,14 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testPlainHttpOnHttpsStandardPortReturnsUriWithPort()
     {
-        $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:443', array(), $loop);
+            $socket = new SocketServer('127.0.0.1:443');
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 443 failed (root and unused?)');
         }
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri());
         });
 
@@ -394,7 +380,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('http://127.0.0.1:443/', $response);
@@ -408,20 +394,19 @@ class FunctionalHttpServerTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $loop = Factory::create();
         try {
             $socket = new SocketServer('tls://127.0.0.1:80', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
-            )), $loop);
+            )));
         } catch (\RuntimeException $e) {
             $this->markTestSkipped('Listening on port 80 failed (root and unused?)');
         }
 
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
-        ), $loop);
+        ));
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             return new Response(200, array(), (string)$request->getUri() . 'x' . $request->getHeaderLine('Host'));
         });
 
@@ -433,7 +418,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertContainsString("HTTP/1.0 200 OK", $response);
         $this->assertContainsString('https://127.0.0.1:80/', $response);
@@ -443,17 +428,16 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testClosedStreamFromRequestHandlerWillSendEmptyBody()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $stream = new ThroughStream();
         $stream->close();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($stream) {
+        $http = new HttpServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -462,7 +446,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.0 200 OK", $response);
         $this->assertStringEndsWith("\r\n\r\n", $response);
@@ -472,62 +456,58 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testRequestHandlerWithStreamingRequestWillReceiveCloseEventIfConnectionClosesWhileSendingBody()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $once = $this->expectCallableOnce();
         $http = new HttpServer(
-            $loop,
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($once) {
                 $request->getBody()->on('close', $once);
             }
         );
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
-        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
+        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nContent-Length: 100\r\n\r\n");
 
-            $loop->addTimer(0.001, function() use ($conn) {
+            Loop::addTimer(0.001, function() use ($conn) {
                 $conn->end();
             });
         });
 
-        Block\sleep(0.1, $loop);
+        Block\sleep(0.1);
 
         $socket->close();
     }
 
     public function testStreamFromRequestHandlerWillBeClosedIfConnectionClosesWhileSendingStreamingRequestBody()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $stream = new ThroughStream();
 
         $http = new HttpServer(
-            $loop,
             new StreamingRequestMiddleware(),
             function (RequestInterface $request) use ($stream) {
                 return new Response(200, array(), $stream);
             }
         );
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
-        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
+        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\nContent-Length: 100\r\n\r\n");
 
-            $loop->addTimer(0.001, function() use ($conn) {
+            Loop::addTimer(0.001, function() use ($conn) {
                 $conn->end();
             });
         });
 
         // stream will be closed within 0.1s
-        $ret = Block\await(Stream\first($stream, 'close'), $loop, 0.1);
+        $ret = Block\await(Stream\first($stream, 'close'), null, 0.1);
 
         $socket->close();
 
@@ -536,28 +516,27 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testStreamFromRequestHandlerWillBeClosedIfConnectionCloses()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $stream = new ThroughStream();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($stream) {
+        $http = new HttpServer(function (RequestInterface $request) use ($stream) {
             return new Response(200, array(), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
-        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) use ($loop) {
+        $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
             $conn->write("GET / HTTP/1.0\r\n\r\n");
 
-            $loop->addTimer(0.1, function () use ($conn) {
+            Loop::addTimer(0.1, function () use ($conn) {
                 $conn->close();
             });
         });
 
         // await response stream to be closed
-        $ret = Block\await(Stream\first($stream, 'close'), $loop, 1.0);
+        $ret = Block\await(Stream\first($stream, 'close'), null, 1.0);
 
         $socket->close();
 
@@ -566,20 +545,19 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testUpgradeWithThroughStreamReturnsDataAsGiven()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($loop) {
+        $http = new HttpServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
-            $loop->addTimer(0.1, function () use ($stream) {
+            Loop::addTimer(0.1, function () use ($stream) {
                 $stream->end();
             });
 
             return new Response(101, array('Upgrade' => 'echo'), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -593,7 +571,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.1 101 Switching Protocols\r\n", $response);
         $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
@@ -603,20 +581,19 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testUpgradeWithRequestBodyAndThroughStreamReturnsDataAsGiven()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($loop) {
+        $http = new HttpServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
-            $loop->addTimer(0.1, function () use ($stream) {
+            Loop::addTimer(0.1, function () use ($stream) {
                 $stream->end();
             });
 
             return new Response(101, array('Upgrade' => 'echo'), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -631,7 +608,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.1 101 Switching Protocols\r\n", $response);
         $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
@@ -641,20 +618,19 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testConnectWithThroughStreamReturnsDataAsGiven()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($loop) {
+        $http = new HttpServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
-            $loop->addTimer(0.1, function () use ($stream) {
+            Loop::addTimer(0.1, function () use ($stream) {
                 $stream->end();
             });
 
             return new Response(200, array(), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -668,7 +644,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
         $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
@@ -678,24 +654,23 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testConnectWithThroughStreamReturnedFromPromiseReturnsDataAsGiven()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) use ($loop) {
+        $http = new HttpServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
 
-            $loop->addTimer(0.1, function () use ($stream) {
+            Loop::addTimer(0.1, function () use ($stream) {
                 $stream->end();
             });
 
-            return new Promise\Promise(function ($resolve) use ($loop, $stream) {
-                $loop->addTimer(0.001, function () use ($resolve, $stream) {
+            return new Promise\Promise(function ($resolve) use ($stream) {
+                Loop::addTimer(0.001, function () use ($resolve, $stream) {
                     $resolve(new Response(200, array(), $stream));
                 });
             });
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -709,7 +684,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
         $this->assertStringEndsWith("\r\n\r\nhelloworld", $response);
@@ -719,17 +694,16 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testConnectWithClosedThroughStreamReturnsNoData()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
-        $http = new HttpServer($loop, function (RequestInterface $request) {
+        $http = new HttpServer(function (RequestInterface $request) {
             $stream = new ThroughStream();
             $stream->close();
 
             return new Response(200, array(), $stream);
         });
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = $connector->connect($socket->getAddress())->then(function (ConnectionInterface $conn) {
@@ -743,7 +717,7 @@ class FunctionalHttpServerTest extends TestCase
             return Stream\buffer($conn);
         });
 
-        $response = Block\await($result, $loop, 1.0);
+        $response = Block\await($result, null, 1.0);
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
         $this->assertStringEndsWith("\r\n\r\n", $response);
@@ -753,16 +727,14 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testLimitConcurrentRequestsMiddlewareRequestStreamPausing()
     {
-        $loop = Factory::create();
-        $connector = new Connector(array(), $loop);
+        $connector = new Connector();
 
         $http = new HttpServer(
-            $loop,
             new LimitConcurrentRequestsMiddleware(5),
             new RequestBodyBufferMiddleware(16 * 1024 * 1024), // 16 MiB
-            function (ServerRequestInterface $request, $next) use ($loop) {
-                return new Promise\Promise(function ($resolve) use ($request, $loop, $next) {
-                    $loop->addTimer(0.1, function () use ($request, $resolve, $next) {
+            function (ServerRequestInterface $request, $next) {
+                return new Promise\Promise(function ($resolve) use ($request, $next) {
+                    Loop::addTimer(0.1, function () use ($request, $resolve, $next) {
                         $resolve($next($request));
                     });
                 });
@@ -772,7 +744,7 @@ class FunctionalHttpServerTest extends TestCase
             }
         );
 
-        $socket = new SocketServer('127.0.0.1:0', array(), $loop);
+        $socket = new SocketServer('127.0.0.1:0');
         $http->listen($socket);
 
         $result = array();
@@ -788,7 +760,7 @@ class FunctionalHttpServerTest extends TestCase
             });
         }
 
-        $responses = Block\await(Promise\all($result), $loop, 1.0);
+        $responses = Block\await(Promise\all($result), null, 1.0);
 
         foreach ($responses as $response) {
             $this->assertContainsString("HTTP/1.0 200 OK", $response, $response);

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -302,7 +302,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:443', array('tls' => array(
+            $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
             )), $loop);
         } catch (\RuntimeException $e) {
@@ -341,7 +341,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:443', array('tls' => array(
+            $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
             )), $loop);
         } catch (\RuntimeException $e) {
@@ -410,7 +410,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $loop = Factory::create();
         try {
-            $socket = new SocketServer('127.0.0.1:80', array('tls' => array(
+            $socket = new SocketServer('tls://127.0.0.1:80', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
             )), $loop);
         } catch (\RuntimeException $e) {

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -6,7 +6,6 @@ use Clue\React\Block;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
 use React\Http\Io\MiddlewareRunner;
 use React\Http\Message\ServerRequest;
 use React\Promise;
@@ -162,7 +161,7 @@ final class MiddlewareRunnerTest extends TestCase
         $response = $middlewareStack($request);
 
         $this->assertTrue($response instanceof PromiseInterface);
-        $response = Block\await($response, Factory::create());
+        $response = Block\await($response);
 
         $this->assertTrue($response instanceof ResponseInterface);
         $this->assertSame(200, $response->getStatusCode());
@@ -229,7 +228,7 @@ final class MiddlewareRunnerTest extends TestCase
 
         $request = new ServerRequest('GET', 'https://example.com/');
 
-        $this->assertSame($response, Block\await($runner($request), Factory::create()));
+        $this->assertSame($response, Block\await($runner($request)));
         $this->assertSame(1, $retryCalled);
         $this->assertSame(2, $called);
         $this->assertSame($exception, $error);

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Http\Io\StreamingServer;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
@@ -48,7 +48,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -60,7 +60,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableOnce());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableOnce());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -75,7 +75,7 @@ class StreamingServerTest extends TestCase
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
-        $server = new StreamingServer(Factory::create(), array($this, 'helperCallableOnce'));
+        $server = new StreamingServer(Loop::get(), array($this, 'helperCallableOnce'));
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -95,7 +95,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -128,7 +128,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -160,7 +160,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -182,7 +182,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -204,7 +204,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -226,7 +226,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetHttp10WithoutHostWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -248,7 +248,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestGetHttp11WithoutHostWillReject()
     {
-        $server = new StreamingServer(Factory::create(), 'var_dump');
+        $server = new StreamingServer(Loop::get(), 'var_dump');
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -261,7 +261,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -281,7 +281,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -294,7 +294,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -316,7 +316,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectWithoutHostWillBePassesAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -338,7 +338,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -360,7 +360,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -381,7 +381,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -393,7 +393,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -407,7 +407,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -433,7 +433,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -455,7 +455,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -475,7 +475,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestAbsoluteWithoutHostWillReject()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -489,7 +489,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -511,7 +511,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -531,7 +531,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             $request->getBody()->pause();
         });
 
@@ -551,7 +551,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             $request->getBody()->resume();
         });
 
@@ -571,7 +571,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCloseWillNotCloseConnection()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
         });
 
@@ -586,7 +586,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();
         });
@@ -603,7 +603,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
         });
@@ -622,7 +622,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
         });
 
@@ -637,7 +637,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -657,7 +657,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -678,7 +678,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsServerHeader()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -708,7 +708,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($never) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -738,7 +738,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($once) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -770,7 +770,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -805,7 +805,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -843,7 +843,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -879,7 +879,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -934,7 +934,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -952,7 +952,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -988,7 +988,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -1023,7 +1023,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 101,
                 array(
@@ -1063,7 +1063,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
                 array(
@@ -1104,7 +1104,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1142,7 +1142,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1161,7 +1161,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1194,7 +1194,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1228,7 +1228,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1264,7 +1264,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array('Content-Length' => '3'),
@@ -1296,7 +1296,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 204,
                 array(),
@@ -1332,7 +1332,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 204,
                 array('Content-Length' => '3'),
@@ -1364,7 +1364,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1396,7 +1396,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsExplicitContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array('Content-Length' => 3),
@@ -1428,7 +1428,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1464,7 +1464,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 304,
                 array('Content-Length' => '3'),
@@ -1497,7 +1497,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1531,7 +1531,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1565,7 +1565,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1602,7 +1602,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1630,7 +1630,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1661,7 +1661,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1690,7 +1690,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1718,7 +1718,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1748,7 +1748,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1775,7 +1775,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1806,7 +1806,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1838,7 +1838,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1864,7 +1864,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1891,7 +1891,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1917,7 +1917,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1942,7 +1942,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1964,7 +1964,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1987,7 +1987,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2009,7 +2009,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Factory::create(), function ($request) use ($errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2036,7 +2036,7 @@ class StreamingServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = new StreamingServer(Loop::get(), function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -2060,7 +2060,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -2079,7 +2079,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -2113,7 +2113,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2154,7 +2154,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($body) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2191,7 +2191,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($body) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2225,7 +2225,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($stream) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(
@@ -2262,7 +2262,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDate()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2292,7 +2292,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWIthCustomDateHeaderOverwritesDefault()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
@@ -2325,7 +2325,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Date' => '')
@@ -2358,7 +2358,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseCanContainMultipleCookieHeaders()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2396,7 +2396,7 @@ class StreamingServerTest extends TestCase
 
     public function testReponseWithExpectContinueRequestContainsContinueWithLaterResponse()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2428,7 +2428,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2459,14 +2459,14 @@ class StreamingServerTest extends TestCase
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $server = new StreamingServer(Factory::create(), 'invalid');
+        $server = new StreamingServer(Loop::get(), 'invalid');
     }
 
     public function testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding()
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array(),
@@ -2505,7 +2505,7 @@ class StreamingServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use ($input) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array('Content-Length' => 5),
@@ -2543,7 +2543,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithResponsePromise()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2571,7 +2571,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseReturnInvalidTypeWillResultInError()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2605,7 +2605,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2633,7 +2633,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2664,7 +2664,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2695,7 +2695,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Transfer-Encoding' => 'chunked'),
@@ -2731,7 +2731,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWillBeHandled()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2759,7 +2759,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2797,7 +2797,7 @@ class StreamingServerTest extends TestCase
      */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             throw new \Error('hello');
         });
 
@@ -2840,7 +2840,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2877,7 +2877,7 @@ class StreamingServerTest extends TestCase
     public function testRequestServerRequestParams()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2911,7 +2911,7 @@ class StreamingServerTest extends TestCase
     public function testRequestQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2931,7 +2931,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2952,7 +2952,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2973,7 +2973,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2992,7 +2992,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCookieWithCommaValueWillBeAddedToServerRequest() {
         $requestValidation = null;
-        $server = new StreamingServer(Factory::create(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3011,7 +3011,7 @@ class StreamingServerTest extends TestCase
 
     public function testNewConnectionWillInvokeParserOnce()
     {
-        $server = new StreamingServer(Factory::create(), $this->expectCallableNever());
+        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3028,7 +3028,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array(), '', '1.0');
 
-        $server = new StreamingServer(Factory::create(), $this->expectCallableOnceWith($request));
+        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3051,7 +3051,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'close'));
 
-        $server = new StreamingServer(Factory::create(), $this->expectCallableOnceWith($request));
+        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3074,7 +3074,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Factory::create(), function () {
+        $server = new StreamingServer(Loop::get(), function () {
             return new Response(200, array('Connection' => 'close'));
         });
 
@@ -3099,7 +3099,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Factory::create(), function () {
+        $server = new StreamingServer(Loop::get(), function () {
             return new Response();
         });
 
@@ -3124,7 +3124,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'keep-alive'), '', '1.0');
 
-        $server = new StreamingServer(Factory::create(), function () {
+        $server = new StreamingServer(Loop::get(), function () {
             return new Response();
         });
 
@@ -3150,7 +3150,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Factory::create(), function () use ($body) {
+        $server = new StreamingServer(Loop::get(), function () use ($body) {
             return new Response(200, array(), $body);
         });
 
@@ -3176,7 +3176,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Factory::create(), function () use ($body) {
+        $server = new StreamingServer(Loop::get(), function () use ($body) {
             return new Response(200, array(), $body);
         });
 

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\RequestInterface;
 use RingCentral\Psr7\Response;
 use React\Http\Io\Transaction;
 use React\Http\Message\ResponseException;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Stream\ThroughStream;
@@ -383,10 +383,8 @@ class TransactionTest extends TestCase
 
     public function testReceivingStreamingBodyWillResolveWithBufferedResponseByDefault()
     {
-        $loop = Factory::create();
-
         $stream = new ThroughStream();
-        $loop->addTimer(0.001, function () use ($stream) {
+        Loop::addTimer(0.001, function () use ($stream) {
             $stream->emit('data', array('hello world'));
             $stream->close();
         });
@@ -398,10 +396,10 @@ class TransactionTest extends TestCase
         $sender = $this->makeSenderMock();
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
 
-        $transaction = new Transaction($sender, $loop);
+        $transaction = new Transaction($sender, Loop::get());
         $promise = $transaction->send($request);
 
-        $response = Block\await($promise, $loop);
+        $response = Block\await($promise);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('hello world', (string)$response->getBody());
@@ -409,8 +407,6 @@ class TransactionTest extends TestCase
 
     public function testReceivingStreamingBodyWithSizeExceedingMaximumResponseBufferWillRejectAndCloseResponseStream()
     {
-        $loop = Factory::create();
-
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
@@ -422,17 +418,15 @@ class TransactionTest extends TestCase
         $sender = $this->makeSenderMock();
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
 
-        $transaction = new Transaction($sender, $loop);
+        $transaction = new Transaction($sender, Loop::get());
         $promise = $transaction->send($request);
 
         $this->setExpectedException('OverflowException');
-        Block\await($promise, $loop, 0.001);
+        Block\await($promise, null, 0.001);
     }
 
     public function testCancelBufferingResponseWillCloseStreamAndReject()
     {
-        $loop = Factory::create();
-
         $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
         $stream->expects($this->any())->method('isReadable')->willReturn(true);
         $stream->expects($this->once())->method('close');
@@ -444,12 +438,12 @@ class TransactionTest extends TestCase
         $sender = $this->makeSenderMock();
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
 
-        $transaction = new Transaction($sender, $loop);
+        $transaction = new Transaction($sender, Loop::get());
         $promise = $transaction->send($request);
         $promise->cancel();
 
         $this->setExpectedException('RuntimeException');
-        Block\await($promise, $loop, 0.001);
+        Block\await($promise, null, 0.001);
     }
 
     public function testReceivingStreamingBodyWillResolveWithStreamingResponseIfStreamingIsEnabled()


### PR DESCRIPTION
Builds on top of #410, #417, #418, #419, https://github.com/clue/reactphp-block/pull/60, https://github.com/reactphp/socket/pull/283 and others