### PR TITLE
Allow Explicit content length on HEAD requests

### DIFF
--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -265,6 +265,8 @@ final class StreamingServer extends EventEmitter
         if (($method === 'CONNECT' && $code >= 200 && $code < 300) || ($code >= 100 && $code < 200) || $code === Response::STATUS_NO_CONTENT) {
             // 2xx response to CONNECT and 1xx and 204 MUST NOT include Content-Length or Transfer-Encoding header
             $response = $response->withoutHeader('Content-Length');
+        } elseif ($method === 'HEAD' && $response->hasHeader('Content-Length')) {
+            // HEAD Request: preserve explicit Content-Length
         } elseif ($code === Response::STATUS_NOT_MODIFIED && ($response->hasHeader('Content-Length') || $body->getSize() === 0)) {
             // 304 Not Modified: preserve explicit Content-Length and preserve missing header if body is empty
         } elseif ($body->getSize() !== null) {


### PR DESCRIPTION
Hey guys, I am in the process of building a server to site infront of S3

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13

"The Content-Length entity-header field indicates the size of the entity-body, in decimal number of OCTETs, sent to the recipient or, in the **case of the HEAD method**, the **size of the entity-body that would have been sent had the request been a GET.**"

