### PR TITLE
Consistently close HTTP client connections when response stream closes

### DIFF
--- a/src/Io/ClientRequestStream.php
+++ b/src/Io/ClientRequestStream.php
@@ -16,7 +16,7 @@ use RingCentral\Psr7 as gPsr;
  * @event response
  * @event drain
  * @event error
- * @event end
+ * @event close
  * @internal
  */
 class ClientRequestStream extends EventEmitter implements WritableStreamInterface
@@ -33,9 +33,11 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
     private $request;
 
     /** @var ?ConnectionInterface */
-    private $stream;
+    private $connection;
 
-    private $buffer;
+    /** @var string */
+    private $buffer = '';
+
     private $responseFactory;
     private $state = self::STATE_INIT;
     private $ended = false;
@@ -58,22 +60,22 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
         $this->state = self::STATE_WRITING_HEAD;
 
         $request = $this->request;
-        $streamRef = &$this->stream;
+        $connectionRef = &$this->connection;
         $stateRef = &$this->state;
         $pendingWrites = &$this->pendingWrites;
         $that = $this;
 
         $promise = $this->connect();
         $promise->then(
-            function (ConnectionInterface $stream) use ($request, &$streamRef, &$stateRef, &$pendingWrites, $that) {
-                $streamRef = $stream;
-                assert($streamRef instanceof ConnectionInterface);
+            function (ConnectionInterface $connection) use ($request, &$connectionRef, &$stateRef, &$pendingWrites, $that) {
+                $connectionRef = $connection;
+                assert($connectionRef instanceof ConnectionInterface);
 
-                $stream->on('drain', array($that, 'handleDrain'));
-                $stream->on('data', array($that, 'handleData'));
-                $stream->on('end', array($that, 'handleEnd'));
-                $stream->on('error', array($that, 'handleError'));
-                $stream->on('close', array($that, 'handleClose'));
+                $connection->on('drain', array($that, 'handleDrain'));
+                $connection->on('data', array($that, 'handleData'));
+                $connection->on('end', array($that, 'handleEnd'));
+                $connection->on('error', array($that, 'handleError'));
+                $connection->on('close', array($that, 'close'));
 
                 assert($request instanceof RequestInterface);
                 $headers = "{$request->getMethod()} {$request->getRequestTarget()} HTTP/{$request->getProtocolVersion()}\r\n";
@@ -83,7 +85,7 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
                     }
                 }
 
-                $more = $stream->write($headers . "\r\n" . $pendingWrites);
+                $more = $connection->write($headers . "\r\n" . $pendingWrites);
 
                 assert($stateRef === ClientRequestStream::STATE_WRITING_HEAD);
                 $stateRef = ClientRequestStream::STATE_HEAD_WRITTEN;
@@ -113,7 +115,7 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
 
         // write directly to connection stream if already available
         if (self::STATE_HEAD_WRITTEN <= $this->state) {
-            return $this->stream->write($data);
+            return $this->connection->write($data);
         }
 
         // otherwise buffer and try to establish connection
@@ -157,26 +159,28 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
                 $response = gPsr\parse_response($this->buffer);
                 $bodyChunk = (string) $response->getBody();
             } catch (\InvalidArgumentException $exception) {
-                $this->emit('error', array($exception));
-            }
-
-            $this->buffer = null;
-
-            $this->stream->removeListener('drain', array($this, 'handleDrain'));
-            $this->stream->removeListener('data', array($this, 'handleData'));
-            $this->stream->removeListener('end', array($this, 'handleEnd'));
-            $this->stream->removeListener('error', array($this, 'handleError'));
-            $this->stream->removeListener('close', array($this, 'handleClose'));
-
-            if (!isset($response)) {
+                $this->closeError($exception);
                 return;
             }
 
-            $this->stream->on('close', array($this, 'handleClose'));
+            // response headers successfully received => remove listeners for connection events
+            $connection = $this->connection;
+            assert($connection instanceof ConnectionInterface);
+            $connection->removeListener('drain', array($this, 'handleDrain'));
+            $connection->removeListener('data', array($this, 'handleData'));
+            $connection->removeListener('end', array($this, 'handleEnd'));
+            $connection->removeListener('error', array($this, 'handleError'));
+            $connection->removeListener('close', array($this, 'close'));
+            $this->connection = null;
+            $this->buffer = '';
 
-            assert($response instanceof ResponseInterface);
-            assert($this->stream instanceof ConnectionInterface);
-            $body = $this->stream;
+            // take control over connection handling and close connection once response body closes
+            $that = $this;
+            $input = $body = new CloseProtectionStream($connection);
+            $input->on('close', function () use ($connection, $that) {
+                $connection->close();
+                $that->close();
+            });
 
             // determine length of response body
             $length = null;
@@ -194,7 +198,11 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
             $this->emit('response', array($response, $body));
 
             // re-emit HTTP response body to trigger body parsing if parts of it are buffered
-            $this->stream->emit('data', array($bodyChunk));
+            if ($bodyChunk !== '') {
+                $input->handleData($bodyChunk);
+            } elseif ($length === 0) {
+                $input->handleEnd();
+            }
         }
     }
 
@@ -217,12 +225,6 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
     }
 
     /** @internal */
-    public function handleClose()
-    {
-        $this->close();
-    }
-
-    /** @internal */
     public function closeError(\Exception $error)
     {
         if (self::STATE_END <= $this->state) {
@@ -240,9 +242,11 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
 
         $this->state = self::STATE_END;
         $this->pendingWrites = '';
+        $this->buffer = '';
 
-        if ($this->stream) {
-            $this->stream->close();
+        if ($this->connection instanceof ConnectionInterface) {
+            $this->connection->close();
+            $this->connection = null;
         }
 
         $this->emit('close');

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -6,7 +6,6 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Client\Client as HttpClient;
-use React\Http\Message\Response;
 use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
 use React\Socket\ConnectorInterface;
@@ -116,18 +115,8 @@ class Sender
             $deferred->reject($error);
         });
 
-        $requestStream->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($deferred, $request) {
-            $length = null;
-            $code = $response->getStatusCode();
-            if ($request->getMethod() === 'HEAD' || ($code >= 100 && $code < 200) || $code == Response::STATUS_NO_CONTENT || $code == Response::STATUS_NOT_MODIFIED) {
-                $length = 0;
-            } elseif (\strtolower($response->getHeaderLine('Transfer-Encoding')) === 'chunked') {
-                $body = new ChunkedDecoder($body);
-            } elseif ($response->hasHeader('Content-Length')) {
-                $length = (int) $response->getHeaderLine('Content-Length');
-            }
-
-            $deferred->resolve($response->withBody(new ReadableBodyStream($body, $length)));
+        $requestStream->on('response', function (ResponseInterface $response) use ($deferred, $request) {
+            $deferred->resolve($response);
         });
 
         if ($body instanceof ReadableStreamInterface) {

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -94,8 +94,10 @@ class Sender
         }
 
         // automatically add `Connection: close` request header for HTTP/1.1 requests to avoid connection reuse
-        if ($request->getProtocolVersion() === '1.1' && !$request->hasHeader('Connection')) {
+        if ($request->getProtocolVersion() === '1.1') {
             $request = $request->withHeader('Connection', 'close');
+        } else {
+            $request = $request->withoutHeader('Connection');
         }
 
         // automatically add `Authorization: Basic …` request header if URL includes `user:pass@host`

--- a/tests/Io/ClientRequestStreamTest.php
+++ b/tests/Io/ClientRequestStreamTest.php
@@ -35,11 +35,12 @@ class ClientRequestStreamTest extends TestCase
 
         $this->successfulConnectionMock();
 
-        $this->stream->expects($this->exactly(6))->method('on')->withConsecutive(
+        $this->stream->expects($this->atLeast(6))->method('on')->withConsecutive(
             array('drain', $this->identicalTo(array($request, 'handleDrain'))),
             array('data', $this->identicalTo(array($request, 'handleData'))),
             array('end', $this->identicalTo(array($request, 'handleEnd'))),
             array('error', $this->identicalTo(array($request, 'handleError'))),
+            array('close', $this->identicalTo(array($request, 'handleClose'))),
             array('close', $this->identicalTo(array($request, 'handleClose')))
         );
 

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -303,6 +303,20 @@ class SenderTest extends TestCase
     }
 
     /** @test */
+    public function getHttp10RequestShouldSendAGetRequestWithoutConnectionHeaderEvenWhenConnectionKeepAliveHeaderIsSpecified()
+    {
+        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
+        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
+            return !$request->hasHeader('Connection');
+        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
+
+        $sender = new Sender($client);
+
+        $request = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.0');
+        $sender->send($request);
+    }
+
+    /** @test */
     public function getHttp11RequestShouldSendAGetRequestWithConnectionCloseHeaderByDefault()
     {
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
@@ -317,16 +331,16 @@ class SenderTest extends TestCase
     }
 
     /** @test */
-    public function getHttp11RequestShouldSendAGetRequestWithGivenConnectionUpgradeHeader()
+    public function getHttp11RequestShouldSendAGetRequestWithConnectionCloseHeaderEvenWhenConnectionKeepAliveHeaderIsSpecified()
     {
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
-            return $request->getHeaderLine('Connection') === 'upgrade';
+            return $request->getHeaderLine('Connection') === 'close';
         }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
 
         $sender = new Sender($client);
 
-        $request = new Request('GET', 'http://www.example.com', array('Connection' => 'upgrade'), '', '1.1');
+        $request = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.1');
         $sender->send($request);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    protected function expectCallableOnce()
+    public function expectCallableOnce() // protected (PHP 5.4+)
     {
         $mock = $this->createCallableMock();
         $mock
@@ -16,7 +16,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableOnceWith($value)
+    public function expectCallableOnceWith($value) // protected (PHP 5.4+)
     {
         $mock = $this->createCallableMock();
         $mock
@@ -27,7 +27,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableNever()
+    public function expectCallableNever() // protected (PHP 5.4+)
     {
         $mock = $this->createCallableMock();
         $mock


### PR DESCRIPTION
This changeset improves how the HTTP client closes outgoing TCP/IP connections when the response stream closes. This should not affect "normal" operation of well-behaving peers, but would be relatively easy to trigger depending on which HTTP headers the request and response specified. Previously, connections may have been kept in an idle state instead of properly closing the connection and freeing underlying system resources.

Applying these changes required a significant refactoring of the existing logic first and also happens to be a prerequisite for upcoming HTTP keep-alive handling that will be taken care of in a follow-up PR. This does not otherwise affect the public `React\Http\Browser` class or any other public APIs, so this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our public APIs.

Builds on top of #481 and #480
Done in preparation for #468 (HTTP keep-alive)
Also refs #376 (future support for HTTP upgrades)