### PR TITLE
Improve performance, add internal `Clock`, reuse clock in same tick

### DIFF
--- a/src/Io/Clock.php
+++ b/src/Io/Clock.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace React\Http\Io;
+
+use React\EventLoop\LoopInterface;
+
+/**
+ * [internal] Clock source that returns current timestamp and memoize clock for same tick
+ *
+ * This is mostly used as an internal optimization to avoid unneeded syscalls to
+ * get the current system time multiple times within the same loop tick. For the
+ * purpose of the HTTP server, the clock is assumed to not change to a
+ * significant degree within the same loop tick. If you need a high precision
+ * clock source, you may want to use `\hrtime()` instead (PHP 7.3+).
+ *
+ * The API is modelled to resemble the PSR-20 `ClockInterface` (in draft at the
+ * time of writing this), but uses a `float` return value for performance
+ * reasons instead.
+ *
+ * Note that this is an internal class only and nothing you should usually care
+ * about for outside use.
+ *
+ * @internal
+ */
+class Clock
+{
+    /** @var LoopInterface $loop */
+    private $loop;
+
+    /** @var ?float */
+    private $now;
+
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /** @return float */
+    public function now()
+    {
+        if ($this->now === null) {
+            $this->now = \microtime(true);
+
+            // remember clock for current loop tick only and update on next tick
+            $now =& $this->now;
+            $this->loop->futureTick(function () use (&$now) {
+                assert($now !== null);
+                $now = null;
+            });
+        }
+
+        return $this->now;
+    }
+}

--- a/src/Io/RequestHeaderParser.php
+++ b/src/Io/RequestHeaderParser.php
@@ -24,6 +24,14 @@ class RequestHeaderParser extends EventEmitter
 {
     private $maxSize = 8192;
 
+    /** @var Clock */
+    private $clock;
+
+    public function __construct(Clock $clock)
+    {
+        $this->clock = $clock;
+    }
+
     public function handle(ConnectionInterface $conn)
     {
         $buffer = '';
@@ -155,8 +163,8 @@ class RequestHeaderParser extends EventEmitter
         // create new obj implementing ServerRequestInterface by preserving all
         // previous properties and restoring original request-target
         $serverParams = array(
-            'REQUEST_TIME' => \time(),
-            'REQUEST_TIME_FLOAT' => \microtime(true)
+            'REQUEST_TIME' => (int) ($now = $this->clock->now()),
+            'REQUEST_TIME_FLOAT' => $now
         );
 
         // scheme is `http` unless TLS is used

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -54,9 +54,13 @@ final class HttpServerTest extends TestCase
         $ref->setAccessible(true);
         $streamingServer = $ref->getValue($http);
 
-        $ref = new \ReflectionProperty($streamingServer, 'loop');
+        $ref = new \ReflectionProperty($streamingServer, 'clock');
         $ref->setAccessible(true);
-        $loop = $ref->getValue($streamingServer);
+        $clock = $ref->getValue($streamingServer);
+
+        $ref = new \ReflectionProperty($clock, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($clock);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }

--- a/tests/Io/ClockTest.php
+++ b/tests/Io/ClockTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use PHPUnit\Framework\TestCase;
+use React\Http\Io\Clock;
+
+class ClockTest extends TestCase
+{
+    public function testNowReturnsSameTimestampMultipleTimesInSameTick()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $clock = new Clock($loop);
+
+        $now = $clock->now();
+        $this->assertTrue(is_float($now)); // assertIsFloat() on PHPUnit 8+
+        $this->assertEquals($now, $clock->now());
+    }
+
+    public function testNowResetsMemoizedTimestampOnFutureTick()
+    {
+        $tick = null;
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('futureTick')->with($this->callback(function ($cb) use (&$tick) {
+            $tick = $cb;
+            return true;
+        }));
+
+        $clock = new Clock($loop);
+
+        $now = $clock->now();
+
+        $ref = new \ReflectionProperty($clock, 'now');
+        $ref->setAccessible(true);
+        $this->assertEquals($now, $ref->getValue($clock));
+
+        $this->assertNotNull($tick);
+        $tick();
+
+        $this->assertNull($ref->getValue($clock));
+    }
+}

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -10,7 +10,9 @@ class RequestHeaderParserTest extends TestCase
 {
     public function testSplitShouldHappenOnDoubleCrlf()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
 
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
@@ -29,7 +31,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testFeedInOneGo()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableOnce());
 
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
@@ -41,7 +45,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testFeedTwoRequestsOnSeparateConnections()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $called = 0;
         $parser->on('headers', function () use (&$called) {
@@ -65,7 +71,9 @@ class RequestHeaderParserTest extends TestCase
         $request = null;
         $conn = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest, $connection) use (&$request, &$conn) {
             $request = $parsedRequest;
             $conn = $connection;
@@ -88,7 +96,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testHeadersEventShouldEmitRequestWhichShouldEmitEndForStreamingBodyWithoutContentLengthFromInitialRequestBody()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $ended = false;
         $that = $this;
@@ -112,7 +122,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyDataFromInitialRequestBody()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -140,7 +152,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyWithPlentyOfDataFromInitialRequestBody()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -166,7 +180,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testHeadersEventShouldEmitRequestWhichShouldNotEmitStreamingBodyDataWithoutContentLengthFromInitialRequestBody()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -191,7 +207,9 @@ class RequestHeaderParserTest extends TestCase
 
     public function testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyDataUntilContentLengthBoundaryFromInitialRequestBody()
     {
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -218,7 +236,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -245,7 +265,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -264,7 +286,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -284,7 +308,9 @@ class RequestHeaderParserTest extends TestCase
         $error = null;
         $passedConnection = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message, $connection) use (&$error, &$passedConnection) {
             $error = $message;
@@ -306,7 +332,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -325,7 +353,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -344,7 +374,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -363,7 +395,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -382,7 +416,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -401,7 +437,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('error', $this->expectCallableNever());
         $parser->on('headers', function ($parsedRequest, $parsedBodyBuffer) use (&$request) {
             $request = $parsedRequest;
@@ -426,7 +464,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -445,7 +485,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -464,7 +506,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -483,7 +527,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -502,7 +548,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -521,7 +569,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -541,7 +591,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -561,7 +613,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -581,7 +635,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -601,7 +657,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $error = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -621,7 +679,10 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+        $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
+
+        $parser = new RequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -637,8 +698,8 @@ class RequestHeaderParserTest extends TestCase
         $serverParams = $request->getServerParams();
 
         $this->assertEquals('on', $serverParams['HTTPS']);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME']);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME_FLOAT']);
+        $this->assertEquals(1652972091, $serverParams['REQUEST_TIME']);
+        $this->assertEquals(1652972091.3958, $serverParams['REQUEST_TIME_FLOAT']);
 
         $this->assertEquals('127.1.1.1', $serverParams['SERVER_ADDR']);
         $this->assertEquals('8000', $serverParams['SERVER_PORT']);
@@ -651,7 +712,10 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+        $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
+
+        $parser = new RequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -667,8 +731,8 @@ class RequestHeaderParserTest extends TestCase
         $serverParams = $request->getServerParams();
 
         $this->assertArrayNotHasKey('HTTPS', $serverParams);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME']);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME_FLOAT']);
+        $this->assertEquals(1652972091, $serverParams['REQUEST_TIME']);
+        $this->assertEquals(1652972091.3958, $serverParams['REQUEST_TIME_FLOAT']);
 
         $this->assertEquals('127.1.1.1', $serverParams['SERVER_ADDR']);
         $this->assertEquals('8000', $serverParams['SERVER_PORT']);
@@ -681,7 +745,10 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+        $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
+
+        $parser = new RequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -697,8 +764,8 @@ class RequestHeaderParserTest extends TestCase
         $serverParams = $request->getServerParams();
 
         $this->assertArrayNotHasKey('HTTPS', $serverParams);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME']);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME_FLOAT']);
+        $this->assertEquals(1652972091, $serverParams['REQUEST_TIME']);
+        $this->assertEquals(1652972091.3958, $serverParams['REQUEST_TIME_FLOAT']);
 
         $this->assertArrayNotHasKey('SERVER_ADDR', $serverParams);
         $this->assertArrayNotHasKey('SERVER_PORT', $serverParams);
@@ -715,7 +782,10 @@ class RequestHeaderParserTest extends TestCase
 
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+        $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
+
+        $parser = new RequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -728,8 +798,8 @@ class RequestHeaderParserTest extends TestCase
 
         $serverParams = $request->getServerParams();
 
-        $this->assertNotEmpty($serverParams['REQUEST_TIME']);
-        $this->assertNotEmpty($serverParams['REQUEST_TIME_FLOAT']);
+        $this->assertEquals(1652972091, $serverParams['REQUEST_TIME']);
+        $this->assertEquals(1652972091.3958, $serverParams['REQUEST_TIME_FLOAT']);
 
         $this->assertArrayNotHasKey('SERVER_ADDR', $serverParams);
         $this->assertArrayNotHasKey('SERVER_PORT', $serverParams);
@@ -742,7 +812,9 @@ class RequestHeaderParserTest extends TestCase
     {
         $request = null;
 
-        $parser = new RequestHeaderParser();
+        $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
+
+        $parser = new RequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -2292,11 +2292,19 @@ class StreamingServerTest extends TestCase
         $this->assertContainsString("5\r\nhello\r\n", $buffer);
     }
 
-    public function testResponseWithoutExplicitDateHeaderWillAddCurrentDate()
+    public function testResponseWithoutExplicitDateHeaderWillAddCurrentDateFromClock()
     {
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response();
         });
+
+        $ref = new \ReflectionProperty($server, 'clock');
+        $ref->setAccessible(true);
+        $clock = $ref->getValue($server);
+
+        $ref = new \ReflectionProperty($clock, 'now');
+        $ref->setAccessible(true);
+        $ref->setValue($clock, 1652972091.3958);
 
         $buffer = '';
             $this->connection
@@ -2318,11 +2326,11 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', array($data));
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("Date:", $buffer);
+        $this->assertContainsString("Date: Thu, 19 May 2022 14:54:51 GMT\r\n", $buffer);
         $this->assertContainsString("\r\n\r\n", $buffer);
     }
 
-    public function testResponseWIthCustomDateHeaderOverwritesDefault()
+    public function testResponseWithCustomDateHeaderOverwritesDefault()
     {
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
@@ -3022,7 +3030,8 @@ class StreamingServerTest extends TestCase
         $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $requestValidation->getCookieParams());
     }
 
-    public function testRequestCookieWithCommaValueWillBeAddedToServerRequest() {
+    public function testRequestCookieWithCommaValueWillBeAddedToServerRequest()
+    {
         $requestValidation = null;
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
@@ -3045,7 +3054,7 @@ class StreamingServerTest extends TestCase
     {
         $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3062,7 +3071,7 @@ class StreamingServerTest extends TestCase
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3085,7 +3094,7 @@ class StreamingServerTest extends TestCase
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3110,7 +3119,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, array('Connection' => 'close'));
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3135,7 +3144,7 @@ class StreamingServerTest extends TestCase
             return new Response();
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3160,7 +3169,7 @@ class StreamingServerTest extends TestCase
             return new Response();
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3186,7 +3195,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, array(), $body);
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3212,7 +3221,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, array(), $body);
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->getMock();
+        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');


### PR DESCRIPTION
This PR improves the HTTP server performance by adding an internal `Clock` instance that reuses the system clock within the same loop tick. This helps avoiding unneeded `gettimeofday()` syscalls that show a noticeable performance impact especially during benchmark runs (see also #455).

The new internal `Clock` class is mostly used as an internal optimization to avoid unneeded syscalls to get the current system time multiple times within the same loop tick. For the purpose of the HTTP server, the clock is assumed to not change to a significant degree within the same loop tick. If you need a high precision clock source, you may want to use `\hrtime()` instead (PHP 7.3+).

The API is modelled to resemble the PSR-20 `ClockInterface` (in draft at the time of writing this), but uses a `float` return value for performance reasons instead.

For a single HTTP request, this means the following syscalls can be eliminated:

```diff
pselect6(5, [4], [], [], NULL, NULL)    = 1 (in [4])
poll([{fd=4, events=POLLIN|POLLERR|POLLHUP}], 1, 0) = 1 ([{fd=4, revents=POLLIN}])
accept(4, {sa_family=AF_INET6, sin6_port=htons(54462), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "::ffff:127.0.0.1", &sin6_addr), sin6_scope_id=0}, [128 => 28]) = 3
fcntl(3, F_GETFL)                       = 0x2 (flags O_RDWR)
fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
fcntl(3, F_GETFL)                       = 0x802 (flags O_RDWR|O_NONBLOCK)
fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
pselect6(5, [3 4], [], [], NULL, NULL)  = 1 (in [3])
poll([{fd=3, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 0) = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "G", 1, MSG_PEEK, NULL, NULL) = 1
recvfrom(3, "GET / HTTP/1.1\r\nHost: localhost:"..., 65536, 0, NULL, NULL) = 78
poll([{fd=3, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 0) = 0 (Timeout)
recvfrom(3, 0x7fceeb63d066, 65458, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
getpeername(3, {sa_family=AF_INET6, sin6_port=htons(54462), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "::ffff:127.0.0.1", &sin6_addr), sin6_scope_id=0}, [128 => 28]) = 0
getsockname(3, {sa_family=AF_INET6, sin6_port=htons(8080), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "::ffff:127.0.0.1", &sin6_addr), sin6_scope_id=0}, [128 => 28]) = 0
gettimeofday({tv_sec=1652528350, tv_usec=915571}, NULL) = 0
- gettimeofday({tv_sec=1652528350, tv_usec=915621}, NULL) = 0
- gettimeofday({tv_sec=1652528350, tv_usec=915765}, NULL) = 0
pselect6(5, [3 4], [3], [], NULL, NULL) = 1 (out [3])
sendto(3, "HTTP/1.1 200 OK\r\nContent-Type: t"..., 150, 0, NULL, 0) = 150
pselect6(5, [3 4], [], [], NULL, NULL)  = 1 (in [3])
poll([{fd=3, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 0) = 1 ([{fd=3, revents=POLLIN}])
recvfrom(3, "", 1, MSG_PEEK, NULL, NULL) = 0
recvfrom(3, "", 65536, 0, NULL, NULL)   = 0
shutdown(3, SHUT_RDWR)                  = 0
fcntl(3, F_GETFL)                       = 0x802 (flags O_RDWR|O_NONBLOCK)
fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
close(3)                                = 0

pselect6(5, [4], [], [], NULL, NULL)    = …
```

This is especially noticeable during a benchmark run. In particular, the HTTP server may handle multiple concurrent connections in a single loop tick, so even the first `gettimeofday()` call above will only be invoked once per tick. Running `docker run -it --rm --net=host jordi/ab -n1000000 -c50 -k http://localhost:8080/` against the example HTTP server suggests results improved from 19188 req/s to 20318 req/s on my machine (best of 5 each).

This changeset only refactors some internal logic and does not affect the public API, so it should be safe to apply. The test suite confirms this has 100% code coverage.

Refs #455 and https://github.com/reactphp/event-loop/pull/246