### PR TITLE
Move cookie parsing into dedicated class

### DIFF
--- a/src/Io/CookieParser.php
+++ b/src/Io/CookieParser.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace React\Http\Io;
+
+/**
+ * @internal
+ */
+final class CookieParser
+{
+    /**
+     * @param string $cookie
+     * @return array
+     */
+    public static function parse($cookie)
+    {
+        $cookieArray = \explode(';', $cookie);
+        $result = array();
+
+        foreach ($cookieArray as $pair) {
+            $pair = \trim($pair);
+            $nameValuePair = \explode('=', $pair, 2);
+
+            if (\count($nameValuePair) === 2) {
+                $key = \urldecode($nameValuePair[0]);
+                $value = \urldecode($nameValuePair[1]);
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Message/ServerRequest.php
+++ b/src/Message/ServerRequest.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use React\Http\Io\BufferedBody;
+use React\Http\Io\CookieParser;
 use React\Http\Io\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
 use RingCentral\Psr7\Request;
@@ -88,7 +89,7 @@ final class ServerRequest extends Request implements ServerRequestInterface
         $cookieHeaders = $this->getHeader("Cookie");
 
         if (count($cookieHeaders) === 1) {
-            $this->cookies = $this->parseCookie($cookieHeaders[0]);
+            $this->cookies = CookieParser::parse($cookieHeaders[0]);
         }
     }
 
@@ -170,28 +171,5 @@ final class ServerRequest extends Request implements ServerRequestInterface
         $new = clone $this;
         unset($new->attributes[$name]);
         return $new;
-    }
-
-    /**
-     * @param string $cookie
-     * @return array
-     */
-    private function parseCookie($cookie)
-    {
-        $cookieArray = \explode(';', $cookie);
-        $result = array();
-
-        foreach ($cookieArray as $pair) {
-            $pair = \trim($pair);
-            $nameValuePair = \explode('=', $pair, 2);
-
-            if (\count($nameValuePair) === 2) {
-                $key = \urldecode($nameValuePair[0]);
-                $value = \urldecode($nameValuePair[1]);
-                $result[$key] = $value;
-            }
-        }
-
-        return $result;
     }
 }

--- a/tests/Io/CookieParserTest.php
+++ b/tests/Io/CookieParserTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use PHPUnit\Framework\TestCase;
+use React\Http\Io\Clock;
+use React\Http\Io\CookieParser;
+use React\Http\Message\ServerRequest;
+
+class CookieParserTest extends TestCase
+{
+    public function testParseSingleCookieNameValuePairWillReturnValidArray()
+    {
+        $this->assertEquals(array('hello' => 'world'), CookieParser::parse('hello=world'));
+    }
+
+    public function testParseMultipleCookieNameValuePairWillReturnValidArray()
+    {
+        $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), CookieParser::parse('hello=world; test=abc'));
+    }
+
+    public function testMultipleCookiesWithSameNameWillReturnLastValue()
+    {
+        $this->assertEquals(array('hello' => 'abc'), CookieParser::parse('hello=world; hello=abc'));
+    }
+
+    public function testOtherEqualSignsWillBeAddedToValueAndWillReturnValidArray()
+    {
+        $this->assertEquals(array('hello' => 'world=test=php'), CookieParser::parse('hello=world=test=php'));
+    }
+
+    public function testSingleCookieValueInCookiesReturnsEmptyArray()
+    {
+        $this->assertEquals(array(), CookieParser::parse('world'));
+    }
+
+    public function testSingleMutlipleCookieValuesReturnsEmptyArray()
+    {
+        $this->assertEquals(array(), CookieParser::parse('world; test'));
+    }
+
+    public function testSingleValueIsValidInMultipleValueCookieWillReturnValidArray()
+    {
+        $this->assertEquals(array('test' => 'php'), CookieParser::parse('world; test=php'));
+    }
+
+    public function testUrlEncodingForValueWillReturnValidArray()
+    {
+        $this->assertEquals(array('hello' => 'world!', 'test' => '100% coverage'), CookieParser::parse('hello=world%21; test=100%25%20coverage'));
+    }
+
+}

--- a/tests/Message/ServerRequestTest.php
+++ b/tests/Message/ServerRequestTest.php
@@ -134,30 +134,6 @@ class ServerRequestTest extends TestCase
         $this->assertEquals('127.0.0.1', $serverParams['SERVER_ADDR']);
     }
 
-    public function testParseSingleCookieNameValuePairWillReturnValidArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'hello=world')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world'), $cookies);
-    }
-
-    public function testParseMultipleCookieNameValuePairWillReturnValidArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'hello=world; test=abc')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $cookies);
-    }
-
     public function testParseMultipleCookieHeadersAreNotAllowedAndWillReturnEmptyArray()
     {
         $this->request = new ServerRequest(
@@ -168,78 +144,6 @@ class ServerRequestTest extends TestCase
 
         $cookies = $this->request->getCookieParams();
         $this->assertEquals(array(), $cookies);
-    }
-
-    public function testMultipleCookiesWithSameNameWillReturnLastValue()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'hello=world; hello=abc')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'abc'), $cookies);
-    }
-
-    public function testOtherEqualSignsWillBeAddedToValueAndWillReturnValidArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'hello=world=test=php')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world=test=php'), $cookies);
-    }
-
-    public function testSingleCookieValueInCookiesReturnsEmptyArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'world')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array(), $cookies);
-    }
-
-    public function testSingleMutlipleCookieValuesReturnsEmptyArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'world; test')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array(), $cookies);
-    }
-
-    public function testSingleValueIsValidInMultipleValueCookieWillReturnValidArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'world; test=php')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('test' => 'php'), $cookies);
-    }
-
-    public function testUrlEncodingForValueWillReturnValidArray()
-    {
-        $this->request = new ServerRequest(
-            'GET',
-            'http://localhost',
-            array('Cookie' => 'hello=world%21; test=100%25%20coverage')
-        );
-
-        $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world!', 'test' => '100% coverage'), $cookies);
     }
 
     public function testUrlEncodingForKeyWillReturnValidArray()


### PR DESCRIPTION
By moving this code into a dedicated class we prepare for future changes required by RFC's, and don't grow the `ServerRequest` class beyond what it purpose it.