### PR TITLE
Add factory methods for common HTML/JSON/plaintext/XML response types

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,7 @@ This is an HTTP server which responds with `Hello World!` to every request.
 require __DIR__ . '/vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         "Hello World!\n"
     );
 });
@@ -738,11 +734,7 @@ object and expects a [response](#server-response) object in return:
 
 ```php
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         "Hello World!\n"
     );
 });
@@ -953,14 +945,10 @@ and will be passed to the callback function like this.
 
  ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    $body = "The method of the request is: " . $request->getMethod();
-    $body .= "The requested path is: " . $request->getUri()->getPath();
+    $body = "The method of the request is: " . $request->getMethod() . "\n";
+    $body .= "The requested path is: " . $request->getUri()->getPath() . "\n";
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         $body
     );
 });
@@ -996,13 +984,9 @@ The following parameters are currently available:
 
 ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
+    $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'] . "\n";
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         $body
     );
 });
@@ -1030,11 +1014,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
         $body = 'The value of "foo" is: ' . htmlspecialchars($queryParams['foo']);
     }
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/html'
-        ),
+    return React\Http\Message\Response::html(
         $body
     );
 });
@@ -1077,9 +1057,7 @@ request headers (commonly used for `POST` requests for HTML form submission data
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     $name = $request->getParsedBody()['name'] ?? 'anonymous';
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(),
+    return React\Http\Message\Response::plaintext(
         "Hello $name!\n"
     );
 });
@@ -1102,10 +1080,8 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $data = json_decode((string)$request->getBody());
     $name = $data->name ?? 'anonymous';
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array('Content-Type' => 'application/json'),
-        json_encode(['message' => "Hello $name!"])
+    return React\Http\Message\Response::json(
+        ['message' => "Hello $name!"]
     );
 });
 ```
@@ -1125,9 +1101,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $files = $request->getUploadedFiles();
     $name = isset($files['avatar']) ? $files['avatar']->getClientFilename() : 'nothing';
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(),
+    return React\Http\Message\Response::plaintext(
         "Uploaded $name\n"
     );
 });
@@ -1208,24 +1182,16 @@ $http = new React\Http\HttpServer(
             });
 
             $body->on('end', function () use ($resolve, &$bytes){
-                $resolve(new React\Http\Message\Response(
-                    React\Http\Message\Response::STATUS_OK,
-                    array(
-                        'Content-Type' => 'text/plain'
-                    ),
+                $resolve(React\Http\Message\Response::plaintext(
                     "Received $bytes bytes\n"
                 ));
             });
 
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (Exception $e) use ($resolve, &$bytes) {
-                $resolve(new React\Http\Message\Response(
-                    React\Http\Message\Response::STATUS_BAD_REQUEST,
-                    array(
-                        'Content-Type' => 'text/plain'
-                    ),
+                $resolve(React\Http\Message\Response::plaintext(
                     "Encountered error after $bytes bytes: {$e->getMessage()}\n"
-                ));
+                )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST));
             });
         });
     }
@@ -1272,23 +1238,15 @@ $http = new React\Http\HttpServer(
     function (Psr\Http\Message\ServerRequestInterface $request) {
         $size = $request->getBody()->getSize();
         if ($size === null) {
-            $body = 'The request does not contain an explicit length.';
-            $body .= 'This example does not accept chunked transfer encoding.';
+            $body = "The request does not contain an explicit length. ";
+            $body .= "This example does not accept chunked transfer encoding.\n";
 
-            return new React\Http\Message\Response(
-                React\Http\Message\Response::STATUS_LENGTH_REQUIRED,
-                array(
-                    'Content-Type' => 'text/plain'
-                ),
+            return React\Http\Message\Response::plaintext(
                 $body
-            );
+            )->withStatus(React\Http\Message\Response::STATUS_LENGTH_REQUIRED);
         }
 
-        return new React\Http\Message\Response(
-            React\Http\Message\Response::STATUS_OK,
-            array(
-                'Content-Type' => 'text/plain'
-            ),
+        return React\Http\Message\Response::plaintext(
             "Request body size: " . $size . " bytes\n"
         );
     }
@@ -1344,25 +1302,16 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
-        $body = "Your cookie value is: " . $request->getCookieParams()[$key];
+        $body = "Your cookie value is: " . $request->getCookieParams()[$key] . "\n";
 
-        return new React\Http\Message\Response(
-            React\Http\Message\Response::STATUS_OK,
-            array(
-                'Content-Type' => 'text/plain'
-            ),
+        return React\Http\Message\Response::plaintext(
             $body
         );
     }
 
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain',
-            'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')
-        ),
-        "Your cookie has been set."
-    );
+    return React\Http\Message\Response::plaintext(
+        "Your cookie has been set.\n"
+    )->withHeader('Set-Cookie', urlencode($key) . '=' . urlencode('test;more'));
 });
 ```
 
@@ -1413,11 +1362,7 @@ In its most simple form, you can use it like this:
 
 ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         "Hello World!\n"
     );
 });
@@ -1441,17 +1386,16 @@ This example shows how such a long-term action could look like:
 
 ```php
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    return new Promise(function ($resolve, $reject) {
+    $promise = new Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
-            $response = new React\Http\Message\Response(
-                React\Http\Message\Response::STATUS_OK,
-                array(
-                    'Content-Type' => 'text/plain'
-                ),
-                "Hello world"
-            );
-            $resolve($response);
+            $resolve();
         });
+    });
+
+    return $promise->then(function () { 
+        return React\Http\Message\Response::plaintext(
+            "Hello World!"
+        );
     });
 });
 ```
@@ -1571,11 +1515,7 @@ a `string` response body like this:
 
 ```php 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
-    return new React\Http\Message\Response(
-        React\Http\Message\Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         "Hello World!\n"
     );
 });
@@ -1845,11 +1785,9 @@ $http = new React\Http\HttpServer(
             $resolve($next($request));
         });
         return $promise->then(null, function (Exception $e) {
-            return new React\Http\Message\Response(
-                React\Http\Message\Response::STATUS_INTERNAL_SERVER_ERROR,
-                array(),
-                'Internal error: ' . $e->getMessage()
-            );
+            return React\Http\Message\Response::plaintext(
+                'Internal error: ' . $e->getMessage() . "\n"
+            )->withStatus(React\Http\Message\Response::STATUS_INTERNAL_SERVER_ERROR);
         });
     },
     function (Psr\Http\Message\ServerRequestInterface $request) {

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ multiple concurrent HTTP requests without blocking.
         * [withResponseBuffer()](#withresponsebuffer)
     * [React\Http\Message](#reacthttpmessage)
         * [Response](#response)
+            * [html()](#html)
+            * [json()](#json)
+            * [plaintext()](#plaintext)
+            * [xml()](#xml)
         * [ServerRequest](#serverrequest)
         * [ResponseException](#responseexception)
     * [React\Http\Middleware](#reacthttpmiddleware)
@@ -2462,6 +2466,183 @@ constants with the `STATUS_*` prefix. For instance, the `200 OK` and
 > Internally, this implementation builds on top of an existing incoming
   response message and only adds required streaming support. This base class is
   considered an implementation detail that may change in the future.
+
+##### html()
+
+The static `html(string $html): Response` method can be used to
+create an HTML response.
+
+```php
+$html = <<<HTML
+<!doctype html>
+<html>
+<body>Hello wörld!</body>
+</html>
+
+HTML;
+
+$response = React\Http\Message\Response::html($html);
+```
+
+This is a convenient shortcut method that returns the equivalent of this:
+
+```
+$response = new React\Http\Message\Response(
+    React\Http\Message\Response::STATUS_OK,
+    [
+        'Content-Type' => 'text/html; charset=utf-8'
+    ],
+    $html
+);
+```
+
+This method always returns a response with a `200 OK` status code and
+the appropriate `Content-Type` response header for the given HTTP source
+string encoded in UTF-8 (Unicode). It's generally recommended to end the
+given plaintext string with a trailing newline.
+
+If you want to use a different status code or custom HTTP response
+headers, you can manipulate the returned response object using the
+provided PSR-7 methods or directly instantiate a custom HTTP response
+object using the `Response` constructor:
+
+```php
+$response = React\Http\Message\Response::html(
+    "<h1>Error</h1>\n<p>Invalid user name given.</p>\n"
+)->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+```
+
+##### json()
+
+The static `json(mixed $data): Response` method can be used to
+create a JSON response.
+
+```php
+$response = React\Http\Message\Response::json(['name' => 'Alice']);
+```
+
+This is a convenient shortcut method that returns the equivalent of this:
+
+```
+$response = new React\Http\Message\Response(
+    React\Http\Message\Response::STATUS_OK,
+    [
+        'Content-Type' => 'application/json'
+    ],
+    json_encode(
+        ['name' => 'Alice'],
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION
+    ) . "\n"
+);
+```
+
+This method always returns a response with a `200 OK` status code and
+the appropriate `Content-Type` response header for the given structured
+data encoded as a JSON text.
+
+The given structured data will be encoded as a JSON text. Any `string`
+values in the data must be encoded in UTF-8 (Unicode). If the encoding
+fails, this method will throw an `InvalidArgumentException`.
+
+By default, the given structured data will be encoded with the flags as
+shown above. This includes pretty printing (PHP 5.4+) and preserving
+zero fractions for `float` values (PHP 5.6.6+) to ease debugging. It is
+assumed any additional data overhead is usually compensated by using HTTP
+response compression.
+
+If you want to use a different status code or custom HTTP response
+headers, you can manipulate the returned response object using the
+provided PSR-7 methods or directly instantiate a custom HTTP response
+object using the `Response` constructor:
+
+```php
+$response = React\Http\Message\Response::json(
+    ['error' => 'Invalid user name given']
+)->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+```
+
+##### plaintext()
+
+The static `plaintext(string $text): Response` method can be used to
+create a plaintext response.
+
+```php
+$response = React\Http\Message\Response::plaintext("Hello wörld!\n");
+```
+
+This is a convenient shortcut method that returns the equivalent of this:
+
+```
+$response = new React\Http\Message\Response(
+    React\Http\Message\Response::STATUS_OK,
+    [
+        'Content-Type' => 'text/plain; charset=utf-8'
+    ],
+    "Hello wörld!\n"
+);
+```
+
+This method always returns a response with a `200 OK` status code and
+the appropriate `Content-Type` response header for the given plaintext
+string encoded in UTF-8 (Unicode). It's generally recommended to end the
+given plaintext string with a trailing newline.
+
+If you want to use a different status code or custom HTTP response
+headers, you can manipulate the returned response object using the
+provided PSR-7 methods or directly instantiate a custom HTTP response
+object using the `Response` constructor:
+
+```php
+$response = React\Http\Message\Response::plaintext(
+    "Error: Invalid user name given.\n"
+)->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+```
+
+##### xml()
+
+The static `xml(string $xml): Response` method can be used to
+create an XML response.
+
+```php
+$xml = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<body>
+    <greeting>Hello wörld!</greeting>
+</body>
+
+XML;
+
+$response = React\Http\Message\Response::xml($xml);
+```
+
+This is a convenient shortcut method that returns the equivalent of this:
+
+```
+$response = new React\Http\Message\Response(
+    React\Http\Message\Response::STATUS_OK,
+    [
+        'Content-Type' => 'application/xml'
+    ],
+    $xml
+);
+```
+
+This method always returns a response with a `200 OK` status code and
+the appropriate `Content-Type` response header for the given XML source
+string. It's generally recommended to use UTF-8 (Unicode) and specify
+this as part of the leading XML declaration and to end the given XML
+source string with a trailing newline.
+
+If you want to use a different status code or custom HTTP response
+headers, you can manipulate the returned response object using the
+provided PSR-7 methods or directly instantiate a custom HTTP response
+object using the `Response` constructor:
+
+```php
+$response = React\Http\Message\Response::xml(
+    "<error><message>Invalid user name given.</message></error>\n"
+)->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+```
 
 #### ServerRequest
 

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -1,17 +1,10 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
-        "Hello world\n"
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
+    return React\Http\Message\Response::plaintext(
+        "Hello World!\n"
     );
 });
 

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -1,17 +1,10 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $counter = 0;
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$counter) {
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) use (&$counter) {
+    return React\Http\Message\Response::plaintext(
         "Welcome number " . ++$counter . "!\n"
     );
 });

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -1,18 +1,11 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
-    $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'];
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
+    $body = "Your IP is: " . $request->getServerParams()['REMOTE_ADDR'] . "\n";
 
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
+    return React\Http\Message\Response::plaintext(
         $body
     );
 });

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -1,11 +1,8 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     $queryParams = $request->getQueryParams();
 
     $body = 'The query parameter "foo" is not set. Click the following link ';
@@ -15,11 +12,7 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
         $body = 'The value of "foo" is: ' . htmlspecialchars($queryParams['foo']);
     }
 
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/html'
-        ),
+    return React\Http\Message\Response::html(
         $body
     );
 });

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -1,33 +1,21 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     $key = 'react\php';
 
     if (isset($request->getCookieParams()[$key])) {
-        $body = "Your cookie value is: " . $request->getCookieParams()[$key];
+        $body = "Your cookie value is: " . $request->getCookieParams()[$key] . "\n";
 
-        return new Response(
-            Response::STATUS_OK,
-            array(
-                'Content-Type' => 'text/plain'
-            ),
+        return React\Http\Message\Response::plaintext(
             $body
         );
     }
 
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain',
-            'Set-Cookie' => urlencode($key) . '=' . urlencode('test;more')
-        ),
-        "Your cookie has been set."
-    );
+    return React\Http\Message\Response::plaintext(
+        "Your cookie has been set.\n"
+    )->withHeader('Set-Cookie', urlencode($key) . '=' . urlencode('test;more'));
 });
 
 $socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -1,24 +1,20 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
-use React\Http\Message\Response;
-use React\Promise\Promise;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
-    return new Promise(function ($resolve, $reject) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
+    $promise = new React\Promise\Promise(function ($resolve, $reject) {
         Loop::addTimer(1.5, function() use ($resolve) {
-            $response = new Response(
-                Response::STATUS_OK,
-                array(
-                    'Content-Type' => 'text/plain'
-                ),
-                "Hello world"
-            );
-            $resolve($response);
+            $resolve();
         });
+    });
+
+    return $promise->then(function () {
+        return React\Http\Message\Response::plaintext(
+            "Hello world!\n"
+        );
     });
 });
 

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -1,30 +1,18 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-use React\Promise\Promise;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $count = 0;
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) use (&$count) {
-    return new Promise(function ($resolve, $reject) use (&$count) {
-        $count++;
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) use (&$count) {
+    $count++;
 
-        if ($count%2 === 0) {
-            throw new Exception('Second call');
-        }
+    if ($count % 2 === 0) {
+        throw new Exception('Second call');
+    }
 
-        $response = new Response(
-            Response::STATUS_OK,
-            array(
-                'Content-Type' => 'text/plain'
-            ),
-            "Hello World!\n"
-        );
-
-        $resolve($response);
-    });
+    return React\Http\Message\Response::plaintext(
+        "Hello World!\n"
+    );
 });
 
 $socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -1,13 +1,12 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Message\Response;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     if ($request->getMethod() !== 'GET' || $request->getUri()->getPath() !== '/') {
         return new Response(Response::STATUS_NOT_FOUND);
     }

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -6,49 +6,32 @@
 // $ php examples/59-server-json-api.php 8080
 // $ curl -v http://localhost:8080/ -H 'Content-Type: application/json' -d '{"name":"Alice"}'
 
-use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Message\Response;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
-        return new Response(
-            Response::STATUS_UNSUPPORTED_MEDIA_TYPE,
-            array(
-                'Content-Type' => 'application/json'
-            ),
-            json_encode(array('error' => 'Only supports application/json')) . "\n"
-        );
+        return Response::json(
+            array('error' => 'Only supports application/json')
+        )->withStatus(Response::STATUS_UNSUPPORTED_MEDIA_TYPE);
     }
 
     $input = json_decode($request->getBody()->getContents());
     if (json_last_error() !== JSON_ERROR_NONE) {
-        return new Response(
-            Response::STATUS_BAD_REQUEST,
-            array(
-                'Content-Type' => 'application/json'
-            ),
-            json_encode(array('error' => 'Invalid JSON data given')) . "\n"
-        );
+        return Response::json(
+            array('error' => 'Invalid JSON data given')
+        )->withStatus(Response::STATUS_BAD_REQUEST);
     }
 
     if (!isset($input->name) || !is_string($input->name)) {
-        return new Response(
-            Response::STATUS_UNPROCESSABLE_ENTITY,
-            array(
-                'Content-Type' => 'application/json'
-            ),
-            json_encode(array('error' => 'JSON data does not contain a string "name" property')) . "\n"
-        );
+        return Response::json(
+            array('error' => 'JSON data does not contain a string "name" property')
+        )->withStatus(Response::STATUS_UNPROCESSABLE_ENTITY);
     }
 
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'application/json'
-        ),
-        json_encode(array('message' => 'Hello ' . $input->name)) . "\n"
+    return Response::json(
+        array('message' => 'Hello ' . $input->name)
     );
 });
 

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -1,17 +1,10 @@
 <?php
 
-use Psr\Http\Message\ServerRequestInterface;
-use React\Http\Message\Response;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
-        "Hello world!\n"
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
+    return React\Http\Message\Response::plaintext(
+        "Hello World!\n"
     );
 });
 

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -109,11 +109,7 @@ $body
 
 HTML;
 
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/html; charset=UTF-8'
-        ),
+    return Response::html(
         $html
     );
 };

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -19,24 +19,16 @@ $http = new React\Http\HttpServer(
             });
 
             $body->on('end', function () use ($resolve, &$bytes){
-                $resolve(new React\Http\Message\Response(
-                    React\Http\Message\Response::STATUS_OK,
-                    array(
-                        'Content-Type' => 'text/plain'
-                    ),
+                $resolve(React\Http\Message\Response::plaintext(
                     "Received $bytes bytes\n"
                 ));
             });
 
             // an error occures e.g. on invalid chunked encoded data or an unexpected 'end' event
             $body->on('error', function (Exception $e) use ($resolve, &$bytes) {
-                $resolve(new React\Http\Message\Response(
-                    React\Http\Message\Response::STATUS_BAD_REQUEST,
-                    array(
-                        'Content-Type' => 'text/plain'
-                    ),
+                $resolve(React\Http\Message\Response::plaintext(
                     "Encountered error after $bytes bytes: {$e->getMessage()}\n"
-                ));
+                )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST));
             });
         });
     }

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -3,25 +3,17 @@
 // $ php examples/71-server-http-proxy.php 8080
 // $ curl -v --proxy http://localhost:8080 http://reactphp.org/
 
-use Psr\Http\Message\RequestInterface;
-use React\Http\Message\Response;
-use RingCentral\Psr7;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 // Note how this example uses the `HttpServer` without the `StreamingRequestMiddleware`.
 // This means that this proxy buffers the whole request before "processing" it.
 // As such, this is store-and-forward proxy. This could also use the advanced
 // `StreamingRequestMiddleware` to forward the incoming request as it comes in.
-$http = new React\Http\HttpServer(function (RequestInterface $request) {
+$http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     if (strpos($request->getRequestTarget(), '://') === false) {
-        return new Response(
-            Response::STATUS_BAD_REQUEST,
-            array(
-                'Content-Type' => 'text/plain'
-            ),
-            'This is a plain HTTP proxy'
-        );
+        return React\Http\Message\Response::plaintext(
+            "This is a plain HTTP proxy\n"
+        )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
     }
 
     // prepare outgoing client request by updating request-target and Host header
@@ -35,12 +27,8 @@ $http = new React\Http\HttpServer(function (RequestInterface $request) {
     // pseudo code only: simply dump the outgoing request as a string
     // left up as an exercise: use an HTTP client to send the outgoing request
     // and forward the incoming response to the original client request
-    return new Response(
-        Response::STATUS_OK,
-        array(
-            'Content-Type' => 'text/plain'
-        ),
-        Psr7\str($outgoing)
+    return React\Http\Message\Response::plaintext(
+        RingCentral\Psr7\str($outgoing)
     );
 });
 

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -93,11 +93,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     switch ($request->getUri()->getPath()) {
         case '/':
-            return new Response(
-                Response::STATUS_OK,
-                array(
-                    'Content-Type' => 'text/html'
-                ),
+            return Response::html(
                 '<html><a href="1g.bin">1g.bin</a><br/><a href="10g.bin">10g.bin</a></html>'
             );
         case '/1g.bin':

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -43,6 +43,221 @@ use RingCentral\Psr7\Response as Psr7Response;
 final class Response extends Psr7Response implements StatusCodeInterface
 {
     /**
+     * Create an HTML response
+     *
+     * ```php
+     * $html = <<<HTML
+     * <!doctype html>
+     * <html>
+     * <body>Hello wörld!</body>
+     * </html>
+     *
+     * HTML;
+     *
+     * $response = React\Http\Message\Response::html($html);
+     * ```
+     *
+     * This is a convenient shortcut method that returns the equivalent of this:
+     *
+     * ```
+     * $response = new React\Http\Message\Response(
+     *     React\Http\Message\Response::STATUS_OK,
+     *     [
+     *         'Content-Type' => 'text/html; charset=utf-8'
+     *     ],
+     *     $html
+     * );
+     * ```
+     *
+     * This method always returns a response with a `200 OK` status code and
+     * the appropriate `Content-Type` response header for the given HTTP source
+     * string encoded in UTF-8 (Unicode). It's generally recommended to end the
+     * given plaintext string with a trailing newline.
+     *
+     * If you want to use a different status code or custom HTTP response
+     * headers, you can manipulate the returned response object using the
+     * provided PSR-7 methods or directly instantiate a custom HTTP response
+     * object using the `Response` constructor:
+     *
+     * ```php
+     * $response = React\Http\Message\Response::html(
+     *     "<h1>Error</h1>\n<p>Invalid user name given.</p>\n"
+     * )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+     * ```
+     *
+     * @param string $html
+     * @return self
+     */
+    public static function html($html)
+    {
+        return new self(self::STATUS_OK, array('Content-Type' => 'text/html; charset=utf-8'), $html);
+    }
+
+    /**
+     * Create a JSON response
+     *
+     * ```php
+     * $response = React\Http\Message\Response::json(['name' => 'Alice']);
+     * ```
+     *
+     * This is a convenient shortcut method that returns the equivalent of this:
+     *
+     * ```
+     * $response = new React\Http\Message\Response(
+     *     React\Http\Message\Response::STATUS_OK,
+     *     [
+     *         'Content-Type' => 'application/json'
+     *     ],
+     *     json_encode(
+     *         ['name' => 'Alice'],
+     *         JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION
+     *     ) . "\n"
+     * );
+     * ```
+     *
+     * This method always returns a response with a `200 OK` status code and
+     * the appropriate `Content-Type` response header for the given structured
+     * data encoded as a JSON text.
+     *
+     * The given structured data will be encoded as a JSON text. Any `string`
+     * values in the data must be encoded in UTF-8 (Unicode). If the encoding
+     * fails, this method will throw an `InvalidArgumentException`.
+     *
+     * By default, the given structured data will be encoded with the flags as
+     * shown above. This includes pretty printing (PHP 5.4+) and preserving
+     * zero fractions for `float` values (PHP 5.6.6+) to ease debugging. It is
+     * assumed any additional data overhead is usually compensated by using HTTP
+     * response compression.
+     *
+     * If you want to use a different status code or custom HTTP response
+     * headers, you can manipulate the returned response object using the
+     * provided PSR-7 methods or directly instantiate a custom HTTP response
+     * object using the `Response` constructor:
+     *
+     * ```php
+     * $response = React\Http\Message\Response::json(
+     *     ['error' => 'Invalid user name given']
+     * )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+     * ```
+     *
+     * @param mixed $data
+     * @return self
+     * @throws \InvalidArgumentException when encoding fails
+     */
+    public static function json($data)
+    {
+        $json = @\json_encode(
+            $data,
+            (\defined('JSON_PRETTY_PRINT') ? \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE : 0) | (\defined('JSON_PRESERVE_ZERO_FRACTION') ? \JSON_PRESERVE_ZERO_FRACTION : 0)
+        );
+
+        // throw on error, now `false` but used to be `(string) "null"` before PHP 5.5
+        if ($json === false || (\PHP_VERSION_ID < 50500 && \json_last_error() !== \JSON_ERROR_NONE)) {
+            throw new \InvalidArgumentException(
+                'Unable to encode given data as JSON' . (\function_exists('json_last_error_msg') ? ': ' . \json_last_error_msg() : ''),
+                \json_last_error()
+            );
+        }
+
+        return new self(self::STATUS_OK, array('Content-Type' => 'application/json'), $json . "\n");
+    }
+
+    /**
+     * Create a plaintext response
+     *
+     * ```php
+     * $response = React\Http\Message\Response::plaintext("Hello wörld!\n");
+     * ```
+     *
+     * This is a convenient shortcut method that returns the equivalent of this:
+     *
+     * ```
+     * $response = new React\Http\Message\Response(
+     *     React\Http\Message\Response::STATUS_OK,
+     *     [
+     *         'Content-Type' => 'text/plain; charset=utf-8'
+     *     ],
+     *     "Hello wörld!\n"
+     * );
+     * ```
+     *
+     * This method always returns a response with a `200 OK` status code and
+     * the appropriate `Content-Type` response header for the given plaintext
+     * string encoded in UTF-8 (Unicode). It's generally recommended to end the
+     * given plaintext string with a trailing newline.
+     *
+     * If you want to use a different status code or custom HTTP response
+     * headers, you can manipulate the returned response object using the
+     * provided PSR-7 methods or directly instantiate a custom HTTP response
+     * object using the `Response` constructor:
+     *
+     * ```php
+     * $response = React\Http\Message\Response::plaintext(
+     *     "Error: Invalid user name given.\n"
+     * )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+     * ```
+     *
+     * @param string $text
+     * @return self
+     */
+    public static function plaintext($text)
+    {
+        return new self(self::STATUS_OK, array('Content-Type' => 'text/plain; charset=utf-8'), $text);
+    }
+
+    /**
+     * Create an XML response
+     *
+     * ```php
+     * $xml = <<<XML
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <body>
+     *     <greeting>Hello wörld!</greeting>
+     * </body>
+     *
+     * XML;
+     *
+     * $response = React\Http\Message\Response::xml($xml);
+     * ```
+     *
+     * This is a convenient shortcut method that returns the equivalent of this:
+     *
+     * ```
+     * $response = new React\Http\Message\Response(
+     *     React\Http\Message\Response::STATUS_OK,
+     *     [
+     *         'Content-Type' => 'application/xml'
+     *     ],
+     *     $xml
+     * );
+     * ```
+     *
+     * This method always returns a response with a `200 OK` status code and
+     * the appropriate `Content-Type` response header for the given XML source
+     * string. It's generally recommended to use UTF-8 (Unicode) and specify
+     * this as part of the leading XML declaration and to end the given XML
+     * source string with a trailing newline.
+     *
+     * If you want to use a different status code or custom HTTP response
+     * headers, you can manipulate the returned response object using the
+     * provided PSR-7 methods or directly instantiate a custom HTTP response
+     * object using the `Response` constructor:
+     *
+     * ```php
+     * $response = React\Http\Message\Response::xml(
+     *     "<error><message>Invalid user name given.</message></error>\n"
+     * )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
+     * ```
+     *
+     * @param string $xml
+     * @return self
+     */
+    public static function xml($xml)
+    {
+        return new self(self::STATUS_OK, array('Content-Type' => 'application/xml'), $xml);
+    }
+
+    /**
      * @param int                                            $status  HTTP status code (e.g. 200/404), see `self::STATUS_*` constants
      * @param array<string,string|string[]>                  $headers additional response headers
      * @param string|ReadableStreamInterface|StreamInterface $body    response body

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -53,4 +53,75 @@ class ResponseTest extends TestCase
         $this->setExpectedException('InvalidArgumentException');
         new Response(200, array(), tmpfile());
     }
+
+
+    public function testHtmlMethodReturnsHtmlResponse()
+    {
+        $response = Response::html('<!doctype html><body>Hello wörld!</body>');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/html; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals('<!doctype html><body>Hello wörld!</body>', (string) $response->getBody());
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testJsonMethodReturnsPrettyPrintedJsonResponse()
+    {
+        $response = Response::json(array('text' => 'Hello wörld!'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals("{\n    \"text\": \"Hello wörld!\"\n}\n", (string) $response->getBody());
+    }
+
+    /**
+     * @requires PHP 5.6.6
+     */
+    public function testJsonMethodReturnsZeroFractionsInJsonResponse()
+    {
+        $response = Response::json(1.0);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals("1.0\n", (string) $response->getBody());
+    }
+
+    public function testJsonMethodReturnsJsonTextForSimpleString()
+    {
+        $response = Response::json('Hello world!');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals("\"Hello world!\"\n", (string) $response->getBody());
+    }
+
+    public function testJsonMethodThrowsForInvalidString()
+    {
+        if (PHP_VERSION_ID < 50500) {
+            $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON');
+        } else {
+            $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON: Malformed UTF-8 characters, possibly incorrectly encoded');
+        }
+        Response::json("Hello w\xF6rld!");
+    }
+
+    public function testPlaintextMethodReturnsPlaintextResponse()
+    {
+        $response = Response::plaintext("Hello wörld!\n");
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/plain; charset=utf-8', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals("Hello wörld!\n", (string) $response->getBody());
+    }
+
+    public function testXmlMethodReturnsXmlResponse()
+    {
+        $response = Response::xml('<?xml version="1.0" encoding="utf-8"?><body>Hello wörld!</body>');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/xml', $response->getHeaderLine('Content-Type'));
+        $this->assertEquals('<?xml version="1.0" encoding="utf-8"?><body>Hello wörld!</body>', (string) $response->getBody());
+    }
 }


### PR DESCRIPTION
This changeset adds factory methods for common HTML/JSON/plaintext/XML response types:

```php
$response = React\Http\Response\html("<h1>Hello wörld!</h1>\n");
$response = React\Http\Response\json(['message' => 'Hello wörld!']);
$response = React\Http\Response\plaintext("Hello wörld!\n");
$response = React\Http\Response\xml("<message>Hello wörld!</message>\n");
```

Using the new factory methods is entirely optional and directly using the `Response` constructor remains supported of course, but we now use these factory methods throughout our documentation and examples to make them more readable. Accordingly, this does not affect backwards compatibility.

This builds on top of #403 (thank you @WyriHaximus!), but instead of exposing a new class, this changeset simply adds a number of static methods to the existing `Response` class. This makes it easier to use these methods in application code because no separate import is required, in particular when using the HTTP status code constants implemented in #432.

Supersedes / closes #403
Builds on top of #432
Refs https://github.com/clue/reactphp-ndjson/pull/14