### PR TITLE
Testsuite improvements

### DIFF
--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -865,7 +865,7 @@ class RequestHeaderParserTest extends TestCase
         $this->assertEquals(array(), $ref->getValue($parser));
     }
 
-    public function testQueryParmetersWillBeSet()
+    public function testQueryParametersWillBeSet()
     {
         $request = null;
 

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Io\Clock;
 use React\Http\Io\RequestHeaderParser;
 use React\Tests\Http\TestCase;
 
@@ -12,7 +13,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
 
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
@@ -33,7 +34,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableOnce());
 
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
@@ -47,7 +48,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $called = 0;
         $parser->on('headers', function () use (&$called) {
@@ -73,7 +74,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest, $connection) use (&$request, &$conn) {
             $request = $parsedRequest;
             $conn = $connection;
@@ -98,7 +99,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $ended = false;
         $that = $this;
@@ -124,7 +125,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -154,7 +155,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -182,7 +183,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -209,7 +210,7 @@ class RequestHeaderParserTest extends TestCase
     {
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $buffer = '';
         $that = $this;
@@ -238,7 +239,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -267,7 +268,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -288,7 +289,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
         });
@@ -310,7 +311,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message, $connection) use (&$error, &$passedConnection) {
             $error = $message;
@@ -334,7 +335,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -355,7 +356,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -376,7 +377,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -397,7 +398,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -418,7 +419,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -439,7 +440,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('error', $this->expectCallableNever());
         $parser->on('headers', function ($parsedRequest, $parsedBodyBuffer) use (&$request) {
             $request = $parsedRequest;
@@ -466,7 +467,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -487,7 +488,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -508,7 +509,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -529,7 +530,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -550,7 +551,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -571,7 +572,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -593,7 +594,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -615,7 +616,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -637,7 +638,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -659,7 +660,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
         $parser->on('headers', $this->expectCallableNever());
         $parser->on('error', function ($message) use (&$error) {
             $error = $message;
@@ -682,7 +683,7 @@ class RequestHeaderParserTest extends TestCase
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
         $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -715,7 +716,7 @@ class RequestHeaderParserTest extends TestCase
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
         $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -748,7 +749,7 @@ class RequestHeaderParserTest extends TestCase
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
         $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -785,7 +786,7 @@ class RequestHeaderParserTest extends TestCase
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
         $clock->expects($this->once())->method('now')->willReturn(1652972091.3958);
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -870,7 +871,7 @@ class RequestHeaderParserTest extends TestCase
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();
 
-        $parser = new RequestHeaderParser($clock);
+        $parser = $this->createRequestHeaderParser($clock);
 
         $parser->on('headers', function ($parsedRequest) use (&$request) {
             $request = $parsedRequest;
@@ -906,5 +907,10 @@ class RequestHeaderParserTest extends TestCase
         $data .= "\r\n";
 
         return $data;
+    }
+
+    private function createRequestHeaderParser(Clock $clock)
+    {
+        return new RequestHeaderParser($clock);
     }
 }

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -51,7 +51,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventWillNotBeEmittedForIncompleteHeaders()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -63,7 +63,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestEventIsEmitted()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnce());
+        $server = $this->createStreamingServer($this->expectCallableOnce());
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -78,7 +78,7 @@ class StreamingServerTest extends TestCase
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
-        $server = new StreamingServer(Loop::get(), array($this, 'helperCallableOnce'));
+        $server = $this->createStreamingServer(array($this, 'helperCallableOnce'));
 
         $server->listen($this->socket);
         $this->socket->emit('connection', array($this->connection));
@@ -98,7 +98,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -131,7 +131,7 @@ class StreamingServerTest extends TestCase
     {
         $i = 0;
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$i, &$requestAssertion) {
             $i++;
             $requestAssertion = $request;
         });
@@ -163,7 +163,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndCustomPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -185,7 +185,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndHttpsPort()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -207,7 +207,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetWithHostAndDefaultPortWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -229,7 +229,7 @@ class StreamingServerTest extends TestCase
     public function testRequestGetHttp10WithoutHostWillBeIgnored()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -251,7 +251,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestGetHttp11WithoutHostWillReject()
     {
-        $server = new StreamingServer(Loop::get(), 'var_dump');
+        $server = $this->createStreamingServer('var_dump');
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -264,7 +264,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOptionsAsterisk()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -284,7 +284,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonOptionsWithAsteriskRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -297,7 +297,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityForm()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -319,7 +319,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectWithoutHostWillBePassesAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -341,7 +341,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormWithDefaultPortWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -363,7 +363,7 @@ class StreamingServerTest extends TestCase
     public function testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs()
     {
         $requestAssertion = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -384,7 +384,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestConnectOriginFormRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -396,7 +396,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -410,7 +410,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -436,7 +436,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -458,7 +458,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -478,7 +478,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestAbsoluteWithoutHostWillReject()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
@@ -492,7 +492,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -514,7 +514,7 @@ class StreamingServerTest extends TestCase
     {
         $requestAssertion = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestAssertion) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestAssertion) {
             $requestAssertion = $request;
         });
 
@@ -534,7 +534,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->pause();
         });
 
@@ -554,7 +554,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeWillBeForwardedToConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->resume();
         });
 
@@ -574,7 +574,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestCloseWillNotCloseConnection()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
         });
 
@@ -589,7 +589,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->pause();
         });
@@ -606,7 +606,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             $request->getBody()->close();
             $request->getBody()->resume();
         });
@@ -625,7 +625,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($never) {
             $request->getBody()->on('data', $never);
         });
 
@@ -640,7 +640,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -660,7 +660,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnceWith('incomplete');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             $request->getBody()->on('data', $once);
         });
 
@@ -681,7 +681,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsServerHeader()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -711,7 +711,7 @@ class StreamingServerTest extends TestCase
     {
         $never = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($never) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($never) {
             return new Promise(function () { }, $never);
         });
 
@@ -741,7 +741,7 @@ class StreamingServerTest extends TestCase
     {
         $once = $this->expectCallableOnce();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($once) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($once) {
             return new Promise(function () { }, $once);
         });
 
@@ -773,7 +773,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -808,7 +808,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -846,7 +846,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->close();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -882,7 +882,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -937,7 +937,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -955,7 +955,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -991,7 +991,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -1026,7 +1026,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 101,
                 array(
@@ -1066,7 +1066,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
                 array(
@@ -1107,7 +1107,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1145,7 +1145,7 @@ class StreamingServerTest extends TestCase
     {
         $stream = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -1164,7 +1164,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1197,7 +1197,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1231,7 +1231,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(),
@@ -1267,7 +1267,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array('Content-Length' => '3'),
@@ -1299,7 +1299,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 204,
                 array(),
@@ -1335,7 +1335,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 204,
                 array('Content-Length' => '3'),
@@ -1367,7 +1367,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1399,7 +1399,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsExplicitContentLengthHeaderForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array('Content-Length' => 3),
@@ -1431,7 +1431,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsExplicitContentLengthHeaderForHeadRequests()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Content-Length' => 3),
@@ -1463,7 +1463,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 304,
                 array(),
@@ -1499,7 +1499,7 @@ class StreamingServerTest extends TestCase
         $stream = new ThroughStream();
         $stream->on('close', $this->expectCallableOnce());
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 304,
                 array('Content-Length' => '3'),
@@ -1532,7 +1532,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1566,7 +1566,7 @@ class StreamingServerTest extends TestCase
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1600,7 +1600,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
         $server->on('error', function ($message) use (&$error) {
             $error = $message;
         });
@@ -1637,7 +1637,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1665,7 +1665,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1696,7 +1696,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1725,7 +1725,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1753,7 +1753,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
         $requestValidation = null;
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent, &$requestValidation) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1783,7 +1783,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1810,7 +1810,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1841,7 +1841,7 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableNever();
 
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1873,7 +1873,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1899,7 +1899,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1926,7 +1926,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -1952,7 +1952,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return \React\Promise\resolve(new Response());
         });
@@ -1977,7 +1977,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -1999,7 +1999,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2022,7 +2022,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2044,7 +2044,7 @@ class StreamingServerTest extends TestCase
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
-        $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
 
@@ -2071,7 +2071,7 @@ class StreamingServerTest extends TestCase
         $endEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
+        $server = $this->createStreamingServer(function ($request) use ($dataEvent, $closeEvent, $endEvent, $errorEvent){
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('end', $endEvent);
@@ -2095,7 +2095,7 @@ class StreamingServerTest extends TestCase
         $closeEvent = $this->expectCallableOnce();
         $errorEvent = $this->expectCallableNever();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($dataEvent, $endEvent, $closeEvent, $errorEvent) {
             $request->getBody()->on('data', $dataEvent);
             $request->getBody()->on('end', $endEvent);
             $request->getBody()->on('close', $closeEvent);
@@ -2114,7 +2114,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(),
@@ -2148,7 +2148,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2189,7 +2189,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2226,7 +2226,7 @@ class StreamingServerTest extends TestCase
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
                 array(),
@@ -2260,7 +2260,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
     {
         $stream = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
                 array(
@@ -2297,7 +2297,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDateFromClock()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2335,7 +2335,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithCustomDateHeaderOverwritesDefault()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
@@ -2368,7 +2368,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Date' => '')
@@ -2401,7 +2401,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseCanContainMultipleCookieHeaders()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array(
@@ -2439,7 +2439,7 @@ class StreamingServerTest extends TestCase
 
     public function testReponseWithExpectContinueRequestContainsContinueWithLaterResponse()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2471,7 +2471,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2502,14 +2502,14 @@ class StreamingServerTest extends TestCase
     public function testInvalidCallbackFunctionLeadsToException()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $server = new StreamingServer(Loop::get(), 'invalid');
+        $server = $this->createStreamingServer('invalid');
     }
 
     public function testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding()
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array(),
@@ -2548,7 +2548,7 @@ class StreamingServerTest extends TestCase
     {
         $input = new ThroughStream();
 
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
                 array('Content-Length' => 5),
@@ -2586,7 +2586,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithResponsePromise()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve(new Response());
         });
 
@@ -2614,7 +2614,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseReturnInvalidTypeWillResultInError()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return "invalid";
         });
 
@@ -2648,7 +2648,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return \React\Promise\resolve("invalid");
         });
 
@@ -2676,7 +2676,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject(new \Exception());
             });
@@ -2707,7 +2707,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 throw new \Exception('Bad call');
             });
@@ -2738,7 +2738,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response(
                 200,
                 array('Transfer-Encoding' => 'chunked'),
@@ -2774,7 +2774,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseWillBeHandled()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Response();
         });
 
@@ -2802,7 +2802,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             throw new \Exception('hello');
         });
 
@@ -2840,7 +2840,7 @@ class StreamingServerTest extends TestCase
      */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             throw new \Error('hello');
         });
 
@@ -2883,7 +2883,7 @@ class StreamingServerTest extends TestCase
 
     public function testResponseRejectOfNonExceptionWillResultInErrorMessage()
     {
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) {
             return new Promise(function ($resolve, $reject) {
                 $reject('Invalid type');
             });
@@ -2920,7 +2920,7 @@ class StreamingServerTest extends TestCase
     public function testRequestServerRequestParams()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2954,7 +2954,7 @@ class StreamingServerTest extends TestCase
     public function testRequestQueryParametersWillBeAddedToRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2974,7 +2974,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -2995,7 +2995,7 @@ class StreamingServerTest extends TestCase
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3016,7 +3016,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3036,7 +3036,7 @@ class StreamingServerTest extends TestCase
     public function testRequestCookieWithCommaValueWillBeAddedToServerRequest()
     {
         $requestValidation = null;
-        $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use (&$requestValidation) {
+        $server = $this->createStreamingServer(function (ServerRequestInterface $request) use (&$requestValidation) {
             $requestValidation = $request;
         });
 
@@ -3055,7 +3055,7 @@ class StreamingServerTest extends TestCase
 
     public function testNewConnectionWillInvokeParserOnce()
     {
-        $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
+        $server = $this->createStreamingServer($this->expectCallableNever());
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3072,7 +3072,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array(), '', '1.0');
 
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
+        $server = $this->createStreamingServer($this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3095,7 +3095,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'close'));
 
-        $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
+        $server = $this->createStreamingServer($this->expectCallableOnceWith($request));
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
         $parser->expects($this->once())->method('handle');
@@ -3118,7 +3118,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response(200, array('Connection' => 'close'));
         });
 
@@ -3143,7 +3143,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response();
         });
 
@@ -3168,7 +3168,7 @@ class StreamingServerTest extends TestCase
     {
         $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'keep-alive'), '', '1.0');
 
-        $server = new StreamingServer(Loop::get(), function () {
+        $server = $this->createStreamingServer(function () {
             return new Response();
         });
 
@@ -3194,7 +3194,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function () use ($body) {
+        $server = $this->createStreamingServer(function () use ($body) {
             return new Response(200, array(), $body);
         });
 
@@ -3220,7 +3220,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $body = new ThroughStream();
-        $server = new StreamingServer(Loop::get(), function () use ($body) {
+        $server = $this->createStreamingServer(function () use ($body) {
             return new Response(200, array(), $body);
         });
 
@@ -3253,5 +3253,10 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
 
         return $data;
+    }
+
+    private function createStreamingServer($requestHandler)
+    {
+        return new StreamingServer(Loop::get(), $requestHandler);
     }
 }


### PR DESCRIPTION
The changes introduced in this PR simplify the tested classes' creation. This will pave the path for a significantly small change set for #425 and upcoming PR's that will add full HTTP 1.1, and 2 in the future that deal with connection reuse. And as such are bound to introduce changes to the affected internal classes.

On it's own these changes might not look like they bring something new to the project, but they are aimed at our developer experience.