### PR TITLE
Include buffer logic to avoid dependency on reactphp/promise-stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.3 || ^1.2.1",
-        "react/promise-stream": "^1.4",
         "react/socket": "^1.12",
         "react/stream": "^1.2",
         "ringcentral/psr7": "^1.2"
@@ -43,6 +42,7 @@
         "clue/socks-react": "^1.4",
         "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
         "react/async": "^4 || ^3 || ^2",
+        "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.9"
     },
     "autoload": {

--- a/src/Middleware/RequestBodyBufferMiddleware.php
+++ b/src/Middleware/RequestBodyBufferMiddleware.php
@@ -6,7 +6,7 @@ use OverflowException;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Io\BufferedBody;
 use React\Http\Io\IniUtil;
-use React\Promise\Stream;
+use React\Promise\Promise;
 use React\Stream\ReadableStreamInterface;
 
 final class RequestBodyBufferMiddleware
@@ -29,19 +29,19 @@ final class RequestBodyBufferMiddleware
         $this->sizeLimit = IniUtil::iniSizeToBytes($sizeLimit);
     }
 
-    public function __invoke(ServerRequestInterface $request, $stack)
+    public function __invoke(ServerRequestInterface $request, $next)
     {
         $body = $request->getBody();
         $size = $body->getSize();
 
         // happy path: skip if body is known to be empty (or is already buffered)
-        if ($size === 0 || !$body instanceof ReadableStreamInterface) {
+        if ($size === 0 || !$body instanceof ReadableStreamInterface || !$body->isReadable()) {
             // replace with empty body if body is streaming (or buffered size exceeds limit)
             if ($body instanceof ReadableStreamInterface || $size > $this->sizeLimit) {
                 $request = $request->withBody(new BufferedBody(''));
             }
 
-            return $stack($request);
+            return $next($request);
         }
 
         // request body of known size exceeding limit
@@ -50,21 +50,60 @@ final class RequestBodyBufferMiddleware
             $sizeLimit = 0;
         }
 
-        return Stream\buffer($body, $sizeLimit)->then(function ($buffer) use ($request, $stack) {
-            $request = $request->withBody(new BufferedBody($buffer));
+        /** @var ?\Closure $closer */
+        $closer = null;
 
-            return $stack($request);
-        }, function ($error) use ($stack, $request, $body) {
-            // On buffer overflow keep the request body stream in,
-            // but ignore the contents and wait for the close event
-            // before passing the request on to the next middleware.
-            if ($error instanceof OverflowException) {
-                return Stream\first($body, 'close')->then(function () use ($stack, $request) {
-                    return $stack($request);
-                });
-            }
+        return new Promise(function ($resolve, $reject) use ($body, &$closer, $sizeLimit, $request, $next) {
+            // buffer request body data in memory, discard but keep buffering if limit is reached
+            $buffer = '';
+            $bufferer = null;
+            $body->on('data', $bufferer = function ($data) use (&$buffer, $sizeLimit, $body, &$bufferer) {
+                $buffer .= $data;
 
-            throw $error;
+                // On buffer overflow keep the request body stream in,
+                // but ignore the contents and wait for the close event
+                // before passing the request on to the next middleware.
+                if (isset($buffer[$sizeLimit])) {
+                    assert($bufferer instanceof \Closure);
+                    $body->removeListener('data', $bufferer);
+                    $bufferer = null;
+                    $buffer = '';
+                }
+            });
+
+            // call $next with current buffer and resolve or reject with its results
+            $body->on('close', $closer = function () use (&$buffer, $request, $resolve, $reject, $next) {
+                try {
+                    // resolve with result of next handler
+                    $resolve($next($request->withBody(new BufferedBody($buffer))));
+                } catch (\Exception $e) {
+                    $reject($e);
+                } catch (\Throwable $e) { // @codeCoverageIgnoreStart
+                    // reject Errors just like Exceptions (PHP 7+)
+                    $reject($e); // @codeCoverageIgnoreEnd
+                }
+            });
+
+            // reject buffering if body emits error
+            $body->on('error', function (\Exception $e) use ($reject, $body, $closer) {
+                // remove close handler to avoid resolving, then close and reject
+                assert($closer instanceof \Closure);
+                $body->removeListener('close', $closer);
+                $body->close();
+
+                $reject(new \RuntimeException(
+                    'Error while buffering request body: ' . $e->getMessage(),
+                    $e->getCode(),
+                    $e
+                ));
+            });
+        }, function () use ($body, &$closer) {
+            // cancelled buffering: remove close handler to avoid resolving, then close and reject
+            assert($closer instanceof \Closure);
+            $body->removeListener('close', $closer);
+            $body->close();
+
+            throw new \RuntimeException('Cancelled buffering request body');
         });
     }
 }


### PR DESCRIPTION
This changeset adds buffering logic to avoid the otherwise unneeded dependency on [reactphp/promise-stream](https://github.com/reactphp/promise-stream). There are plans to deprecate that package as discussed in https://github.com/orgs/reactphp/discussions/475 and in either case I'd like to remove additional dependencies where possible.

In particular, reactphp/http appears to be the only ReactPHP package that depends on reactphp/promise-stream at the moment. This means that most consumers of this package would no longer install reactphp/promise-stream at all. Perhaps most notably, this means that IDE autocompletion for `all()` would now only suggest the correct `React\Promise\all()` function instead of the rarely useful `React\Promise\Stream\all()` function.

This changeset does not otherwise affect our public API, so this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our APIs. This improves error reporting slightly, but I've tried to keep changes to a minimum otherwise.

Note that this changeset does not preclude the discussion in https://github.com/orgs/reactphp/discussions/475, so whether or not or when the package will be deprecated is still up for debate. If you want to explicitly install this dependency, you can still install it like this:

```bash
composer require react/promise-stream
```

Builds on top of #480, #460 and others
Refs #468