### PR TITLE
Add `Request` class to represent outgoing HTTP request message

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ multiple concurrent HTTP requests without blocking.
             * [json()](#json)
             * [plaintext()](#plaintext)
             * [xml()](#xml)
+        * [Request](#request-1)
         * [ServerRequest](#serverrequest)
         * [ResponseException](#responseexception)
     * [React\Http\Middleware](#reacthttpmiddleware)
@@ -2627,6 +2628,24 @@ $response = React\Http\Message\Response::xml(
     "<error><message>Invalid user name given.</message></error>\n"
 )->withStatus(React\Http\Message\Response::STATUS_BAD_REQUEST);
 ```
+
+#### Request
+
+The `React\Http\Message\Request` class can be used to
+respresent an outgoing HTTP request message.
+
+This class implements the
+[PSR-7 `RequestInterface`](https://www.php-fig.org/psr/psr-7/#32-psrhttpmessagerequestinterface)
+which extends the
+[PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
+
+This is mostly used internally to represent each outgoing HTTP request
+message for the HTTP client implementation. Likewise, you can also use this
+class with other HTTP client implementations and for tests.
+
+> Internally, this implementation builds on top of an existing outgoing
+  request message and only adds support for streaming. This base class is
+  considered an implementation detail that may change in the future.
 
 #### ServerRequest
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -3,13 +3,12 @@
 namespace React\Http;
 
 use Psr\Http\Message\ResponseInterface;
-use RingCentral\Psr7\Request;
 use RingCentral\Psr7\Uri;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
 use React\Http\Io\Transaction;
+use React\Http\Message\Request;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
@@ -836,10 +835,6 @@ class Browser
         if ($this->baseUrl !== null) {
             // ensure we're actually below the base URL
             $url = Uri::resolve($this->baseUrl, $url);
-        }
-
-        if ($body instanceof ReadableStreamInterface) {
-            $body = new ReadableBodyStream($body);
         }
 
         foreach ($this->defaultHeaders as $key => $value) {

--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -5,14 +5,13 @@ namespace React\Http\Io;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
-use React\Http\Message\Response;
-use RingCentral\Psr7\Request;
-use RingCentral\Psr7\Uri;
 use React\EventLoop\LoopInterface;
+use React\Http\Message\Response;
 use React\Http\Message\ResponseException;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Stream\ReadableStreamInterface;
+use RingCentral\Psr7\Uri;
 
 /**
  * @internal

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace React\Http\Message;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use React\Http\Io\BufferedBody;
+use React\Http\Io\ReadableBodyStream;
+use React\Stream\ReadableStreamInterface;
+use RingCentral\Psr7\Request as BaseRequest;
+
+/**
+ * Respresents an outgoing HTTP request message.
+ *
+ * This class implements the
+ * [PSR-7 `RequestInterface`](https://www.php-fig.org/psr/psr-7/#32-psrhttpmessagerequestinterface)
+ * which extends the
+ * [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface).
+ *
+ * This is mostly used internally to represent each outgoing HTTP request
+ * message for the HTTP client implementation. Likewise, you can also use this
+ * class with other HTTP client implementations and for tests.
+ *
+ * > Internally, this implementation builds on top of an existing outgoing
+ *   request message and only adds support for streaming. This base class is
+ *   considered an implementation detail that may change in the future.
+ *
+ * @see RequestInterface
+ */
+final class Request extends BaseRequest implements RequestInterface
+{
+    /**
+     * @param string                                         $method  HTTP method for the request.
+     * @param string|UriInterface                            $url     URL for the request.
+     * @param array<string,string|string[]>                  $headers Headers for the message.
+     * @param string|ReadableStreamInterface|StreamInterface $body    Message body.
+     * @param string                                         $version HTTP protocol version.
+     * @throws \InvalidArgumentException for an invalid URL or body
+     */
+    public function __construct(
+        $method,
+        $url,
+        array $headers = array(),
+        $body = '',
+        $version = '1.1'
+    ) {
+        if (\is_string($body)) {
+            $body = new BufferedBody($body);
+        } elseif ($body instanceof ReadableStreamInterface && !$body instanceof StreamInterface) {
+            $body = new ReadableBodyStream($body);
+        } elseif (!$body instanceof StreamInterface) {
+            throw new \InvalidArgumentException('Invalid request body given');
+        }
+
+        parent::__construct($method, $url, $headers, $body, $version);
+    }
+}

--- a/src/Message/ServerRequest.php
+++ b/src/Message/ServerRequest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\UriInterface;
 use React\Http\Io\BufferedBody;
 use React\Http\Io\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
-use RingCentral\Psr7\Request;
+use RingCentral\Psr7\Request as BaseRequest;
 
 /**
  * Respresents an incoming server request message.
@@ -30,7 +30,7 @@ use RingCentral\Psr7\Request;
  *
  * @see ServerRequestInterface
  */
-final class ServerRequest extends Request implements ServerRequestInterface
+final class ServerRequest extends BaseRequest implements ServerRequestInterface
 {
     private $attributes = array();
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -7,16 +7,15 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
 use React\Http\Browser;
 use React\Http\HttpServer;
+use React\Http\Message\Response;
 use React\Http\Message\ResponseException;
 use React\Http\Middleware\StreamingRequestMiddleware;
-use React\Http\Message\Response;
 use React\Promise\Promise;
 use React\Promise\Stream;
 use React\Socket\Connector;
 use React\Socket\SocketServer;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
-use RingCentral\Psr7\Request;
 
 class FunctionalBrowserTest extends TestCase
 {

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -6,10 +6,10 @@ use React\Http\Client\Client as HttpClient;
 use React\Http\Client\RequestData;
 use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
+use React\Http\Message\Request;
 use React\Promise;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
-use RingCentral\Psr7\Request;
 
 class SenderTest extends TestCase
 {

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -7,14 +7,14 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Transaction;
+use React\Http\Message\Request;
+use React\Http\Message\Response;
 use React\Http\Message\ResponseException;
 use React\EventLoop\Loop;
 use React\Promise;
 use React\Promise\Deferred;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
-use RingCentral\Psr7\Request;
-use RingCentral\Psr7\Response;
 
 class TransactionTest extends TestCase
 {

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace React\Tests\Http\Message;
+
+use React\Http\Io\HttpBodyStream;
+use React\Http\Message\Request;
+use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
+
+class RequestTest extends TestCase
+{
+    public function testConstructWithStringRequestBodyReturnsStringBodyWithAutomaticSize()
+    {
+        $request = new Request(
+            'GET',
+            'http://localhost',
+            array(),
+            'foo'
+        );
+
+        $body = $request->getBody();
+        $this->assertSame(3, $body->getSize());
+        $this->assertEquals('foo', (string) $body);
+    }
+
+    public function testConstructWithStreamingRequestBodyReturnsBodyWhichImplementsReadableStreamInterfaceWithUnknownSize()
+    {
+        $request = new Request(
+            'GET',
+            'http://localhost',
+            array(),
+            new ThroughStream()
+        );
+
+        $body = $request->getBody();
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertNull($body->getSize());
+    }
+
+    public function testConstructWithHttpBodyStreamReturnsBodyAsIs()
+    {
+        $request = new Request(
+            'GET',
+            'http://localhost',
+            array(),
+            $body = new HttpBodyStream(new ThroughStream(), 100)
+        );
+
+        $this->assertSame($body, $request->getBody());
+    }
+
+    public function testConstructWithNullBodyThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid request body given');
+        new Request(
+            'GET',
+            'http://localhost',
+            array(),
+            null
+        );
+    }
+}


### PR DESCRIPTION
This changeset adds a `Request` class to represent an outgoing HTTP request message. This class implements the [PSR-7 `RequestInterface`](https://www.php-fig.org/psr/psr-7/#32-psrhttpmessagerequestinterface) which extends the [PSR-7 `MessageInterface`](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface). It is mostly used internally to represent each outgoing HTTP request message for the HTTP client implementation. Likewise, you can also use this class with other HTTP client implementations and for tests.

This class complements our other PSR-7 implementations (#370 and others) and is one step further towards moving away from the RingCentral implementations as discussed in #331/#437. On top of this, this PR is done in preparation for HTTP keep-alive support as discussed in #468/#39. Once this PR is merged, I'll file the next follow-up PRs to reuse this class for our outgoing request messages much like already done for the incoming response messages as per #389.