### PR TITLE
Set up PHPStan on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,23 @@ jobs:
       - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit
+
+  PHPStan:
+    name: PHPStan
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php: [ 8.1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: phpstan
+      - name: Install Composer dependencies
+        run: composer install
+      - name: Run static analysis
+        run: phpstan analyse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
   PHPStan:
     name: PHPStan
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     strategy:
       matrix:
         php: [ 8.1 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
   PHPStan:
     name: PHPStan
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ 8.1 ]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6041 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\>\\:\\:cancel\\(\\)\\.$#"
+			count: 1
+			path: examples/03-client-request-any.php
+
+		-
+			message: "#^Parameter \\#3 \\$body of method React\\\\Http\\\\Browser\\:\\:post\\(\\) expects React\\\\Stream\\\\ReadableStreamInterface\\|string, string\\|false given\\.$#"
+			count: 1
+			path: examples/04-client-post-json.php
+
+		-
+			message: "#^Parameter \\#3 \\$body of method React\\\\Http\\\\Browser\\:\\:put\\(\\) expects React\\\\Stream\\\\ReadableStreamInterface\\|string, string\\|false given\\.$#"
+			count: 1
+			path: examples/05-client-put-xml.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/51-server-hello-world.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/52-server-count-visitors.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/53-server-whatsmyip.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/54-server-query-parameter.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/55-server-cookie-handling.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/56-server-sleep.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/57-server-error-handling.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/58-server-stream-response.php
+
+		-
+			message: "#^Cannot access property \\$name on mixed\\.$#"
+			count: 1
+			path: examples/59-server-json-api.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/59-server-json-api.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/61-server-hello-world-https.php
+
+		-
+			message: "#^Cannot access offset 'age' on array\\|object\\.$#"
+			count: 1
+			path: examples/62-server-form-upload.php
+
+		-
+			message: "#^Cannot access offset 'name' on array\\|object\\.$#"
+			count: 1
+			path: examples/62-server-form-upload.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/62-server-form-upload.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/63-server-streaming-request.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/71-server-http-proxy.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/72-server-http-connect-proxy.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/81-server-upgrade-echo.php
+
+		-
+			message: "#^Parameter \\#1 \\$readable of class React\\\\Stream\\\\CompositeStream constructor expects React\\\\Stream\\\\ReadableStreamInterface, React\\\\Stream\\\\WritableStreamInterface given\\.$#"
+			count: 1
+			path: examples/82-server-upgrade-chat.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/82-server-upgrade-chat.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:__construct\\(\\) has parameter \\$chunk with no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:__construct\\(\\) has parameter \\$count with no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:getPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function rtrim expects string, string\\|null given\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$chunk has no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$count has no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$paused has no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$position has no type specified\\.$#"
+			count: 1
+			path: examples/92-client-benchmark-upload.php
+
+		-
+			message: "#^Call to an undefined method ChunkRepeater\\:\\:getSize\\(\\)\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:__construct\\(\\) has parameter \\$chunk with no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:__construct\\(\\) has parameter \\$count with no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:getSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method ChunkRepeater\\:\\:pipe\\(\\) should return React\\\\Stream\\\\WritableStreamInterface but empty return statement found\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$chunk has no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$count has no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$paused has no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Property ChunkRepeater\\:\\:\\$position has no type specified\\.$#"
+			count: 1
+			path: examples/99-server-benchmark-download.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:delete\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:delete\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:get\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:get\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:head\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:head\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:patch\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:patch\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:post\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:post\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:put\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:put\\(\\) should return React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but returns React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\>\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:request\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:requestMayBeStreaming\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:requestStreaming\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Browser\\:\\:withOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^PHPDoc tag @return contains generic type React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface, Exception\\> but interface React\\\\Promise\\\\PromiseInterface is not generic\\.$#"
+			count: 3
+			path: src/Browser.php
+
+		-
+			message: "#^PHPDoc tag @return contains generic type React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but interface React\\\\Promise\\\\PromiseInterface is not generic\\.$#"
+			count: 6
+			path: src/Browser.php
+
+		-
+			message: "#^Parameter \\#1 \\$string1 of function strcasecmp expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Browser\\:\\:\\$baseUrl has no type specified\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Browser\\:\\:\\$defaultHeaders has no type specified\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Browser\\:\\:\\$protocolVersion has no type specified\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Browser\\:\\:\\$transaction has no type specified\\.$#"
+			count: 1
+			path: src/Browser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Client\\:\\:request\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Client\\:\\:request\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Client\\:\\:request\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Client\\:\\:request\\(\\) has parameter \\$protocolVersion with no type specified\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Client\\:\\:request\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Client\\:\\:\\$connector has no type specified\\.$#"
+			count: 1
+			path: src/Client/Client.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:closeError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:connect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleDrain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\Request\\:\\:writeHead\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$buffer has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$connector has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$ended has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$pendingWrites has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$requestData has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$responseFactory has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$responseFactory is unused\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$state has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\Request\\:\\:\\$stream has no type specified\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Variable \\$bodyChunk might not be defined\\.$#"
+			count: 1
+			path: src/Client/Request.php
+
+		-
+			message: "#^Cannot access offset 'user' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:__construct\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:__construct\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:__construct\\(\\) has parameter \\$protocolVersion with no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:__construct\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getAuthHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getDefaultPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getHost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getScheme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:getUrlUserPass\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:mergeDefaultheaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:mergeDefaultheaders\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:setProtocolVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Client\\\\RequestData\\:\\:setProtocolVersion\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\RequestData\\:\\:\\$headers has no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\RequestData\\:\\:\\$method has no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\RequestData\\:\\:\\$protocolVersion has no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Client\\\\RequestData\\:\\:\\$url has no type specified\\.$#"
+			count: 1
+			path: src/Client/RequestData.php
+
+		-
+			message: "#^Method React\\\\Http\\\\HttpServer\\:\\:listen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/HttpServer.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$requestHandler$#"
+			count: 1
+			path: src/HttpServer.php
+
+		-
+			message: "#^Parameter \\#1 \\$memory_limit of method React\\\\Http\\\\HttpServer\\:\\:getConcurrentRequestsLimit\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/HttpServer.php
+
+		-
+			message: "#^Parameter \\#1 \\$size of static method React\\\\Http\\\\Io\\\\IniUtil\\:\\:iniSizeToBytes\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/HttpServer.php
+
+		-
+			message: "#^Parameter \\#2 \\$post_max_size of method React\\\\Http\\\\HttpServer\\:\\:getConcurrentRequestsLimit\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: src/HttpServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\BufferedBody\\:\\:rewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/BufferedBody.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\BufferedBody\\:\\:seek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/BufferedBody.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\BufferedBody\\:\\:\\$buffer has no type specified\\.$#"
+			count: 1
+			path: src/Io/BufferedBody.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\BufferedBody\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/BufferedBody.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\BufferedBody\\:\\:\\$position has no type specified\\.$#"
+			count: 1
+			path: src/Io/BufferedBody.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\<1, max\\>\\|false given\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$buffer has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$chunkSize has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$headerCompleted has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedDecoder\\:\\:\\$transferredSize has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedDecoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ChunkedEncoder\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/ChunkedEncoder.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\CloseProtectionStream\\:\\:\\$paused has no type specified\\.$#"
+			count: 1
+			path: src/Io/CloseProtectionStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\EmptyBodyStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/EmptyBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\EmptyBodyStream\\:\\:rewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/EmptyBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\EmptyBodyStream\\:\\:seek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/EmptyBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\EmptyBodyStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/EmptyBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:rewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:seek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\HttpBodyStream\\:\\:\\$size has no type specified\\.$#"
+			count: 1
+			path: src/Io/HttpBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\IniUtil\\:\\:iniSizeToBytes\\(\\) should return int but returns float\\|int\\.$#"
+			count: 4
+			path: src/Io/IniUtil.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:__construct\\(\\) has parameter \\$maxLength with no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:\\$maxLength has no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:\\$stream has no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\LengthLimitedStream\\:\\:\\$transferredLength has no type specified\\.$#"
+			count: 1
+			path: src/Io/LengthLimitedStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MiddlewareRunner\\:\\:call\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MiddlewareRunner.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MiddlewareRunner\\:\\:call\\(\\) has parameter \\$position with no type specified\\.$#"
+			count: 1
+			path: src/Io/MiddlewareRunner.php
+
+		-
+			message: "#^PHPDoc tag @return contains generic type React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> but interface React\\\\Promise\\\\PromiseInterface is not generic\\.$#"
+			count: 1
+			path: src/Io/MiddlewareRunner.php
+
+		-
+			message: "#^Cannot call method getParsedBody\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Cannot call method getUploadedFiles\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Cannot call method withParsedBody\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Cannot call method withUploadedFiles\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:extractPost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:extractPost\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:extractPost\\(\\) has parameter \\$postFields with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:extractPost\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:getParameterFromHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:getParameterFromHeader\\(\\) has parameter \\$header with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:getParameterFromHeader\\(\\) has parameter \\$parameter with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseBody\\(\\) has parameter \\$boundary with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseBody\\(\\) has parameter \\$buffer with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseFile\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseFile\\(\\) has parameter \\$contents with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseFile\\(\\) has parameter \\$filename with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseFile\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseHeaders\\(\\) has parameter \\$header with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parsePart\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parsePart\\(\\) has parameter \\$chunk with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parsePost\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parsePost\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parsePost\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseUploadedFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseUploadedFile\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseUploadedFile\\(\\) has parameter \\$contents with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\MultipartParser\\:\\:parseUploadedFile\\(\\) has parameter \\$filename with no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Parameter \\#1 \\$size of static method React\\\\Http\\\\Io\\\\IniUtil\\:\\:iniSizeToBytes\\(\\) expects string, int\\|string\\|false given\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\MultipartParser\\:\\:\\$emptyCount has no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\MultipartParser\\:\\:\\$filesCount has no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\MultipartParser\\:\\:\\$postCount has no type specified\\.$#"
+			count: 1
+			path: src/Io/MultipartParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:handleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:handleData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:handleData\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:handleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:pauseImplicit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:resume\\(\\) with return type void returns void but should not return anything\\.$#"
+			count: 3
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:resumeImplicit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$closePaused has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$dataPaused has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$endPaused has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$errorPaused has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$implicit has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:\\$paused has no type specified\\.$#"
+			count: 1
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Result of method React\\\\Http\\\\Io\\\\PauseBufferStream\\:\\:close\\(\\) \\(void\\) is used\\.$#"
+			count: 3
+			path: src/Io/PauseBufferStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:__construct\\(\\) has parameter \\$size with no type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:handleEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:pipe\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:rewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:seek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:\\$closed has no type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:\\$position has no type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\ReadableBodyStream\\:\\:\\$size has no type specified\\.$#"
+			count: 1
+			path: src/Io/ReadableBodyStream.php
+
+		-
+			message: "#^Cannot access offset 'host' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 3
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Cannot access offset 'host' on array\\{\\}\\|array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Cannot access offset 'port' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 2
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Cannot access offset 'port' on array\\{\\}\\|array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Cannot access offset 'scheme' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 2
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Cannot access offset 'scheme' on array\\{\\}\\|array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\RequestHeaderParser\\:\\:handle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 2
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$listener of method Evenement\\\\EventEmitterInterface\\:\\:removeListener\\(\\) expects callable\\(\\)\\: mixed, \\(Closure\\(mixed\\)\\: void\\)\\|null given\\.$#"
+			count: 2
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Parameter \\#3 \\$headers of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects array\\<string, array\\<string\\>\\|string\\>, array\\<int\\|string, array\\<int, mixed\\>\\> given\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Parameter \\#6 \\$serverParams of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects array\\<string, string\\>, array\\<string, float\\|int\\|string\\> given\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\RequestHeaderParser\\:\\:\\$connectionParams \\(array\\<int\\|string, array\\<string, string\\>\\>\\) does not accept array\\<int\\|string, array\\<string, int\\|string\\>\\>\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\RequestHeaderParser\\:\\:\\$maxSize has no type specified\\.$#"
+			count: 1
+			path: src/Io/RequestHeaderParser.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Sender\\:\\:\\$http has no type specified\\.$#"
+			count: 1
+			path: src/Io/Sender.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:on\\(\\)\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Instanceof between mixed and Exception will always evaluate to false\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\StreamingServer\\:\\:handleRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\StreamingServer\\:\\:handleResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\StreamingServer\\:\\:listen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\StreamingServer\\:\\:writeError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\StreamingServer\\:\\:writeError\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Parameter \\#2 \\$listener of method Evenement\\\\EventEmitterInterface\\:\\:on\\(\\) expects callable\\(\\)\\: mixed, array\\{mixed, 'handle'\\} given\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\StreamingServer\\:\\:\\$callback has no type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\StreamingServer\\:\\:\\$parser has no type specified\\.$#"
+			count: 1
+			path: src/Io/StreamingServer.php
+
+		-
+			message: "#^Call to an undefined method React\\\\Promise\\\\PromiseInterface\\:\\:cancel\\(\\)\\.$#"
+			count: 2
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:next\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:progress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:progress\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:progress\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:send\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\Transaction\\:\\:withOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$followRedirects has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$loop has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$maxRedirects has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$maximumSize has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$obeySuccessCode has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$sender has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$streaming has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Io\\\\Transaction\\:\\:\\$timeout has no type specified\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Io/Transaction.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Io\\\\UploadedFile\\:\\:moveTo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Io/UploadedFile.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ResponseException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: src/Message/ResponseException.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ResponseException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Message/ResponseException.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ResponseException\\:\\:__construct\\(\\) has parameter \\$previous with no type specified\\.$#"
+			count: 1
+			path: src/Message/ResponseException.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ResponseException\\:\\:\\$response has no type specified\\.$#"
+			count: 1
+			path: src/Message/ResponseException.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getCookieParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getParsedBody\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getQueryParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getServerParams\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:getUploadedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:parseCookie\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:withCookieParams\\(\\) has parameter \\$cookies with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:withParsedBody\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:withQueryParams\\(\\) has parameter \\$query with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Message\\\\ServerRequest\\:\\:withUploadedFiles\\(\\) has parameter \\$uploadedFiles with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$attributes has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$cookies has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$fileParams has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$parsedBody has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$queryParams has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Message\\\\ServerRequest\\:\\:\\$serverParams has no type specified\\.$#"
+			count: 1
+			path: src/Message/ServerRequest.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:__invoke\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:__invoke\\(\\) has parameter \\$next with no type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:processQueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:\\$limit has no type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:\\$pending has no type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddleware\\:\\:\\$queue has no type specified\\.$#"
+			count: 1
+			path: src/Middleware/LimitConcurrentRequestsMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddleware\\:\\:__invoke\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyBufferMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddleware\\:\\:__invoke\\(\\) has parameter \\$stack with no type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyBufferMiddleware.php
+
+		-
+			message: "#^Parameter \\#1 \\$size of static method React\\\\Http\\\\Io\\\\IniUtil\\:\\:iniSizeToBytes\\(\\) expects string, int\\|string\\|false given\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyBufferMiddleware.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddleware\\:\\:\\$sizeLimit has no type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyBufferMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\RequestBodyParserMiddleware\\:\\:__invoke\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyParserMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\RequestBodyParserMiddleware\\:\\:__invoke\\(\\) has parameter \\$next with no type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyParserMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\RequestBodyParserMiddleware\\:\\:parseFormUrlencoded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyParserMiddleware.php
+
+		-
+			message: "#^Property React\\\\Http\\\\Middleware\\\\RequestBodyParserMiddleware\\:\\:\\$multipart has no type specified\\.$#"
+			count: 1
+			path: src/Middleware/RequestBodyParserMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\StreamingRequestMiddleware\\:\\:__invoke\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Middleware/StreamingRequestMiddleware.php
+
+		-
+			message: "#^Method React\\\\Http\\\\Middleware\\\\StreamingRequestMiddleware\\:\\:__invoke\\(\\) has parameter \\$next with no type specified\\.$#"
+			count: 1
+			path: src/Middleware/StreamingRequestMiddleware.php
+
+		-
+			message: "#^Call to an undefined method React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\>\\:\\:cancel\\(\\)\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:provideOtherUris\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:setUpBrowser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testBrowserShouldNotSendDefaultUserAgentHeaderIfWithoutHeaderRemovesUserAgent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testBrowserShouldSendDefaultUserAgentHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testCancelGetRequestShouldCancelUnderlyingSocketConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithConnectorAssignsGivenConnector\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithConnectorTwiceThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithConnectorWithLegacySignatureAssignsGivenConnector\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithInvalidConnectorThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithInvalidLoopThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithLoopAssignsGivenLoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithLoopTwiceThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithLoopWithLegacySignatureAssignsGivenLoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testConstructWithoutLoopAssignsLoopAutomatically\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testDeleteSendsDeleteRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testGetSendsGetRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testHeadSendsHeadRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testPatchSendsPatchRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testPostSendsPostRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testPutSendsPutRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testRequestOptionsSendsPutRequestWithStreamingExplicitlyDisabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testRequestStreamingGetSendsGetRequestWithStreamingExplicitlyEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testResolveUriWithBaseEndsWithoutSlash\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testResolveUriWithBaseEndsWithoutSlash\\(\\) has parameter \\$base with no type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testResolveUriWithBaseEndsWithoutSlash\\(\\) has parameter \\$expectedAbsolute with no type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithBase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithBaseUrlInvalidSchemeFails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithBaseUrlNotAbsoluteFails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithFollowRedirectsFalseSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithFollowRedirectsTenSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithFollowRedirectsTrueSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithFollowRedirectsZeroSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithHeaderShouldBeOverwrittenByExplicitHeaderInGetMethod\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithHeaderShouldOverwriteExistingHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithMultipleHeadersShouldBeMergedCorrectlyWithMultipleDefaultHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithProtocolVersionFollowedByGetRequestSendsRequestWithProtocolVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithProtocolVersionInvalidThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithRejectErrorResponseFalseSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithRejectErrorResponseTrueSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithResponseBufferThousandSetsSenderOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithTimeout10SetsTimeoutOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithTimeoutFalseSetsNegativeTimeoutOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithTimeoutNegativeSetsZeroTimeoutOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithTimeoutTrueSetsDefaultTimeoutOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithoutBaseFollowedByGetRequestTriesToSendIncompleteRequestUrl\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:testWithoutHeaderShouldRemoveExistingHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$expected$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionProperty constructor expects object\\|string, mixed given\\.$#"
+			count: 9
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$connector of class React\\\\Http\\\\Browser constructor expects React\\\\EventLoop\\\\LoopInterface\\|React\\\\Socket\\\\ConnectorInterface\\|null, string given\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of method ReflectionProperty\\:\\:getValue\\(\\) expects object\\|null, mixed given\\.$#"
+			count: 9
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$loop of class React\\\\Http\\\\Browser constructor expects React\\\\EventLoop\\\\LoopInterface\\|React\\\\Socket\\\\ConnectorInterface\\|null, string given\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:\\$browser has no type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:\\$loop has no type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\BrowserTest\\:\\:\\$sender has no type specified\\.$#"
+			count: 1
+			path: tests/BrowserTest.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 2
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Cannot access offset 'json' on mixed\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testCancelPendingConnectionEmitsClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testPostDataReturnsData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testPostJsonReturnsData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testRequestLegacyHttpServerWithOnlyLineFeedReturnsSuccessfulResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testRequestToLocalhostEmitsSingleRemoteConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\FunctionalIntegrationTest\\:\\:testSuccessfulResponseEmitsEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 2
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function parse_url expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Client/FunctionalIntegrationTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithEmptyQueryString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithHeadersInCustomCase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithOptionsAbsoluteRequestForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithOptionsAsteriskRequestForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithProtocolVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithProtocolVersionThroughConstructor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringReturnsHTTPRequestMessageWithZeroQueryStringAndRootPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestDataTest\\:\\:toStringUsesUserPassFromURL\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestDataTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:closeShouldCancelPendingConnectionAttempt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:closeShouldEmitCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:endAfterCloseIsNoOp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:endShouldStartConnectingAndChangeStreamIntoNonWritableMode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:multivalueHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:pipeShouldPipeDataIntoTheRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:postRequestShouldSendAPostRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldBindToStreamEventsAndUseconnector\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldConnectViaTlsIfUrlUsesHttpsScheme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfConnectionClosesBeforeResponseIsParsed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfConnectionEmitsError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfConnectionFails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfRequestParserThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfUrlHasNoScheme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldEmitErrorIfUrlIsInvalid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:requestShouldRemoveAllListenerAfterClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:setUpStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:successfulAsyncConnectionMock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:successfulConnectionMock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:writeAfterCloseReturnsFalse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:writeShouldStartConnecting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:writeWithAPostRequestShouldForwardDrainEventIfFirstChunkExceedsBuffer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:writeWithAPostRequestShouldSendBodyAfterHeadersAndEmitDrainEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:writeWithAPostRequestShouldSendToTheStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:\\$connector has no type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Client\\\\RequestTest\\:\\:\\$stream has no type specified\\.$#"
+			count: 1
+			path: tests/Client/RequestTest.php
+
+		-
+			message: "#^Cannot access offset 'Content\\-Length' on mixed\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot access offset 'Transfer\\-Encoding' on mixed\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 4
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot access offset 'headers' on mixed\\.$#"
+			count: 2
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method close\\(\\) on React\\\\Socket\\\\SocketServer\\|null\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 18
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method getHeaderLine\\(\\) on mixed\\.$#"
+			count: 6
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method getProtocolVersion\\(\\) on mixed\\.$#"
+			count: 4
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on mixed\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Cannot call method hasHeader\\(\\) on mixed\\.$#"
+			count: 3
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:cleanUpSocketServer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:setUpBrowserAndServer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testCanAccessHttps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testCancelGetRequestWillRejectRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testCancelRedirectedRequestShouldReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testCancelRequestWithPromiseFollowerWillRejectRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testErrorStatusCodeDoesNotRejectWithRejectErrorResponseFalse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testErrorStatusCodeRejectsWithResponseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testFollowRedirectsZeroRejectsOnRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testFollowingRedirectsFalseResolvesWithRedirectResult\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithBaseAndFullAddressResolves\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithBaseAndRelativeAddressResolves\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithRelativeAddressRejects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithResponseBufferExceededDuringStreamingRejects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithResponseBufferExceededRejects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testGetRequestWithResponseBufferMatchedExactlyResolves\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testHeadRequestReceivesResponseWithEmptyBodyButWithContentLengthResponseHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testInvalidPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testPostStreamChunked\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testPostStreamClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testPostStreamKnownLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testPostStreamWillStartSendingRequestEvenWhenBodyDoesNotEmitData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testPostString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testReceiveStreamAndExplicitlyCloseConnectionEvenWhenServerKeepsConnectionOpen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRedirectFromPageWithInvalidAuthToPageWithCorrectAuthenticationSucceeds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRedirectRequestAbsolute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRedirectRequestRelative\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRedirectToPageWithAuthenticationSendsAuthenticationFromLocationHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamReturnsResponseBodyUntilConnectionsEndsForHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamReturnsResponseWithResponseBodyUndecodedWhenResponseHasDoubleTransferEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamReturnsResponseWithTransferEncodingChunkedAndResponseBodyDecodedForHttp11\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamWithHeadRequestReturnsEmptyResponseBodWithTransferEncodingChunkedForHttp11\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamingGetReceivesResponseWithStreamingBodyAndKnownSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamingGetReceivesResponseWithStreamingBodyAndUnknownSizeFromStreamingEndpoint\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamingGetReceivesStreamingResponseBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestStreamingGetReceivesStreamingResponseBodyEvenWhenResponseBufferExceeded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestWithAuthenticationSucceeds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testRequestWithoutAuthenticationFails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testResponseStatus204ShouldResolveWithEmptyBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testResponseStatus304ShouldResolveWithEmptyBodyButContentLengthResponseHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testSendsExplicitHttp10Request\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testSendsHttp11ByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testSimpleRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testTimeoutDelayedResponseAfterStreamingRequestShouldReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testTimeoutDelayedResponseShouldReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testTimeoutFalseShouldResolveSuccessfully\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testVerifyPeerDisabledForBadSslResolves\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:testVerifyPeerEnabledForBadSslRejects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function React\\\\Promise\\\\Stream\\\\buffer expects React\\\\Stream\\\\ReadableStreamInterface\\<string\\>, Psr\\\\Http\\\\Message\\\\StreamInterface given\\.$#"
+			count: 2
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$timer of static method React\\\\EventLoop\\\\Loop\\:\\:cancelTimer\\(\\) expects React\\\\EventLoop\\\\TimerInterface, React\\\\EventLoop\\\\TimerInterface\\|null given\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$body of class React\\\\Http\\\\Message\\\\Response constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|React\\\\Stream\\\\ReadableStreamInterface\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 6
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:\\$base has no type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\FunctionalBrowserTest\\:\\:\\$browser has no type specified\\.$#"
+			count: 1
+			path: tests/FunctionalBrowserTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:on\\(\\)\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Function React\\\\Tests\\\\Http\\\\noScheme\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Function React\\\\Tests\\\\Http\\\\noScheme\\(\\) has parameter \\$uri with no type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testClosedStreamFromRequestHandlerWillSendEmptyBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testConnectWithClosedThroughStreamReturnsNoData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testConnectWithThroughStreamReturnedFromPromiseReturnsDataAsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testConnectWithThroughStreamReturnsDataAsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testLimitConcurrentRequestsMiddlewareRequestStreamPausing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnHttpsStandardPortReturnsUriWithPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnRandomPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnRandomPortWithOtherHostHeaderTakesPrecedence\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnRandomPortWithSingleRequestHandlerArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnRandomPortWithoutHostHeaderUsesSocketUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnStandardPortReturnsUriWithNoPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testPlainHttpOnStandardPortWithoutHostHeaderReturnsUriWithNoPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testRequestHandlerWithStreamingRequestWillReceiveCloseEventIfConnectionClosesWhileSendingBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsOnHttpStandardPortReturnsUriWithPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsOnRandomPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsOnRandomPortWithoutHostHeaderUsesSocketUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsOnStandardPortReturnsUriWithNoPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsOnStandardPortWithoutHostHeaderUsesSocketUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testSecureHttpsReturnsData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testStreamFromRequestHandlerWillBeClosedIfConnectionCloses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testStreamFromRequestHandlerWillBeClosedIfConnectionClosesWhileSendingStreamingRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testUpgradeWithRequestBodyAndThroughStreamReturnsDataAsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\FunctionalHttpServerTest\\:\\:testUpgradeWithThroughStreamReturnsDataAsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertContainsString\\(\\) invoked with 3 parameters, 2 required\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$uri of method React\\\\Socket\\\\Connector\\:\\:connect\\(\\) expects string, string\\|null given\\.$#"
+			count: 23
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$message of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringEndsWith\\(\\) expects string, mixed given\\.$#"
+			count: 7
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringStartsWith\\(\\) expects string, mixed given\\.$#"
+			count: 6
+			path: tests/FunctionalHttpServerTest.php
+
+		-
+			message: "#^Cannot access offset 'foo' on array\\|object\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Cannot access offset 'foo' on array\\|object\\|null\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:createPostFileUploadRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:helperCallableOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:provideIniSettingsForConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:setUpConnectionMockAndSocket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testConstructFiltersOutConfigurationMiddlewareBefore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testConstructServerWithMemoryLimitDoesLimitConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testConstructServerWithUnlimitedMemoryLimitDoesNotLimitConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testConstructWithoutLoopAssignsLoopAutomatically\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testForwardErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testInvalidCallbackFunctionLeadsToException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testPostFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testPostFormData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testPostJsonWillNotBeParsedByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerConcurrency\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerGetPostMaxSizeFromIniIsCapped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerGetPostMaxSizeReturnsSizeCappedFromGivenIniSetting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerGetPostMaxSizeReturnsSizeFromGivenIniSetting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerReceivesBufferedRequestByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testServerWithStreamingRequestMiddlewareReceivesStreamingRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testSimpleRequestCallsArrayRequestHandlerOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testSimpleRequestCallsRequestHandlerOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:testSimpleRequestWithMiddlewareArrayProcessesMiddlewareStack\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionProperty constructor expects object\\|string, mixed given\\.$#"
+			count: 8
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of method ReflectionProperty\\:\\:getValue\\(\\) expects object\\|null, mixed given\\.$#"
+			count: 8
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$requestHandlerOrLoop of class React\\\\Http\\\\HttpServer constructor expects \\(callable\\(\\)\\: mixed\\)\\|React\\\\EventLoop\\\\LoopInterface, 'invalid' given\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$size of static method React\\\\Http\\\\Io\\\\IniUtil\\:\\:iniSizeToBytes\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:\\$connection has no type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\HttpServerTest\\:\\:\\$socket has no type specified\\.$#"
+			count: 1
+			path: tests/HttpServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testDetachReturnsNullAndCloses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetContentsAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetContentsAfterEndsReturnsEmptyStringWithoutChangingPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetContentsMultipleTimesReturnsBodyOnlyOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetContentsReturnsWholeBufferAndAdvancesPositionToEof\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetMetadataWithKeyReturnsNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testGetMetadataWithoutKeyReturnsEmptyArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testReadAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testReadAfterEndReturnsEmptyStringWithoutChangingPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testReadReturnsChunkAndAdvancesPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testReadZeroThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testRewindAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testRewindSeeksToStartPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testSeekAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testSeekAfterEndIsPermitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testSeekAndTellPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testSeekBeforeStartThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testSeekWithInvalidModeThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testTellAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testWriteAdvancesPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testWriteAfterCloseThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testWriteAfterEndAppendsAndFillsWithNullBytes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testWriteInMiddleOfBufferOverwrites\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\BufferedBodyTest\\:\\:testWriteOverEndOverwritesAndAppends\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/BufferedBodyTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:setUpParser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testAdditionalWhitespaceInEndChunkWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testBigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testChunkHeaderIsTooBig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testChunkIsBiggerThenExpected\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testChunkIsMaximumSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testCompletlySplitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEmitCrlfAsChunkBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEmitEmptyChunkBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEmitSingleCharacter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEmptyHeaderAndFilledBodyLeadsToError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEmptyHeaderLeadsToError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEndChunkWithMultipleTrailersWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testEndChunkWithTrailersWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testExtensionWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testHandleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testHandleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testHandleUnexpectedEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testHexDecimalInBodyIsPotentialThread\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testHexDecimalInBodyIsPotentialThreadSplitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testInvalidChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testLateCrlf\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testLeadingZerosInEndChunkWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testLeadingZerosInInvalidChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testLeadingZerosWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testLowerCaseHexWillBeHandled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testMixed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testMixedUpperAndLowerCaseHexValuesInHeaderWillBeHandled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testNegativeHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testNeverEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testNoCrlfInChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testNoCrlfInChunkSplitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testOneUnfinished\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testOutputStreamCanCloseInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testParameterWithEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testPauseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testPipeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testResumeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testSimpleChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testSplittedBoth\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testSplittedChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testSplittedHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testTwoChunks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testUpperCaseHexWillBeHandled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:testWrongChunkHex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnce\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ChunkedDecoderTest\\:\\:\\$parser has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedDecoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:setUpChunkedStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testBiggerStringToCheckHexValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testChunked\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testEmptyString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testHandleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testHandleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testPauseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testPipeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:testResumeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:\\$chunkedStream has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ChunkedEncoderTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ChunkedEncoderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ClockTest\\:\\:testNowResetsMemoizedTimestampOnFutureTick\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ClockTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ClockTest\\:\\:testNowReturnsSameTimestampMultipleTimesInSameTick\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ClockTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testCloseDoesNotCloseTheInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testCloseResumesInputStreamIfItWasPreviouslyPaused\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testEndWontBeEmittedAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testErrorIsNeverCalledAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testErrorWontCloseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testInputStreamIsNotReadableAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testPauseAfterCloseHasNoEffect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testPipeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testResumeAfterCloseHasNoEffect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testResumeStreamWillResumeInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\CloseProtectionStreamTest\\:\\:testStopEmittingDataAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/CloseProtectionStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:setUpBodyStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testCloseTwiceEmitsCloseEventAndClearsListeners\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testDetachReturnsNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testEof\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testGetContentsReturnsEmpy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testGetMetaDataWithKeyReturnsNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testGetMetaDataWithoutKeyReturnsEmptyArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testGetSizeReturnsZero\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testIsReadableReturnsFalseWhenAlreadyClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testIsReadableReturnsTrueWhenNotClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testIsSeekable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testIsWriteable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testPauseIsNoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testPipeStreamReturnsDestinationStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testRead\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testResumeIsNoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testRewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testSeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testTell\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testToStringReturnsEmptyString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:testWrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:\\$bodyStream has no type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\EmptyBodyStreamTest\\:\\:\\$input is unused\\.$#"
+			count: 1
+			path: tests/Io/EmptyBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:setUpBodyStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testDataEmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testDetach\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testEof\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testGetContents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testGetMetaData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testGetSizeCustom\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testGetSizeDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testHandleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testHandleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testIsReadable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testIsSeekable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testIsWriteable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testPauseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testPipeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testRead\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testResumeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testRewind\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testSeek\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testStopDataEmittingAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testTell\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testToString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:testWrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnce\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:\\$bodyStream has no type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\HttpBodyStreamTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/HttpBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:provideIniSizes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:provideInvalidInputIniSizeToBytes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testIniSizeToBytes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testIniSizeToBytes\\(\\) has parameter \\$input with no type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testIniSizeToBytes\\(\\) has parameter \\$output with no type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testIniSizeToBytesWithInvalidSuffixReturnsNumberWithoutSuffix\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testInvalidInputIniSizeToBytes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\IniUtilTest\\:\\:testInvalidInputIniSizeToBytes\\(\\) has parameter \\$input with no type specified\\.$#"
+			count: 1
+			path: tests/Io/IniUtilTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:setUpInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testHandleClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testHandleError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testHandleUnexpectedEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testInputStreamKeepsEmitting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testOutputStreamCanCloseInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testPauseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testPipeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testResumeStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testSimpleChunk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:testZeroLengthInContentLengthWillIgnoreEmittedDataEvents\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:\\$stream has no type specified\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\LengthLimitedStreamTest\\:\\:\\$stream is unused\\.$#"
+			count: 1
+			path: tests/Io/LengthLimitedStreamTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\ResponseInterface\\|React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\>\\:\\:cancel\\(\\)\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\ResponseInterface\\|React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\>\\:\\:getBody\\(\\)\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on mixed\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:provideErrorHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:provideProcessStackMiddlewares\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:provideUncommonMiddlewareArrayFormats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testCancelPendingNextHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testCancelResultingPromiseWillCancelPendingNextHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testEmptyMiddlewareStackThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testFinalHandlerReceivesOneArgument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testMiddlewareHandlerReceivesTwoArguments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testMultipleRunsInvokeAllMiddlewareInCorrectOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testNextCanBeRunMoreThanOnceWithoutCorruptingTheMiddlewareStack\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testNextCanBeRunMoreThanOnceWithoutCorruptingTheMiddlewareStack\\(\\) has parameter \\$errorHandler with no type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testPendingNextRequestHandlersCanBeCalledConcurrently\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testProcessStack\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testProcessStack\\(\\) has parameter \\$expectedCallCount with no type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testProcessStack\\(\\) has parameter \\$middlewares with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testThrowsIfHandlerThrowsException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testThrowsIfHandlerThrowsThrowable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testUncommonMiddlewareArrayFormats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testUncommonMiddlewareArrayFormats\\(\\) has parameter \\$expectedSequence with no type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\MiddlewareRunnerTest\\:\\:testUncommonMiddlewareArrayFormats\\(\\) has parameter \\$middlewareFactory with no type specified\\.$#"
+			count: 1
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$promise of function React\\\\Async\\\\await expects React\\\\Promise\\\\PromiseInterface, Psr\\\\Http\\\\Message\\\\ResponseInterface\\|React\\\\Promise\\\\PromiseInterface\\<Psr\\\\Http\\\\Message\\\\ResponseInterface\\> given\\.$#"
+			count: 2
+			path: tests/Io/MiddlewareRunnerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testDoesNotParseWithoutMultipartFormDataContentType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testEmptyPostKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testEmptyPostValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testFileUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidContentDispositionMissingValueWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidContentDispositionMissingWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidContentDispositionWithoutNameWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidDoubleContentDispositionUsesLast\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidMissingEndBoundaryWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidMissingNewlineAfterValueWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidMissingValueAndEndBoundaryWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidMissingValueWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidUploadFileWithoutContentTypeUsesNullValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testInvalidUploadFileWithoutMultipleContentTypeUsesLastValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testNestedPostKeyAssoc\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testNestedPostKeyVector\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostDeeplyNestedArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostFormDataNamesWithoutQuotationMark\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostMapOverwritesString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostMaxFileSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostMaxFileSizeIgnoredByFilesComingBeforeIt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostStringOverwritesMap\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostVectorOverwritesString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testPostWithQuotationMarkEncapsulatedBoundary\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadEmptyFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadNoFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadTooLargeFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadTooLargeFileWithIniLikeSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadTooManyFilesIgnoresEmptyFilesAndIncludesThemDespiteTruncatedList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\Middleware\\\\MultipartParserTest\\:\\:testUploadTooManyFilesReturnsTruncatedList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Parameter \\#5 \\$version of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects string, float given\\.$#"
+			count: 31
+			path: tests/Io/MultipartParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testCloseEventWillBePassedThroughAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testCloseMethodWillBePassedThroughToInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testDataEventWillBePassedThroughAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testDataEventWillBePipedThroughAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testEndEventWillBePassedThroughAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testErrorEventWillBePassedThroughAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPauseMethodWillBePassedThroughToInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPauseMethodWillNotBePassedThroughToInputAfterClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPauseStreamWillNotPipeThroughDataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughDataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughEndEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughEndEventOnExplicitClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughErrorEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillNotPassThroughErrorEventOnExplicitClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillPassThroughCloseEventOnResume\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillPassThroughDataEventOnResume\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillPassThroughEndEventOnResume\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Io\\\\PauseBufferStreamTest\\:\\:testPausedStreamWillPassThroughErrorEventOnResume\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/PauseBufferStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:setUpStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testCloseInputWillEmitCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testCloseWillCloseInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testCloseWillEmitCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testDataEventOnInputWillEmitDataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testDataEventOnInputWillEmitEndWhenDataReachesExpectedLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testDataEventOnInputWillNotEmitEndWhenDataDoesNotReachExpectedLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testEndEventOnInputWillEmitEndOnlyOnceWhenDataAlreadyReachedExpectedLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testEndInputWillEmitCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testEndInputWillEmitErrorEventWhenDataDoesNotReachExpectedLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testIsEofIfInputIsNotReadable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testIsReadableIfInputIsReadable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPauseWillPauseInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessDetachThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessGetContentsThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessGetMetadataReturnsEmptyArrayWhenNoKeyIsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessGetMetadataReturnsNullWhenKeyIsGiven\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessGetSizeReturnsNull\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessIsSeekableReturnsFalse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessIsWritableReturnsFalse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessReadThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessRewindThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessSeekThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessTellThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessTostringReturnsEmptyString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testPointlessWriteThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:testResumeWillResumeInputStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:\\$input has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\ReadableBodyStreamTest\\:\\:\\$stream has no type specified\\.$#"
+			count: 1
+			path: tests/Io/ReadableBodyStreamTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:on\\(\\)\\.$#"
+			count: 6
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:createAdvancedPostRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:createGetRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testFeedInOneGo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testFeedTwoRequestsOnSeparateConnections\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeaderEventViaHttpsShouldApplyHttpsSchemeFromLocalTlsConnectionAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeaderEventWithShouldApplyDefaultAddressFromLocalConnectionAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeaderOverflowShouldEmitError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestAndConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestWhichShouldEmitEndForStreamingBodyWithoutContentLengthFromInitialRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyDataFromInitialRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyDataUntilContentLengthBoundaryFromInitialRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestWhichShouldEmitStreamingBodyWithPlentyOfDataFromInitialRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldEmitRequestWhichShouldNotEmitStreamingBodyDataWithoutContentLengthFromInitialRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testHeadersEventShouldParsePathAndQueryString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidAbsoluteFormSchemeEmitsError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidAbsoluteFormWithFragmentEmitsError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidAbsoluteFormWithHostHeaderEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidConnectRequestWithNonAuthorityForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidContentLengthRequestHeaderWillEmitError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidEmptyRequestHeadersParseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidHeaderContainsFullUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidHttpVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidMalformedRequestHeadersThrowsParseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidMalformedRequestHeadersWhitespaceThrowsParseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidMalformedRequestLineParseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidRequestWithBothTransferEncodingAndContentLengthWillEmitError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidRequestWithMultipleContentLengthRequestHeadersWillEmitError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testInvalidTransferEncodingRequestHeaderWillEmitError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testOriginFormWithSchemeSeparatorInParam\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testQueryParmetersWillBeSet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWillBeRememberedUntilConnectionIsClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWillBeReusedForMultipleRequestsFromSameConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWillBeSetOnHttpRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWillBeSetOnHttpsRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWillNotSetRemoteAddressForUnixDomainSockets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testServerParamsWontBeSetOnMissingUrls\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testSplitShouldHappenOnDoubleCrlf\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\RequestHeaderParserTest\\:\\:testUriStartingWithColonSlashSlashFails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, mixed given\\.$#"
+			count: 1
+			path: tests/Io/RequestHeaderParserTest.php
+
+		-
+			message: "#^Call to an undefined method React\\\\Promise\\\\PromiseInterface\\:\\:cancel\\(\\)\\.$#"
+			count: 2
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:provideRequestProtocolVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:setUpLoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testCancelRequestWillCancelConnector\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testCancelRequestWillCloseConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testCreateFromLoop\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testRequestProtocolVersion\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testRequestProtocolVersion\\(\\) has parameter \\$headers with no type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testRequestProtocolVersion\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testRequestProtocolVersion\\(\\) has parameter \\$protocolVersion with no type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testRequestProtocolVersion\\(\\) has parameter \\$uri with no type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendCustomMethodWillNotPassContentLengthHeaderForEmptyRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendCustomMethodWithExplicitContentLengthZeroWillBePassedAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendGetWillNotPassContentLengthHeaderForEmptyRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillAutomaticallyPipeChunkEncodeBodyForEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillAutomaticallyPipeChunkEncodeBodyForWriteAndRespectRequestThrottling\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillAutomaticallySendTransferEncodingChunked\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillNotRejectWhenRequestBodyClosesAfterEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillRejectWhenRequestBodyClosesWithoutEnd\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWillRejectWhenRequestBodyEmitsErrorEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostStreamWithExplicitContentLengthWillSendHeaderAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostWillAutomaticallySendContentLengthHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSendPostWillAutomaticallySendContentLengthZeroHeaderForEmptyRequestBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSenderConnectorRejection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:testSenderRejectsInvalidUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\SenderTest\\:\\:\\$loop has no type specified\\.$#"
+			count: 1
+			path: tests/Io/SenderTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:on\\(\\)\\.$#"
+			count: 51
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:pause\\(\\)\\.$#"
+			count: 2
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:resume\\(\\)\\.$#"
+			count: 2
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getCookieParams\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 4
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getHeaderLine\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 16
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getMessage\\(\\) on Throwable\\|null\\.$#"
+			count: 2
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 16
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getPrevious\\(\\) on Exception\\|null\\.$#"
+			count: 2
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getProtocolVersion\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getQueryParams\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 3
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getRequestTarget\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 16
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getServerParams\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 3
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getUri\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 40
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method hasHeader\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:createGetRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:helperCallableOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:setUpConnectionMockAndSocket\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testInvalidCallbackFunctionLeadsToException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserOnceAfterInvokingRequestHandlerWhenStreamingResponseBodyKeepsStreaming\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserOnceAndInvokeRequestHandlerWhenParserIsDoneAndRequestHandlerReturnsConnectionClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserOnceAndInvokeRequestHandlerWhenParserIsDoneForHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserOnceAndInvokeRequestHandlerWhenParserIsDoneForHttp11ConnectionClose\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserTwiceAfterInvokingRequestHandlerWhenConnectionCanBeKeptAliveForHttp10ConnectionKeepAlive\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserTwiceAfterInvokingRequestHandlerWhenConnectionCanBeKeptAliveForHttp11Default\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testNewConnectionWillInvokeParserTwiceAfterInvokingRequestHandlerWhenStreamingResponseBodyEnds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testReponseWithExpectContinueRequestContainsContinueWithLaterResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestAbsoluteEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestAbsoluteNonMatchingHostWillBePassedAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestAbsoluteWithoutHostWillReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestChunkedTransferEncodingCanBeMixedUpperAndLowerCase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestChunkedTransferEncodingEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestChunkedTransferEncodingHeaderCanBeUpperCase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestChunkedTransferEncodingRequestWillEmitDecodedDataEventOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestChunkedTransferEncodingWithAdditionalDataWontBeEmitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestCloseWillNotCloseConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestConnectAuthorityForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestConnectAuthorityFormNonMatchingHostWillBePassedAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestConnectAuthorityFormWithDefaultPortWillBePassedAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestConnectOriginFormRequestTargetWillReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestConnectWithoutHostWillBePassesAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestContentLengthBodyDataWillEmitDataEventOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestContentLengthWillEmitDataEventAndEndEventAndAdditionalDataWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestContentLengthWillEmitDataEventAndEndEventAndAdditionalDataWillBeIgnoredSplitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestCookieWillBeAddedToServerRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestCookieWithCommaValueWillBeAddedToServerRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestCookieWithSeparatorWillBeAddedToServerRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventIsEmitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventIsEmittedForArrayCallable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventWillNotBeEmittedForIncompleteHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventWithPartialBodyWillEmitData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventWithSecondDataEventWillEmitBodyData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventWithSingleRequestHandlerArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestEventWithoutBodyWillNotEmitData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestGetHttp10WithoutHostWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestGetHttp11WithoutHostWillReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestGetWithHostAndCustomPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestGetWithHostAndDefaultPortWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestGetWithHostAndHttpsPort\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidMultipleCookiesWontBeAddedToServerRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestInvalidWillEmitErrorAndSendErrorResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestNonConnectWithAuthorityRequestTargetWillReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestNonOptionsWithAsteriskRequestTargetWillReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestOptionsAbsoluteEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestOptionsAsterisk\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestOptionsAsteriskEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestOverflowWillEmitErrorAndSendErrorResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestPauseAfterCloseWillNotBeForwarded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestPauseWillBeForwardedToConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestQueryParametersWillBeAddedToRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestResumeAfterCloseWillNotBeForwarded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestResumeWillBeForwardedToConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestServerRequestParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestWithoutBodyWillEmitEndOnRequestStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestWithoutDefinedLengthWillIgnoreDataEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestWithoutHostEventUsesSocketAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestZeroContentLengthWillEmitEndAndAdditionalDataWillBeIgnored\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestZeroContentLengthWillEmitEndAndAdditionalDataWillBeIgnoredSplitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testRequestZeroContentLengthWillEmitEndEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamAlreadyClosedWillSendEmptyBodyChunkedEncoded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamAlreadyClosedWillSendEmptyBodyPlainHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamEndingWillSendEmptyBodyChunkedEncoded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamWillBeClosedIfConnectionEmitsCloseEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamWillStreamDataWithChunkedTransferEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseBodyStreamWithContentLengthWillStreamTillLengthWithoutTransferEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseCanContainMultipleCookieHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseConnectMethodStreamWillPipeDataFromConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseConnectMethodStreamWillPipeDataToConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsExplicitContentLengthHeaderForHeadRequests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsExplicitContentLengthHeaderForNotModifiedStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoContentLengthHeaderForNotModifiedStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatusResponseWithStreamingBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyForHeadRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyForHeadRequestWithStreamingResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyForNotModifiedStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsNoResponseBodyForNotModifiedStatusWithStreamingBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsResponseBodyWithPlainBodyWithUnknownSizeForLegacyHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsResponseBodyWithTransferEncodingChunkedForBodyWithUnknownSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseContainsServerHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseExceptionInCallbackWillResultInErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponsePendingPromiseWillBeCancelledIfConnectionCloses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponsePendingPromiseWillNotSendAnything\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseRejectOfNonExceptionWillResultInErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseRejectedPromiseWillResultInErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseResolveWrongTypeInPromiseWillResultInError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseReturnInvalidTypeWillResultInError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseStreamWillBeClosedIfConnectionIsAlreadyClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseUpgradeInResponseCanBeUsedToAdvertisePossibleUpgrade\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseUpgradeSwitchingProtocolIncludesConnectionUpgradeHeaderWithoutContentLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseUpgradeSwitchingProtocolWithStreamWillPipeDataToConnection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseUpgradeWishInRequestCanBeIgnoredByReturningNormalResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWillBeHandled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithCustomDateHeaderOverwritesDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithEmptyDateHeaderRemovesDateHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithExpectContinueRequestWontSendContinueForHttp10\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithResponsePromise\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:testResponseWithoutExplicitDateHeaderWillAddCurrentDateFromClock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionProperty constructor expects object\\|string, mixed given\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$objectOrValue of method ReflectionProperty\\:\\:setValue\\(\\) expects object\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$headers of class React\\\\Http\\\\Message\\\\Response constructor expects array\\<string, array\\<string\\>\\|string\\>, array\\<string, int\\> given\\.$#"
+			count: 3
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$headers of class React\\\\Http\\\\Message\\\\Response constructor expects array\\<string, array\\<string\\>\\|string\\>, array\\<string, int\\|string\\> given\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$requestHandler of class React\\\\Http\\\\Io\\\\StreamingServer constructor expects callable\\(\\)\\: mixed, 'invalid' given\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:\\$connection has no type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Io\\\\StreamingServerTest\\:\\:\\$socket has no type specified\\.$#"
+			count: 1
+			path: tests/Io/StreamingServerTest.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on mixed\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testAuthorizationHeaderIsForwardedWhenLocationContainsAuthentication\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testAuthorizationHeaderIsForwardedWhenRedirectingToSameDomain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelBufferingResponseWillCloseStreamAndReject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionShouldCancelSendingPromise\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCancelRedirectedRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCancelRedirectedRequestAgain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCancelRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCancelTimeoutTimer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCloseBufferingStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCancelTransactionWillCloseBufferingStreamAgain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testCustomRedirectResponseCode333WillFollowLocationHeaderAndSendRedirectedRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testFollowingRedirectWithSpecifiedHeaders\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testReceivingErrorResponseWillRejectWithResponseException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testReceivingStreamingBodyWillResolveWithBufferedResponseByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testReceivingStreamingBodyWillResolveWithStreamingResponseIfStreamingIsEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testReceivingStreamingBodyWithSizeExceedingMaximumResponseBufferWillRejectAndCloseResponseStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testRemovingAuthorizationHeaderWhenChangingHostnamesDuringRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testResponseCode304WithoutLocationWillResolveWithResponseAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testSomeRequestHeadersShouldBeRemovedWhenRedirecting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitNegativeWillNotStartTimeoutTimer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillCancelTimeoutTimerWhenSenderRejectsLaterOn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillCancelTimeoutTimerWhenSenderResolvesLaterOn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillNotStartTimeoutTimerWhenRequestBodyIsStreaming\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillNotStartTimeoutTimerWhenStreamingRequestBodyClosesAfterSenderRejects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillNotStartTimeoutWhenSenderRejectsImmediately\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillNotStartTimeoutWhenSenderResolvesImmediately\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillRejectWhenTimerFires\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillRejectWhenTimerFiresAfterStreamingRequestBodyCloses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillStartTimeoutTimer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillStartTimeoutTimerWhenStreamingRequestBodyClosesWhileSenderIsStillPending\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutExplicitOptionWillStartTimeoutTimerWhenStreamingRequestBodyIsAlreadyClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testTimeoutImplicitFromIniWillStartTimeoutTimer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testWithOptionsDoesNotChangeOriginalInstance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testWithOptionsNullValueReturnsNewInstanceWithDefaultOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\TransactionTest\\:\\:testWithOptionsReturnsNewInstanceWithChangedOption\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$sender of class React\\\\Http\\\\Io\\\\Transaction constructor expects React\\\\Http\\\\Io\\\\Sender, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
+			count: 22
+			path: tests/Io/TransactionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:failtyErrorProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:testFailtyError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:testFailtyError\\(\\) has parameter \\$error with no type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:testGetStreamOnFailedUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:testGetters\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Io\\\\UploadedFileTest\\:\\:testNoMoveFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Io/UploadedFileTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseExceptionTest\\:\\:testCtorDefaults\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseExceptionTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testConstructWithHttpBodyStreamReturnsBodyAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testConstructWithStreamingBodyWillReturnReadableBodyStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testConstructWithStringBodyWillReturnStreamInstance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testFloatBodyWillThrow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testHtmlMethodReturnsHtmlResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testJsonMethodReturnsJsonTextForSimpleString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testJsonMethodReturnsPrettyPrintedJsonResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testJsonMethodReturnsZeroFractionsInJsonResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testJsonMethodThrowsForInvalidString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testPlaintextMethodReturnsPlaintextResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testResourceBodyWillThrow\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ResponseTest\\:\\:testXmlMethodReturnsXmlResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$body of class React\\\\Http\\\\Message\\\\Response constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|React\\\\Stream\\\\ReadableStreamInterface\\|string, float given\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$body of class React\\\\Http\\\\Message\\\\Response constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|React\\\\Stream\\\\ReadableStreamInterface\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Message/ResponseTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:setUpRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithFloatRequestBodyThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithHttpBodyStreamReturnsBodyAsIs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithResourceRequestBodyThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithStreamingRequestBodyReturnsBodyWhichImplementsReadableStreamInterfaceWithSizeZeroDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithStreamingRequestBodyReturnsBodyWithSizeFromContentLengthHeader\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithStreamingRequestBodyReturnsBodyWithSizeUnknownForTransferEncodingChunked\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testConstructWithStringRequestBodyReturnsStringBodyWithAutomaticSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testCookieWithoutSpaceAfterSeparatorWillBeAccepted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testGetAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testGetDefaultAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testGetNoAttributes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testGetQueryParamsFromConstructorUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testGetQueryParamsFromConstructorUriUrlencoded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testMultipleCookiesWithSameNameWillReturnLastValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testOtherEqualSignsWillBeAddedToValueAndWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testParseMultipleCookieHeadersAreNotAllowedAndWillReturnEmptyArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testParseMultipleCookieNameValuePairWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testParseSingleCookieNameValuePairWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testServerRequestParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testSingleCookieValueInCookiesReturnsEmptyArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testSingleMutlipleCookieValuesReturnsEmptyArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testSingleValueIsValidInMultipleValueCookieWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testUrlEncodingForKeyWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testUrlEncodingForValueWillReturnValidArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithCookieParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithParsedBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithQueryParams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithQueryParamsWithoutSpecialEncoding\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithUploadedFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:testWithoutAttribute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$headers of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects array\\<string, array\\<string\\>\\|string\\>, array\\<string, int\\> given\\.$#"
+			count: 2
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$body of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|React\\\\Stream\\\\ReadableStreamInterface\\|string, float given\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$body of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|React\\\\Stream\\\\ReadableStreamInterface\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Property React\\\\Tests\\\\Http\\\\Message\\\\ServerRequestTest\\:\\:\\$request has no type specified\\.$#"
+			count: 1
+			path: tests/Message/ServerRequestTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:on\\(\\)\\.$#"
+			count: 7
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:pause\\(\\)\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Call to an undefined method Psr\\\\Http\\\\Message\\\\StreamInterface\\:\\:resume\\(\\)\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 2
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testDoesNotInvokeNextHandlersWhenQueuedPromiseIsCancelled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testDoesNotReceiveNextRequestIfHandlerIsPending\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testLimitOneRequestConcurrently\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testPendingRequestCanBeCancelledAndForwardsCancellationToInnerPromise\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testQueuedRequestCanBeCancelledBeforeItStartsProcessing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesBufferedRequestSameInstance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextRequestAfterPreviousHandlerIsCancelled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextRequestAfterPreviousHandlerIsSettled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextRequestWhichThrowsAfterPreviousHandlerIsSettled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextStreamingBodyAndDoesEmitDataImmediatelyIfExplicitlyResumed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextStreamingBodyAndDoesNotEmitDataIfExplicitlyClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextStreamingBodyAndDoesNotEmitDataIfExplicitlyPaused\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesNextStreamingBodyWithBufferedDataAfterPreviousHandlerIsSettled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesRequestsSequentially\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesStreamingBodyChangesInstanceWithCustomBodyButSameDataWhenDequeued\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReceivesStreamingBodyRequestSameInstanceWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testRejectsWhenQueuedPromiseIsCancelled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReturnsPendingPromiseChainedFromMiddlewareWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReturnsPendingPromiseFromMiddlewareWhenAboveLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testReturnsResponseDirectlyFromMiddlewareWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testStreamDoesNotPauseOrResumeWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testStreamDoesPauseAndThenResumeWhenDequeued\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testStreamDoesPauseWhenAboveLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testThrowsErrorDirectlyFromMiddlewareWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\LimitConcurrentRequestsMiddlewareTest\\:\\:testThrowsExceptionDirectlyFromMiddlewareWhenBelowLimit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnce\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\ProcessStack\\:\\:__invoke\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/ProcessStack.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\ProcessStack\\:\\:__invoke\\(\\) has parameter \\$stack with no type specified\\.$#"
+			count: 1
+			path: tests/Middleware/ProcessStack.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\ProcessStack\\:\\:reset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/ProcessStack.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\|null\\.$#"
+			count: 12
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 3
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on mixed\\.$#"
+			count: 3
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testAlreadyBufferedExceedingSizeResolvesImmediatelyWithEmptyBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testAlreadyBufferedResolvesImmediately\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testBufferingErrorThrows\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testBufferingResolvesWhenStreamEnds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testEmptyBufferedResolvesImmediatelyWithSameBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testEmptyStreamingResolvesImmediatelyWithEmptyBufferedBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testExcessiveSizeBodyIsDiscardedAndTheRequestIsPassedDownToTheNextMiddleware\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testFullBodyStreamedBeforeCallingNextMiddleware\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testKnownExcessiveSizedBodyIsDisgardedTheRequestIsPassedDownToTheNextMiddleware\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyBufferMiddlewareTest\\:\\:testKnownExcessiveSizedWithIniLikeSize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyBufferMiddlewareTest.php
+
+		-
+			message: "#^Cannot access offset 'a' on array\\|object\\.$#"
+			count: 2
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Cannot access offset 'a' on array\\|object\\|null\\.$#"
+			count: 2
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testDoesNotParseJsonByDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testFormUrlencodedIgnoresBodyWithExcessiveNesting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testFormUrlencodedParsing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testFormUrlencodedParsingIgnoresCaseForHeadersButRespectsContentCase\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testFormUrlencodedParsingNestedStructure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testFormUrlencodedTruncatesBodyWithExcessiveLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testMultipartFormDataIgnoresFieldWithExcessiveNesting\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testMultipartFormDataParsing\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testMultipartFormDataTruncatesBodyWithExcessiveLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\RequestBodyParserMiddlewareTest\\:\\:testMultipartFormDataTruncatesExcessiveNumberOfEmptyFileUploads\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\) expects Countable\\|iterable, array\\|object\\|null given\\.$#"
+			count: 2
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Parameter \\#5 \\$version of class React\\\\Http\\\\Message\\\\ServerRequest constructor expects string, float given\\.$#"
+			count: 4
+			path: tests/Middleware/RequestBodyParserMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\Middleware\\\\StreamingRequestMiddlewareTest\\:\\:testInvokeMiddlewareReturnsResponseFromFollowingHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Middleware/StreamingRequestMiddlewareTest.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\ServerTest\\:\\:testDeprecatedServerIsInstanceOfNewHttpServer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/ServerTest.php
+
+		-
+			message: "#^Call to an undefined static method PHPUnit\\\\Framework\\\\TestCase\\:\\:setExpectedException\\(\\)\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertContainsString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertContainsString\\(\\) has parameter \\$haystack with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertContainsString\\(\\) has parameter \\$needle with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertNotContainsString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertNotContainsString\\(\\) has parameter \\$haystack with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:assertNotContainsString\\(\\) has parameter \\$needle with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:createCallableMock\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableNever\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnceWith\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:expectCallableOnceWith\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:setExpectedException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:setExpectedException\\(\\) has parameter \\$exception with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:setExpectedException\\(\\) has parameter \\$exceptionCode with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method React\\\\Tests\\\\Http\\\\TestCase\\:\\:setExpectedException\\(\\) has parameter \\$exceptionMessage with no type specified\\.$#"
+			count: 1
+			path: tests/TestCase.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+  - phpstan-baseline.neon
+
+parameters:
+  level: 9
+  paths:
+    - examples
+    - src
+    - tests
+  excludePaths:
+    - src/Server.php


### PR DESCRIPTION
This PR sets up PHPStan to run on GitHub Actions, as discussed in [discussions#469](https://github.com/orgs/reactphp/discussions/469).

### Overview

- [x] Sets up PHPStan to run on GitHub Actions on PHP 8.1 only
- [x] Configures PHPStan to run the analysis on the `examples`, `src` and `tests` folders
- [x] Generates the [baseline](https://phpstan.org/user-guide/baseline) so that static analysis passes immediately 

### Baseline

Because this PR aims to set up PHPStan and not address the errors it reports, I've generated a baseline to make the pipeline succeed. We'll then be able to incrementally fix the problems in future PRs.