### PR TITLE
Support for default request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ multiple concurrent HTTP requests without blocking.
         * [withBase()](#withbase)
         * [withProtocolVersion()](#withprotocolversion)
         * [withResponseBuffer()](#withresponsebuffer)
+        * [withHeader()](#withheader)
+        * [withoutHeader()](#withoutheader)
     * [React\Http\Message](#reacthttpmessage)
         * [Response](#response)
             * [html()](#html)
@@ -2380,6 +2382,36 @@ this maximum buffer size setting has no effect on streaming responses.
 Notice that the [`Browser`](#browser) is an immutable object, i.e. this
 method actually returns a *new* [`Browser`](#browser) instance with the
 given setting applied.
+
+#### withHeader()
+
+The `withHeader(string $header, string $value): Browser` method can be used to
+add a request header for all following requests.
+
+```php
+$browser = $browser->withHeader('User-Agent', 'ACME');
+
+$browser->get($url)->then(…);
+```
+
+Note that the new header will overwrite any headers previously set with
+the same name (case-insensitive). Following requests will use these headers
+by default unless they are explicitly set for any requests.
+
+#### withoutHeader()
+
+The `withoutHeader(string $header): Browser` method can be used to
+remove any default request headers previously set via
+the [`withHeader()` method](#withheader).
+
+```php
+$browser = $browser->withoutHeader('User-Agent');
+
+$browser->get($url)->then(…);
+```
+
+Note that this method only affects the headers which were set with the
+method `withHeader(string $header, string $value): Browser`
 
 ### React\Http\Message
 

--- a/src/Client/RequestData.php
+++ b/src/Client/RequestData.php
@@ -29,7 +29,6 @@ class RequestData
         $defaults = array_merge(
             array(
                 'Host'          => $this->getHost().$port,
-                'User-Agent'    => 'ReactPHP/1',
             ),
             $connectionHeaders,
             $authHeaders

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -503,4 +503,101 @@ class BrowserTest extends TestCase
         $promise = $this->browser->get('http://example.com/');
         $promise->cancel();
     }
+
+    public function testWithHeaderShouldOverwriteExistingHeader()
+    {
+        $this->browser = $this->browser->withHeader('User-Agent', 'ACMC'); //should be overwritten
+        $this->browser = $this->browser->withHeader('user-agent', 'ABC'); //should be the user-agent
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array('ABC'), $request->getHeader('UsEr-AgEnT'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
+
+    public function testWithHeaderShouldBeOverwrittenByExplicitHeaderInGetMethod()
+    {
+        $this->browser = $this->browser->withHeader('User-Agent', 'ACMC');
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array('ABC'), $request->getHeader('UsEr-AgEnT'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/', array('user-Agent' => 'ABC')); //should win
+    }
+
+    public function testWithMultipleHeadersShouldBeMergedCorrectlyWithMultipleDefaultHeaders()
+    {
+        $this->browser = $this->browser->withHeader('User-Agent', 'ACMC');
+        $this->browser = $this->browser->withHeader('User-Test', 'Test');
+        $this->browser = $this->browser->withHeader('Custom-HEADER', 'custom');
+        $this->browser = $this->browser->withHeader('just-a-header', 'header-value');
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $expectedHeaders = array(
+                'Host' => array('example.com'),
+
+                'User-Test' => array('Test'),
+                'just-a-header' => array('header-value'),
+
+                'user-Agent' => array('ABC'),
+                'another-header' => array('value'),
+                'custom-header' => array('data'),
+            );
+
+            $that->assertEquals($expectedHeaders, $request->getHeaders());
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $headers = array(
+            'user-Agent' => 'ABC', //should overwrite: 'User-Agent', 'ACMC'
+            'another-header' => 'value',
+            'custom-header' => 'data', //should overwrite: 'Custom-header', 'custom'
+        );
+        $this->browser->get('http://example.com/', $headers);
+    }
+
+    public function testWithoutHeaderShouldRemoveExistingHeader()
+    {
+        $this->browser = $this->browser->withHeader('User-Agent', 'ACMC');
+        $this->browser = $this->browser->withoutHeader('UsEr-AgEnT'); //should remove case-insensitive header
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array(), $request->getHeader('user-agent'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
+
+    public function testBrowserShouldSendDefaultUserAgentHeader()
+    {
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array(0 => 'ReactPHP/1'), $request->getHeader('user-agent'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
+
+    public function testBrowserShouldNotSendDefaultUserAgentHeaderIfWithoutHeaderRemovesUserAgent()
+    {
+        $this->browser = $this->browser->withoutHeader('UsEr-AgEnT');
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array(), $request->getHeader('User-Agent'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
 }

--- a/tests/Client/RequestDataTest.php
+++ b/tests/Client/RequestDataTest.php
@@ -14,7 +14,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -27,7 +26,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET /path?hello=world HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -40,7 +38,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET /?0 HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -53,7 +50,6 @@ class RequestDataTest extends TestCase
 
         $expected = "OPTIONS / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -66,7 +62,6 @@ class RequestDataTest extends TestCase
 
         $expected = "OPTIONS * HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "\r\n";
 
         $this->assertSame($expected, $requestData->__toString());
@@ -80,7 +75,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -131,7 +125,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.1\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "Connection: close\r\n" .
             "\r\n";
 
@@ -145,7 +138,6 @@ class RequestDataTest extends TestCase
 
         $expected = "GET / HTTP/1.0\r\n" .
             "Host: www.example.com\r\n" .
-            "User-Agent: ReactPHP/1\r\n" .
             "Authorization: Basic am9objpkdW1teQ==\r\n" .
             "\r\n";
 

--- a/tests/Client/RequestTest.php
+++ b/tests/Client/RequestTest.php
@@ -181,7 +181,7 @@ class RequestTest extends TestCase
         $this->stream
             ->expects($this->once())
             ->method('write')
-            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome post data$#"));
+            ->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome post data$#"));
 
         $request->end('some post data');
 
@@ -199,7 +199,7 @@ class RequestTest extends TestCase
         $this->successfulConnectionMock();
 
         $this->stream->expects($this->exactly(3))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#")),
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")),
             array($this->identicalTo("post")),
             array($this->identicalTo("data"))
         );
@@ -222,7 +222,7 @@ class RequestTest extends TestCase
         $resolveConnection = $this->successfulAsyncConnectionMock();
 
         $this->stream->expects($this->exactly(2))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#")),
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")),
             array($this->identicalTo("data"))
         )->willReturn(
             true
@@ -258,7 +258,7 @@ class RequestTest extends TestCase
         $resolveConnection = $this->successfulAsyncConnectionMock();
 
         $this->stream->expects($this->exactly(2))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsomepost$#")),
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")),
             array($this->identicalTo("data"))
         )->willReturn(
             false
@@ -290,7 +290,7 @@ class RequestTest extends TestCase
         $this->successfulConnectionMock();
 
         $this->stream->expects($this->exactly(3))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\nUser-Agent:.*\r\n\r\nsome$#")),
+            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")),
             array($this->identicalTo("post")),
             array($this->identicalTo("data"))
         );


### PR DESCRIPTION
closes issue: #449 
new methods for the class Browser (withHeader and withoutHeader)

With this methods you are able to set/remove default headers