### PR TITLE
Improve test suite to skip memory tests when lowering memory limit does not work

### DIFF
--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -404,7 +404,9 @@ final class HttpServerTest extends TestCase
     public function testConstructServerWithMemoryLimitDoesLimitConcurrency()
     {
         $old = ini_get('memory_limit');
-        ini_set('memory_limit', '100M');
+        if (@ini_set('memory_limit', '128M') === false) {
+            $this->markTestSkipped('Unable to change memory limit');
+        }
 
         $http = new HttpServer(function () { });
 


### PR DESCRIPTION
This simple changeset updates the test suite to skip memory tests when lowering memory limit does not work. This only affects the test suite and is a bit harder to reproduce in this repository itself, but I've stumbled over this while updating ReactPHP's combined test suite that runs all tests of all components and happens to use a few bytes more than the current limit.

I'll link the downstream PR against this one, a failed test run can be seen here: https://github.com/clue-labs/reactphp/runs/5063358894?check_suite_focus=true#step:5:54