### PR TITLE
1.when run in k8s, Connect via servicename.

### DIFF
--- a/src/Client/Request.php
+++ b/src/Client/Request.php
@@ -225,6 +225,7 @@ class Request extends EventEmitter implements WritableStreamInterface
         }
 
         $host = $this->requestData->getHost();
+        $host = gethostbyname($host);
         $port = $this->requestData->getPort();
 
         if ($scheme === 'https') {


### PR DESCRIPTION
my service run in k8s env,And I connect other service via servicename.when I run `(new React\Http\Browser())->post('http://openapicenter/index')`,The error message is `Connection to tcp://openapicenter:80 failed during DNS lookup. Last error for IPv4: DNS query for openapicenter (A) returned an error response (Server Failure). Previous error for IPv6: DNS query for openapicenter (AAAA) returned an error response (Server Failure)`. My `/etc/resolv.conf` is `search test.svc.cluster.local svc.cluster.local cluster.local
nameserver 169.254.20.10
nameserver 192.168.0.10
options ndots:3 timeout:1 attempts:2`