### PR TITLE
Refactor internal `Transaction` to avoid assigning dynamic properties (PHP 8.2+ compatibility)

### DIFF
--- a/src/Io/ClientRequestState.php
+++ b/src/Io/ClientRequestState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace React\Http\Io;
+
+/** @internal */
+class ClientRequestState
+{
+    /** @var int */
+    public $numRequests = 0;
+
+    /** @var ?\React\Promise\PromiseInterface */
+    public $pending = null;
+
+    /** @var ?\React\EventLoop\TimerInterface */
+    public $timeout = null;
+}

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -17,6 +17,9 @@ final class HttpServerTest extends TestCase
     private $connection;
     private $socket;
 
+    /** @var ?int */
+    private $called = null;
+
     /**
      * @before
      */

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -17,6 +17,9 @@ class StreamingServerTest extends TestCase
     private $connection;
     private $socket;
 
+    /** @var ?int */
+    private $called = null;
+
     /**
      * @before
      */


### PR DESCRIPTION
This changeset refactors the internal `Transaction` to avoid assigning dynamic properties for PHP 8.2+ compatibility. On top of this, it makes the test suite compatible as well. PHP 8.2 is still under active development and has not reached feature freeze yet, so I've decided against adding it to the test matrix at this point in time. After applying this changeset, the tests work just fine. Prior to this, the test output can easily be checked like this:

```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.2-rc-cli vendor/bin/phpunit
PHPUnit 9.5.21 #StandWithUkraine

.....................................................E.........  63 / 737 (  8%)
............................EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 126 / 737 ( 17%)
EEEEEEEEEEE..........................E......................... 189 / 737 ( 25%)
............................................................... 252 / 737 ( 34%)
............................................................... 315 / 737 ( 42%)
............................................................... 378 / 737 ( 51%)
............................................................... 441 / 737 ( 59%)
.................................................E............. 504 / 737 ( 68%)
............................................................... 567 / 737 ( 76%)
........................................EEEEEEEEEEEEEEEEEEEEEEE 630 / 737 ( 85%)
EEEEEEEEE...................................................... 693 / 737 ( 94%)
............................................                    737 / 737 (100%)

Time: 00:02.522, Memory: 20.00 MB

There were 81 errors:

1) React\Tests\Http\BrowserTest::testCancelGetRequestShouldCancelUnderlyingSocketConnection
Creation of dynamic property React\Promise\Deferred::$numRequests is deprecated

/data/src/Io/Transaction.php:77
/data/src/Browser.php:787
/data/src/Browser.php:113
/data/tests/BrowserTest.php:503


[…]

81) React\Tests\Http\Io\TransactionTest::testCancelTransactionShouldCancelSendingPromise
Creation of dynamic property React\Promise\Deferred::$numRequests is deprecated

/data/src/Io/Transaction.php:77
/data/tests/Io/TransactionTest.php:829

ERRORS!
Tests: 737, Assertions: 1617, Errors: 81.
```

Refs https://github.com/reactphp/dns/pull/186, https://github.com/reactphp/dns/pull/201 and https://github.com/reactphp/stream/pull/165