### PR TITLE
Forward compatibility with upcoming Promise v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -39,6 +41,7 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
+    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -41,7 +39,6 @@ jobs:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
     continue-on-error: true
-    if: false # temporarily skipped until https://github.com/azjezz/setup-hhvm/issues/3 is addressed
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         "fig/http-message-util": "^1.1",
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.3 || ^1.2.1",
-        "react/promise-stream": "^1.1",
-        "react/socket": "^1.9",
+        "react/promise": "^3@dev || ^2.3 || ^1.2.1",
+        "react/promise-stream": "^1.4",
+        "react/socket": "^1.12",
         "react/stream": "^1.2",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
-        "clue/http-proxy-react": "^1.7",
-        "clue/reactphp-ssh-proxy": "^1.3",
-        "clue/socks-react": "^1.3",
+        "clue/http-proxy-react": "dev-promise-v3 as 1.8.0",
+        "clue/reactphp-ssh-proxy": "dev-promise-v3 as 1.4.0",
+        "clue/socks-react": "dev-promise-v3 as 1.4.0",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/async": "^4 || ^3 || ^2",
         "react/promise-timer": "^1.9"
@@ -50,5 +50,19 @@
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Http\\": "tests" }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/reactphp-http-proxy"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/reactphp-socks"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/reactphp-ssh-proxy"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         "fig/http-message-util": "^1.1",
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^3@dev || ^2.3 || ^1.2.1",
+        "react/promise": "^3 || ^2.3 || ^1.2.1",
         "react/promise-stream": "^1.4",
         "react/socket": "^1.12",
         "react/stream": "^1.2",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
-        "clue/http-proxy-react": "dev-promise-v3 as 1.8.0",
-        "clue/reactphp-ssh-proxy": "dev-promise-v3 as 1.4.0",
-        "clue/socks-react": "dev-promise-v3 as 1.4.0",
+        "clue/http-proxy-react": "^1.8",
+        "clue/reactphp-ssh-proxy": "^1.4",
+        "clue/socks-react": "^1.4",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/async": "^4 || ^3 || ^2",
         "react/promise-timer": "^1.9"
@@ -50,19 +50,5 @@
     },
     "autoload-dev": {
         "psr-4": { "React\\Tests\\Http\\": "tests" }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/reactphp-http-proxy"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/reactphp-socks"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/reactphp-ssh-proxy"
-        }
-    ]
+    }
 }

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -9,7 +9,6 @@ use React\EventLoop\LoopInterface;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
 use React\Promise;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ServerInterface;
@@ -158,7 +157,7 @@ final class StreamingServer extends EventEmitter
         }
 
         // cancel pending promise once connection closes
-        if ($response instanceof CancellablePromiseInterface) {
+        if ($response instanceof PromiseInterface && \method_exists($response, 'cancel')) {
             $conn->on('close', function () use ($response) {
                 $response->cancel();
             });

--- a/src/Middleware/LimitConcurrentRequestsMiddleware.php
+++ b/src/Middleware/LimitConcurrentRequestsMiddleware.php
@@ -206,6 +206,6 @@ final class LimitConcurrentRequestsMiddleware
         $first = \reset($this->queue);
         unset($this->queue[key($this->queue)]);
 
-        $first->resolve();
+        $first->resolve(null);
     }
 }

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -726,6 +726,10 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testLimitConcurrentRequestsMiddlewareRequestStreamPausing()
     {
+        if (defined('HHVM_VERSION') && !interface_exists('React\Promise\PromisorInterface')) {
+            $this->markTestSkipped('Not supported on legacy HHVM with Promise v3');
+        }
+
         $connector = new Connector();
 
         $http = new HttpServer(

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Io\MiddlewareRunner;
 use React\Http\Message\ServerRequest;
 use React\Promise;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;
 use React\Tests\Http\Middleware\ProcessStack;
 use React\Tests\Http\TestCase;
@@ -479,7 +478,7 @@ final class MiddlewareRunnerTest extends TestCase
 
         $promise = $middleware($request);
 
-        $this->assertTrue($promise instanceof CancellablePromiseInterface);
+        $this->assertTrue($promise instanceof PromiseInterface && \method_exists($promise, 'cancel'));
         $promise->cancel();
     }
 }

--- a/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+++ b/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
@@ -79,7 +79,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         /**
          * Ensure resolve frees up a slot
          */
-        $deferredA->resolve();
+        $deferredA->resolve(null);
 
         $this->assertTrue($calledA);
         $this->assertTrue($calledB);
@@ -88,7 +88,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         /**
          * Ensure reject also frees up a slot
          */
-        $deferredB->reject();
+        $deferredB->reject(new \RuntimeException());
 
         $this->assertTrue($calledA);
         $this->assertTrue($calledB);
@@ -194,7 +194,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
 
         $limitHandlers(new ServerRequest('GET', 'https://example.com/', array(), $body), function () {});
 
-        $deferred->reject();
+        $deferred->reject(new \RuntimeException());
     }
 
     public function testReceivesBufferedRequestSameInstance()
@@ -452,7 +452,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
             $req = $request;
         });
 
-        $deferred->reject();
+        $deferred->reject(new \RuntimeException());
 
         $this->assertNotSame($request, $req);
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $req);


### PR DESCRIPTION
Builds on top of https://github.com/reactphp/promise/pull/75, https://github.com/reactphp/promise/pull/213, https://github.com/reactphp/promise/pull/138, https://github.com/reactphp/socket/pull/214 and https://github.com/reactphp/promise-stream/pull/20
Also builds on top of dev updates in https://github.com/clue/reactphp-block/pull/61, https://github.com/clue/reactphp-http-proxy/pull/44,  https://github.com/clue/reactphp-socks/pull/106 and https://github.com/clue/reactphp-ssh-proxy/pull/35