### PR TITLE
Support HTTP keep-alive for HTTP client (reusing persistent connections)

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -23,6 +23,7 @@ class Browser
     private $baseUrl;
     private $protocolVersion = '1.1';
     private $defaultHeaders = array(
+        'Connection' => 'close',
         'User-Agent' => 'ReactPHP/1'
     );
 

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -3,30 +3,25 @@
 namespace React\Http\Client;
 
 use Psr\Http\Message\RequestInterface;
-use React\EventLoop\LoopInterface;
+use React\Http\Io\ClientConnectionManager;
 use React\Http\Io\ClientRequestStream;
-use React\Socket\Connector;
-use React\Socket\ConnectorInterface;
 
 /**
  * @internal
  */
 class Client
 {
-    private $connector;
+    /** @var ClientConnectionManager */
+    private $connectionManager;
 
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
+    public function __construct(ClientConnectionManager $connectionManager)
     {
-        if ($connector === null) {
-            $connector = new Connector(array(), $loop);
-        }
-
-        $this->connector = $connector;
+        $this->connectionManager = $connectionManager;
     }
 
     /** @return ClientRequestStream */
     public function request(RequestInterface $request)
     {
-        return new ClientRequestStream($this->connector, $request);
+        return new ClientRequestStream($this->connectionManager, $request);
     }
 }

--- a/src/Io/ClientConnectionManager.php
+++ b/src/Io/ClientConnectionManager.php
@@ -42,4 +42,12 @@ class ClientConnectionManager
 
         return $this->connector->connect(($scheme === 'https' ? 'tls://' : '') . $uri->getHost() . ':' . $port);
     }
+
+    /**
+     * @return void
+     */
+    public function handBack(ConnectionInterface $connection)
+    {
+        $connection->close();
+    }
 }

--- a/src/Io/ClientConnectionManager.php
+++ b/src/Io/ClientConnectionManager.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace React\Http\Io;
+
+use Psr\Http\Message\UriInterface;
+use React\Promise\PromiseInterface;
+use React\Socket\ConnectionInterface;
+use React\Socket\ConnectorInterface;
+
+/**
+ * [Internal] Manages outgoing HTTP connections for the HTTP client
+ *
+ * @internal
+ * @final
+ */
+class ClientConnectionManager
+{
+    /** @var ConnectorInterface */
+    private $connector;
+
+    public function __construct(ConnectorInterface $connector)
+    {
+        $this->connector = $connector;
+    }
+
+    /**
+     * @return PromiseInterface<ConnectionInterface>
+     */
+    public function connect(UriInterface $uri)
+    {
+        $scheme = $uri->getScheme();
+        if ($scheme !== 'https' && $scheme !== 'http') {
+            return \React\Promise\reject(new \InvalidArgumentException(
+                'Invalid request URL given'
+            ));
+        }
+
+        $port = $uri->getPort();
+        if ($port === null) {
+            $port = $scheme === 'https' ? 443 : 80;
+        }
+
+        return $this->connector->connect(($scheme === 'https' ? 'tls://' : '') . $uri->getHost() . ':' . $port);
+    }
+}

--- a/src/Io/ClientConnectionManager.php
+++ b/src/Io/ClientConnectionManager.php
@@ -3,6 +3,8 @@
 namespace React\Http\Io;
 
 use Psr\Http\Message\UriInterface;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ConnectorInterface;
@@ -18,9 +20,28 @@ class ClientConnectionManager
     /** @var ConnectorInterface */
     private $connector;
 
-    public function __construct(ConnectorInterface $connector)
+    /** @var LoopInterface */
+    private $loop;
+
+    /** @var string[] */
+    private $idleUris = array();
+
+    /** @var ConnectionInterface[] */
+    private $idleConnections = array();
+
+    /** @var TimerInterface[] */
+    private $idleTimers = array();
+
+    /** @var \Closure[] */
+    private $idleStreamHandlers = array();
+
+    /** @var float */
+    private $maximumTimeToKeepAliveIdleConnection = 0.001;
+
+    public function __construct(ConnectorInterface $connector, LoopInterface $loop)
     {
         $this->connector = $connector;
+        $this->loop = $loop;
     }
 
     /**
@@ -39,15 +60,78 @@ class ClientConnectionManager
         if ($port === null) {
             $port = $scheme === 'https' ? 443 : 80;
         }
+        $uri = ($scheme === 'https' ? 'tls://' : '') . $uri->getHost() . ':' . $port;
 
-        return $this->connector->connect(($scheme === 'https' ? 'tls://' : '') . $uri->getHost() . ':' . $port);
+        // Reuse idle connection for same URI if available
+        foreach ($this->idleConnections as $id => $connection) {
+            if ($this->idleUris[$id] === $uri) {
+                assert($this->idleStreamHandlers[$id] instanceof \Closure);
+                $connection->removeListener('close', $this->idleStreamHandlers[$id]);
+                $connection->removeListener('data', $this->idleStreamHandlers[$id]);
+                $connection->removeListener('error', $this->idleStreamHandlers[$id]);
+
+                assert($this->idleTimers[$id] instanceof TimerInterface);
+                $this->loop->cancelTimer($this->idleTimers[$id]);
+                unset($this->idleUris[$id], $this->idleConnections[$id], $this->idleTimers[$id], $this->idleStreamHandlers[$id]);
+
+                return \React\Promise\resolve($connection);
+            }
+        }
+
+        // Create new connection if no idle connection to same URI is available
+        return $this->connector->connect($uri);
     }
 
     /**
+     * Hands back an idle connection to the connection manager for possible future reuse.
+     *
      * @return void
      */
-    public function handBack(ConnectionInterface $connection)
+    public function keepAlive(UriInterface $uri, ConnectionInterface $connection)
     {
+        $scheme = $uri->getScheme();
+        assert($scheme === 'https' || $scheme === 'http');
+
+        $port = $uri->getPort();
+        if ($port === null) {
+            $port = $scheme === 'https' ? 443 : 80;
+        }
+
+        $this->idleUris[] = ($scheme === 'https' ? 'tls://' : '') . $uri->getHost() . ':' . $port;
+        $this->idleConnections[] = $connection;
+
+        $that = $this;
+        $cleanUp = function () use ($connection, $that) {
+            // call public method to support legacy PHP 5.3
+            $that->cleanUpConnection($connection);
+        };
+
+        // clean up and close connection when maximum time to keep-alive idle connection has passed
+        $this->idleTimers[] = $this->loop->addTimer($this->maximumTimeToKeepAliveIdleConnection, $cleanUp);
+
+        // clean up and close connection when unexpected close/data/error event happens during idle time
+        $this->idleStreamHandlers[] = $cleanUp;
+        $connection->on('close', $cleanUp);
+        $connection->on('data', $cleanUp);
+        $connection->on('error', $cleanUp);
+    }
+
+    /**
+     * @internal
+     * @return void
+     */
+    public function cleanUpConnection(ConnectionInterface $connection) // private (PHP 5.4+)
+    {
+        $id = \array_search($connection, $this->idleConnections, true);
+        if ($id === false) {
+            return;
+        }
+
+        assert(\is_int($id));
+        assert($this->idleTimers[$id] instanceof TimerInterface);
+        $this->loop->cancelTimer($this->idleTimers[$id]);
+        unset($this->idleUris[$id], $this->idleConnections[$id], $this->idleTimers[$id], $this->idleStreamHandlers[$id]);
+
         $connection->close();
     }
 }

--- a/src/Io/ClientRequestStream.php
+++ b/src/Io/ClientRequestStream.php
@@ -181,7 +181,7 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
             $input->on('close', function () use ($connection, $that, $connectionManager, $request, $response, &$successfulEndReceived) {
                 // only reuse connection after successful response and both request and response allow keep alive
                 if ($successfulEndReceived && $connection->isReadable() && $that->hasMessageKeepAliveEnabled($response) && $that->hasMessageKeepAliveEnabled($request)) {
-                    $connectionManager->handBack($connection);
+                    $connectionManager->keepAlive($request->getUri(), $connection);
                 } else {
                     $connection->close();
                 }

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -54,7 +54,7 @@ class Sender
             $connector = new Connector(array(), $loop);
         }
 
-        return new self(new HttpClient(new ClientConnectionManager($connector)));
+        return new self(new HttpClient(new ClientConnectionManager($connector, $loop)));
     }
 
     private $http;

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -8,6 +8,7 @@ use React\EventLoop\LoopInterface;
 use React\Http\Client\Client as HttpClient;
 use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
+use React\Socket\Connector;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
 
@@ -49,7 +50,11 @@ class Sender
      */
     public static function createFromLoop(LoopInterface $loop, ConnectorInterface $connector = null)
     {
-        return new self(new HttpClient($loop, $connector));
+        if ($connector === null) {
+            $connector = new Connector(array(), $loop);
+        }
+
+        return new self(new HttpClient(new ClientConnectionManager($connector)));
     }
 
     private $http;

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -98,13 +98,6 @@ class Sender
             $size = 0;
         }
 
-        // automatically add `Connection: close` request header for HTTP/1.1 requests to avoid connection reuse
-        if ($request->getProtocolVersion() === '1.1') {
-            $request = $request->withHeader('Connection', 'close');
-        } else {
-            $request = $request->withoutHeader('Connection');
-        }
-
         // automatically add `Authorization: Basic …` request header if URL includes `user:pass@host`
         if ($request->getUri()->getUserInfo() !== '' && !$request->hasHeader('Authorization')) {
             $request = $request->withHeader('Authorization', 'Basic ' . \base64_encode($request->getUri()->getUserInfo()));

--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -302,7 +302,7 @@ class Transaction
                 ->withMethod($request->getMethod() === 'HEAD' ? 'HEAD' : 'GET')
                 ->withoutHeader('Content-Type')
                 ->withoutHeader('Content-Length')
-                ->withBody(new EmptyBodyStream());
+                ->withBody(new BufferedBody(''));
         }
 
         return $request;

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -60,9 +60,13 @@ class BrowserTest extends TestCase
         $ref->setAccessible(true);
         $client = $ref->getValue($sender);
 
-        $ref = new \ReflectionProperty($client, 'connector');
+        $ref = new \ReflectionProperty($client, 'connectionManager');
         $ref->setAccessible(true);
-        $ret = $ref->getValue($client);
+        $connectionManager = $ref->getValue($client);
+
+        $ref = new \ReflectionProperty($connectionManager, 'connector');
+        $ref->setAccessible(true);
+        $ret = $ref->getValue($connectionManager);
 
         $this->assertSame($connector, $ret);
     }
@@ -85,9 +89,13 @@ class BrowserTest extends TestCase
         $ref->setAccessible(true);
         $client = $ref->getValue($sender);
 
-        $ref = new \ReflectionProperty($client, 'connector');
+        $ref = new \ReflectionProperty($client, 'connectionManager');
         $ref->setAccessible(true);
-        $ret = $ref->getValue($client);
+        $connectionManager = $ref->getValue($client);
+
+        $ref = new \ReflectionProperty($connectionManager, 'connector');
+        $ref->setAccessible(true);
+        $ret = $ref->getValue($connectionManager);
 
         $this->assertSame($connector, $ret);
     }

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -556,6 +556,8 @@ class BrowserTest extends TestCase
                 'user-Agent' => array('ABC'),
                 'another-header' => array('value'),
                 'custom-header' => array('data'),
+
+                'Connection' => array('close')
             );
 
             $that->assertEquals($expectedHeaders, $request->getHeaders());
@@ -578,6 +580,32 @@ class BrowserTest extends TestCase
         $that = $this;
         $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
             $that->assertEquals(array(), $request->getHeader('user-agent'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
+
+    public function testWithoutHeaderConnectionShouldRemoveDefaultConnectionHeader()
+    {
+        $this->browser = $this->browser->withoutHeader('Connection');
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array(), $request->getHeader('Connection'));
+            return true;
+        }))->willReturn(new Promise(function () { }));
+
+        $this->browser->get('http://example.com/');
+    }
+
+    public function testWithHeaderConnectionShouldOverwriteDefaultConnectionHeader()
+    {
+        $this->browser = $this->browser->withHeader('Connection', 'keep-alive');
+
+        $that = $this;
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
+            $that->assertEquals(array('keep-alive'), $request->getHeader('Connection'));
             return true;
         }))->willReturn(new Promise(function () { }));
 

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -3,12 +3,13 @@
 namespace React\Tests\Http\Client;
 
 use Psr\Http\Message\ResponseInterface;
-use React\EventLoop\Loop;
 use React\Http\Client\Client;
+use React\Http\Io\ClientConnectionManager;
 use React\Http\Message\Request;
 use React\Promise\Deferred;
 use React\Promise\Stream;
 use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
 use React\Socket\SocketServer;
 use React\Stream\ReadableStreamInterface;
 use React\Tests\Http\TestCase;
@@ -45,7 +46,7 @@ class FunctionalIntegrationTest extends TestCase
         });
         $port = parse_url($socket->getAddress(), PHP_URL_PORT);
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
         $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.0'));
 
         $promise = Stream\first($request, 'close');
@@ -62,7 +63,7 @@ class FunctionalIntegrationTest extends TestCase
             $socket->close();
         });
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
         $request = $client->request(new Request('GET', str_replace('tcp:', 'http:', $socket->getAddress()), array(), '', '1.0'));
 
         $once = $this->expectCallableOnceWith('body');
@@ -82,7 +83,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
 
@@ -107,7 +108,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
 
         $data = str_repeat('.', 33000);
         $request = $client->request(new Request('POST', 'https://' . (mt_rand(0, 1) === 0 ? 'eu.' : '') . 'httpbin.org/post', array('Content-Length' => strlen($data)), '', '1.0'));
@@ -139,7 +140,7 @@ class FunctionalIntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
 
         $data = json_encode(array('numbers' => range(1, 50)));
         $request = $client->request(new Request('POST', 'https://httpbin.org/post', array('Content-Length' => strlen($data), 'Content-Type' => 'application/json'), '', '1.0'));
@@ -169,7 +170,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(Loop::get());
+        $client = new Client(new ClientConnectionManager(new Connector()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
         $request->on('error', $this->expectCallableNever());

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Http\Client;
 
 use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Loop;
 use React\Http\Client\Client;
 use React\Http\Io\ClientConnectionManager;
 use React\Http\Message\Request;
@@ -47,7 +48,7 @@ class FunctionalIntegrationTest extends TestCase
         });
         $port = parse_url($socket->getAddress(), PHP_URL_PORT);
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
         $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.0'));
 
         $promise = Stream\first($request, 'close');
@@ -56,7 +57,7 @@ class FunctionalIntegrationTest extends TestCase
         \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
     }
 
-    public function testRequestToLocalhostWillConnectAndCloseConnectionAfterResponseUntilKeepAliveIsActuallySupported()
+    public function testRequestToLocalhostWillConnectAndCloseConnectionAfterResponseWhenKeepAliveTimesOut()
     {
         $socket = new SocketServer('127.0.0.1:0');
         $socket->on('connection', $this->expectCallableOnce());
@@ -72,9 +73,37 @@ class FunctionalIntegrationTest extends TestCase
         });
         $port = parse_url($socket->getAddress(), PHP_URL_PORT);
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
         $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
 
+        $request->end();
+
+        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+    }
+
+    public function testRequestToLocalhostWillReuseExistingConnectionForSecondRequest()
+    {
+        $socket = new SocketServer('127.0.0.1:0');
+        $socket->on('connection', $this->expectCallableOnce());
+
+        $socket->on('connection', function (ConnectionInterface $connection) use ($socket) {
+            $connection->on('data', function () use ($connection) {
+                $connection->write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
+            });
+            $socket->close();
+        });
+        $port = parse_url($socket->getAddress(), PHP_URL_PORT);
+
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
+
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
+        $promise = Stream\first($request, 'close');
+        $request->end();
+
+        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
+        $promise = Stream\first($request, 'close');
         $request->end();
 
         \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
@@ -88,7 +117,7 @@ class FunctionalIntegrationTest extends TestCase
             $socket->close();
         });
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
         $request = $client->request(new Request('GET', str_replace('tcp:', 'http:', $socket->getAddress()), array(), '', '1.0'));
 
         $once = $this->expectCallableOnceWith('body');
@@ -108,7 +137,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
 
@@ -133,7 +162,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $data = str_repeat('.', 33000);
         $request = $client->request(new Request('POST', 'https://' . (mt_rand(0, 1) === 0 ? 'eu.' : '') . 'httpbin.org/post', array('Content-Length' => strlen($data)), '', '1.0'));
@@ -165,7 +194,7 @@ class FunctionalIntegrationTest extends TestCase
             $this->markTestSkipped('Not supported on HHVM');
         }
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $data = json_encode(array('numbers' => range(1, 50)));
         $request = $client->request(new Request('POST', 'https://httpbin.org/post', array('Content-Length' => strlen($data), 'Content-Type' => 'application/json'), '', '1.0'));
@@ -195,7 +224,7 @@ class FunctionalIntegrationTest extends TestCase
         // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
         ini_set('xdebug.max_nesting_level', 256);
 
-        $client = new Client(new ClientConnectionManager(new Connector()));
+        $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
         $request->on('error', $this->expectCallableNever());

--- a/tests/Io/ClientConnectionManagerTest.php
+++ b/tests/Io/ClientConnectionManagerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use RingCentral\Psr7\Uri;
+use React\Http\Io\ClientConnectionManager;
+use React\Promise\Promise;
+use React\Tests\Http\TestCase;
+
+class ClientConnectionManagerTest extends TestCase
+{
+    public function testConnectWithHttpsUriShouldConnectToTlsWithDefaultPort()
+    {
+        $promise = new Promise(function () { });
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn($promise);
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $ret = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        $this->assertSame($promise, $ret);
+    }
+
+    public function testConnectWithHttpUriShouldConnectToTcpWithDefaultPort()
+    {
+        $promise = new Promise(function () { });
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('reactphp.org:80')->willReturn($promise);
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $ret = $connectionManager->connect(new Uri('http://reactphp.org/'));
+        $this->assertSame($promise, $ret);
+    }
+
+    public function testConnectWithExplicitPortShouldConnectWithGivenPort()
+    {
+        $promise = new Promise(function () { });
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('reactphp.org:8080')->willReturn($promise);
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $ret = $connectionManager->connect(new Uri('http://reactphp.org:8080/'));
+        $this->assertSame($promise, $ret);
+    }
+
+    public function testConnectWithInvalidSchemeShouldRejectWithException()
+    {
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->never())->method('connect');
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $promise = $connectionManager->connect(new Uri('ftp://reactphp.org/'));
+
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertEquals('Invalid request URL given', $exception->getMessage());
+    }
+
+    public function testConnectWithoutSchemeShouldRejectWithException()
+    {
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->never())->method('connect');
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $promise = $connectionManager->connect(new Uri('reactphp.org'));
+
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertEquals('Invalid request URL given', $exception->getMessage());
+    }
+}

--- a/tests/Io/ClientConnectionManagerTest.php
+++ b/tests/Io/ClientConnectionManagerTest.php
@@ -80,4 +80,16 @@ class ClientConnectionManagerTest extends TestCase
         $this->assertInstanceOf('InvalidArgumentException', $exception);
         $this->assertEquals('Invalid request URL given', $exception->getMessage());
     }
+
+    public function testHandBackWillCloseGivenConnectionUntilKeepAliveIsActuallySupported()
+    {
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector);
+
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection->expects($this->once())->method('close');
+
+        $connectionManager->handBack($connection);
+    }
 }

--- a/tests/Io/ClientConnectionManagerTest.php
+++ b/tests/Io/ClientConnectionManagerTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Http\Io;
 use RingCentral\Psr7\Uri;
 use React\Http\Io\ClientConnectionManager;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 use React\Tests\Http\TestCase;
 
 class ClientConnectionManagerTest extends TestCase
@@ -15,9 +16,13 @@ class ClientConnectionManagerTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn($promise);
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
 
         $ret = $connectionManager->connect(new Uri('https://reactphp.org/'));
+
+        assert($ret instanceof PromiseInterface);
         $this->assertSame($promise, $ret);
     }
 
@@ -27,7 +32,9 @@ class ClientConnectionManagerTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('reactphp.org:80')->willReturn($promise);
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
 
         $ret = $connectionManager->connect(new Uri('http://reactphp.org/'));
         $this->assertSame($promise, $ret);
@@ -39,7 +46,9 @@ class ClientConnectionManagerTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('reactphp.org:8080')->willReturn($promise);
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
 
         $ret = $connectionManager->connect(new Uri('http://reactphp.org:8080/'));
         $this->assertSame($promise, $ret);
@@ -50,7 +59,9 @@ class ClientConnectionManagerTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->never())->method('connect');
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
 
         $promise = $connectionManager->connect(new Uri('ftp://reactphp.org/'));
 
@@ -68,7 +79,9 @@ class ClientConnectionManagerTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->never())->method('connect');
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
 
         $promise = $connectionManager->connect(new Uri('reactphp.org'));
 
@@ -81,15 +94,296 @@ class ClientConnectionManagerTest extends TestCase
         $this->assertEquals('Invalid request URL given', $exception->getMessage());
     }
 
-    public function testHandBackWillCloseGivenConnectionUntilKeepAliveIsActuallySupported()
+    public function testConnectReusesIdleConnectionFromPreviousKeepAliveCallWithoutUsingConnectorAndWillAddAndRemoveStreamEventsAndAddAndCancelIdleTimer()
     {
+        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $streamHandler = null;
+        $connectionToReuse->expects($this->exactly(3))->method('on')->withConsecutive(
+            array(
+                'close',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    $streamHandler = $cb;
+                    return true;
+                })
+            ),
+            array(
+                'data',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            ),
+            array(
+                'error',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            )
+        );
+
+        $connectionToReuse->expects($this->exactly(3))->method('removeListener')->withConsecutive(
+            array(
+                'close',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            ),
+            array(
+                'data',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            ),
+            array(
+                'error',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            )
+        );
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->never())->method('connect');
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $connectionToReuse);
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        assert($promise instanceof PromiseInterface);
+
+        $connection = null;
+        $promise->then(function ($value) use (&$connection) {
+            $connection = $value;
+        });
+
+        $this->assertSame($connectionToReuse, $connection);
+    }
+
+    public function testConnectReusesIdleConnectionFromPreviousKeepAliveCallWithoutUsingConnectorAlsoWhenUriPathAndQueryAndFragmentIsDifferent()
+    {
+        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->never())->method('connect');
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/http?foo#bar'), $connectionToReuse);
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/http/'));
+        assert($promise instanceof PromiseInterface);
+
+        $connection = null;
+        $promise->then(function ($value) use (&$connection) {
+            $connection = $value;
+        });
+
+        $this->assertSame($connectionToReuse, $connection);
+    }
+
+    public function testConnectUsesConnectorWithSameUriAndReturnsPromiseForNewConnectionFromConnectorWhenPreviousKeepAliveCallUsedDifferentUri()
+    {
+        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $promise = new Promise(function () { });
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn($promise);
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('http://reactphp.org/'), $connectionToReuse);
+
+        $ret = $connectionManager->connect(new Uri('https://reactphp.org/'));
+
+        assert($ret instanceof PromiseInterface);
+        $this->assertSame($promise, $ret);
+    }
+
+    public function testConnectUsesConnectorForNewConnectionWhenPreviousConnectReusedIdleConnectionFromPreviousKeepAliveCall()
+    {
+        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $firstConnection);
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        assert($promise instanceof PromiseInterface);
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        assert($promise instanceof PromiseInterface);
+
+        $connection = null;
+        $promise->then(function ($value) use (&$connection) {
+            $connection = $value;
+        });
+
+        $this->assertSame($secondConnection, $connection);
+    }
+
+    public function testKeepAliveAddsTimerAndDoesNotCloseConnectionImmediately()
+    {
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection->expects($this->never())->method('close');
+
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
 
-        $connectionManager = new ClientConnectionManager($connector);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything());
 
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $connection);
+    }
+
+    public function testKeepAliveClosesConnectionAfterIdleTimeout()
+    {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('close');
 
-        $connectionManager->handBack($connection);
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $timerCallback = null;
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timerCallback) {
+            $timerCallback = $cb;
+            return true;
+        }))->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $connection);
+
+        // manually invoker timer function to emulate time has passed
+        $this->assertNotNull($timerCallback);
+        call_user_func($timerCallback); // $timerCallback() (PHP 5.4+)
+    }
+
+    public function testConnectUsesConnectorForNewConnectionWhenIdleConnectionFromPreviousKeepAliveCallHasAlreadyTimedOut()
+    {
+        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $firstConnection->expects($this->once())->method('close');
+
+        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $secondConnection->expects($this->never())->method('close');
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+
+        $timerCallback = null;
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timerCallback) {
+            $timerCallback = $cb;
+            return true;
+        }))->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $firstConnection);
+
+        // manually invoker timer function to emulate time has passed
+        $this->assertNotNull($timerCallback);
+        call_user_func($timerCallback); // $timerCallback() (PHP 5.4+)
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        assert($promise instanceof PromiseInterface);
+
+        $connection = null;
+        $promise->then(function ($value) use (&$connection) {
+            $connection = $value;
+        });
+
+        $this->assertSame($secondConnection, $connection);
+    }
+
+    public function testConnectUsesConnectorForNewConnectionWhenIdleConnectionFromPreviousKeepAliveCallHasAlreadyFiredUnexpectedStreamEventBeforeIdleTimeoutThatClosesConnection()
+    {
+        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $firstConnection->expects($this->once())->method('close');
+
+        $streamHandler = null;
+        $firstConnection->expects($this->exactly(3))->method('on')->withConsecutive(
+            array(
+                'close',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    $streamHandler = $cb;
+                    return true;
+                })
+            ),
+            array(
+                'data',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            ),
+            array(
+                'error',
+                $this->callback(function ($cb) use (&$streamHandler) {
+                    assert($streamHandler instanceof \Closure);
+                    return $cb === $streamHandler;
+                })
+            )
+        );
+
+        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $secondConnection->expects($this->never())->method('close');
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $connectionManager = new ClientConnectionManager($connector, $loop);
+
+        $connectionManager->keepAlive(new Uri('https://reactphp.org/'), $firstConnection);
+
+        // manually invoke connection close to emulate server closing idle connection before idle timeout
+        $this->assertNotNull($streamHandler);
+        call_user_func($streamHandler); // $streamHandler() (PHP 5.4+)
+
+        $promise = $connectionManager->connect(new Uri('https://reactphp.org/'));
+        assert($promise instanceof PromiseInterface);
+
+        $connection = null;
+        $promise->then(function ($value) use (&$connection) {
+            $connection = $value;
+        });
+
+        $this->assertSame($secondConnection, $connection);
     }
 }

--- a/tests/Io/ClientRequestStreamTest.php
+++ b/tests/Io/ClientRequestStreamTest.php
@@ -488,7 +488,7 @@ class ClientRequestStreamTest extends TestCase
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
-        $connectionManager->expects($this->once())->method('handBack')->with($connection);
+        $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
         $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -569,7 +569,7 @@ class ClientRequestStreamTest extends TestCase
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
-        $connectionManager->expects($this->once())->method('handBack')->with($connection);
+        $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -590,7 +590,7 @@ class ClientRequestStreamTest extends TestCase
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
-        $connectionManager->expects($this->once())->method('handBack')->with($connection);
+        $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'FOO, KEEP-ALIVE, BAR'), '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -681,7 +681,7 @@ class ClientRequestStreamTest extends TestCase
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
-        $connectionManager->expects($this->once())->method('handBack')->with($connection);
+        $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
         $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);

--- a/tests/Io/ClientRequestStreamTest.php
+++ b/tests/Io/ClientRequestStreamTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ResponseInterface;
+use RingCentral\Psr7\Uri;
 use React\Http\Io\ClientRequestStream;
 use React\Http\Message\Request;
 use React\Promise\Deferred;
@@ -13,26 +14,17 @@ use React\Tests\Http\TestCase;
 
 class ClientRequestStreamTest extends TestCase
 {
-    private $connector;
-
-    /**
-     * @before
-     */
-    public function setUpStream()
-    {
-        $this->connector = $this->getMockBuilder('React\Socket\ConnectorInterface')
-            ->getMock();
-    }
-
     /** @test */
-    public function requestShouldBindToStreamEventsAndUseconnector()
+    public function testRequestShouldUseConnectionManagerWithUriFromRequestAndBindToStreamEvents()
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $uri = new Uri('http://www.example.com');
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->with($uri)->willReturn(\React\Promise\resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $requestData = new Request('GET', $uri);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $connection->expects($this->atLeast(5))->method('on')->withConsecutive(
             array('drain', $this->identicalTo(array($request, 'handleDrain'))),
@@ -57,26 +49,14 @@ class ClientRequestStreamTest extends TestCase
         $request->handleData("\r\nbody");
     }
 
-    /**
-     * @test
-     */
-    public function requestShouldConnectViaTlsIfUrlUsesHttpsScheme()
-    {
-        $this->connector->expects($this->once())->method('connect')->with('tls://www.example.com:443')->willReturn(new Promise(function () { }));
-
-        $requestData = new Request('GET', 'https://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
-
-        $request->end();
-    }
-
     /** @test */
     public function requestShouldEmitErrorIfConnectionFails()
     {
-        $this->connector->expects($this->once())->method('connect')->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\reject(new \RuntimeException()));
 
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
         $request->on('close', $this->expectCallableOnce());
@@ -89,10 +69,11 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
         $request->on('close', $this->expectCallableOnce());
@@ -106,10 +87,11 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('Exception')));
         $request->on('close', $this->expectCallableOnce());
@@ -123,10 +105,11 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('InvalidArgumentException')));
         $request->on('close', $this->expectCallableOnce());
@@ -135,48 +118,17 @@ class ClientRequestStreamTest extends TestCase
         $request->handleData("\r\n\r\n");
     }
 
-    /**
-     * @test
-     */
-    public function requestShouldEmitErrorIfUrlIsInvalid()
-    {
-        $this->connector->expects($this->never())->method('connect');
-
-        $requestData = new Request('GET', 'ftp://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
-
-        $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('InvalidArgumentException')));
-        $request->on('close', $this->expectCallableOnce());
-
-        $request->end();
-    }
-
-    /**
-     * @test
-     */
-    public function requestShouldEmitErrorIfUrlHasNoScheme()
-    {
-        $this->connector->expects($this->never())->method('connect');
-
-        $requestData = new Request('GET', 'www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
-
-        $request->on('error', $this->expectCallableOnceWith($this->isInstanceOf('InvalidArgumentException')));
-        $request->on('close', $this->expectCallableOnce());
-
-        $request->end();
-    }
-
     /** @test */
     public function getRequestShouldSendAGetRequest()
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.0\r\nHost: www.example.com\r\n\r\n");
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
     }
@@ -187,10 +139,11 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
     }
@@ -201,11 +154,12 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('write')->with("OPTIONS * HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('OPTIONS', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
         $requestData = $requestData->withRequestTarget('*');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
     }
@@ -216,10 +170,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -240,10 +195,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -264,10 +220,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -288,10 +245,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("HEAD / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('HEAD', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -312,10 +270,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -336,10 +295,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->never())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -360,10 +320,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->never())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -384,10 +345,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->once())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -408,10 +370,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->never())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -432,10 +395,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->never())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -456,10 +420,11 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
         $connection->expects($this->never())->method('close');
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -492,10 +457,11 @@ class ClientRequestStreamTest extends TestCase
             return true;
         }));
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $that = $this;
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
@@ -519,10 +485,11 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('write')->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome post data$#"));
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end('some post data');
 
@@ -541,10 +508,11 @@ class ClientRequestStreamTest extends TestCase
             array($this->identicalTo("data"))
         );
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->write("some");
         $request->write("post");
@@ -567,10 +535,11 @@ class ClientRequestStreamTest extends TestCase
         );
 
         $deferred = new Deferred();
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn($deferred->promise());
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn($deferred->promise());
 
         $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $this->assertFalse($request->write("some"));
         $this->assertFalse($request->write("post"));
@@ -604,10 +573,11 @@ class ClientRequestStreamTest extends TestCase
         );
 
         $deferred = new Deferred();
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn($deferred->promise());
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn($deferred->promise());
 
         $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $this->assertFalse($request->write("some"));
         $this->assertFalse($request->write("post"));
@@ -636,10 +606,11 @@ class ClientRequestStreamTest extends TestCase
             array($this->identicalTo("data"))
         );
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $loop = $this
             ->getMockBuilder('React\EventLoop\LoopInterface')
@@ -663,13 +634,11 @@ class ClientRequestStreamTest extends TestCase
      */
     public function writeShouldStartConnecting()
     {
-        $this->connector->expects($this->once())
-                        ->method('connect')
-                        ->with('www.example.com:80')
-                        ->willReturn(new Promise(function () { }));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(new Promise(function () { }));
 
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->write('test');
     }
@@ -679,10 +648,11 @@ class ClientRequestStreamTest extends TestCase
      */
     public function endShouldStartConnectingAndChangeStreamIntoNonWritableMode()
     {
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(new Promise(function () { }));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(new Promise(function () { }));
 
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
 
@@ -694,8 +664,10 @@ class ClientRequestStreamTest extends TestCase
      */
     public function closeShouldEmitCloseEvent()
     {
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
         $request->close();
@@ -706,8 +678,10 @@ class ClientRequestStreamTest extends TestCase
      */
     public function writeAfterCloseReturnsFalse()
     {
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->close();
 
@@ -720,10 +694,11 @@ class ClientRequestStreamTest extends TestCase
      */
     public function endAfterCloseIsNoOp()
     {
-        $this->connector->expects($this->never())->method('connect');
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->never())->method('connect');
 
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->close();
         $request->end();
@@ -737,10 +712,11 @@ class ClientRequestStreamTest extends TestCase
         $promise = new Promise(function () {}, function () {
             throw new \RuntimeException();
         });
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn($promise);
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn($promise);
 
         $requestData = new Request('POST', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
 
@@ -754,8 +730,10 @@ class ClientRequestStreamTest extends TestCase
     /** @test */
     public function requestShouldRemoveAllListenerAfterClosed()
     {
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', function () {});
         $this->assertCount(1, $request->listeners('close'));
@@ -769,10 +747,11 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
-        $this->connector->expects($this->once())->method('connect')->with('www.example.com:80')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
+        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
-        $request = new ClientRequestStream($this->connector, $requestData);
+        $request = new ClientRequestStream($connectionManager, $requestData);
 
         $response = null;
         $request->on('response', $this->expectCallableOnce());

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -291,62 +291,6 @@ class SenderTest extends TestCase
     }
 
     /** @test */
-    public function getHttp10RequestShouldSendAGetRequestWithoutConnectionHeaderByDefault()
-    {
-        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
-        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
-            return !$request->hasHeader('Connection');
-        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
-
-        $sender = new Sender($client);
-
-        $request = new Request('GET', 'http://www.example.com', array(), '', '1.0');
-        $sender->send($request);
-    }
-
-    /** @test */
-    public function getHttp10RequestShouldSendAGetRequestWithoutConnectionHeaderEvenWhenConnectionKeepAliveHeaderIsSpecified()
-    {
-        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
-        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
-            return !$request->hasHeader('Connection');
-        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
-
-        $sender = new Sender($client);
-
-        $request = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.0');
-        $sender->send($request);
-    }
-
-    /** @test */
-    public function getHttp11RequestShouldSendAGetRequestWithConnectionCloseHeaderByDefault()
-    {
-        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
-        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
-            return $request->getHeaderLine('Connection') === 'close';
-        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
-
-        $sender = new Sender($client);
-
-        $request = new Request('GET', 'http://www.example.com', array(), '', '1.1');
-        $sender->send($request);
-    }
-
-    /** @test */
-    public function getHttp11RequestShouldSendAGetRequestWithConnectionCloseHeaderEvenWhenConnectionKeepAliveHeaderIsSpecified()
-    {
-        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
-        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
-            return $request->getHeaderLine('Connection') === 'close';
-        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
-
-        $sender = new Sender($client);
-
-        $request = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.1');
-        $sender->send($request);
-    }
-
-    /** @test */
     public function getRequestWithUserAndPassShouldSendAGetRequestWithBasicAuthorizationHeader()
     {
         $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -14,11 +14,20 @@ use React\Tests\Http\TestCase;
 
 class SenderTest extends TestCase
 {
+    /** @var \React\EventLoop\LoopInterface */
+    private $loop;
+
+    /**
+     * @before
+     */
+    public function setUpLoop()
+    {
+        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+    }
+
     public function testCreateFromLoop()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-
-        $sender = Sender::createFromLoop($loop, null);
+        $sender = Sender::createFromLoop($this->loop, null);
 
         $this->assertInstanceOf('React\Http\Io\Sender', $sender);
     }
@@ -28,7 +37,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->never())->method('connect');
 
-        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector, $this->loop)));
 
         $request = new Request('GET', 'www.google.com');
 
@@ -47,7 +56,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\reject(new \RuntimeException('Rejected')));
 
-        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector, $this->loop)));
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -374,7 +383,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn($promise);
 
-        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector, $this->loop)));
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -397,7 +406,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($connection));
 
-        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector, $this->loop)));
 
         $request = new Request('GET', 'http://www.google.com/');
 

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\RequestInterface;
 use React\Http\Client\Client as HttpClient;
+use React\Http\Io\ClientConnectionManager;
 use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
 use React\Http\Message\Request;
@@ -13,19 +14,11 @@ use React\Tests\Http\TestCase;
 
 class SenderTest extends TestCase
 {
-    private $loop;
-
-    /**
-     * @before
-     */
-    public function setUpLoop()
-    {
-        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-    }
-
     public function testCreateFromLoop()
     {
-        $sender = Sender::createFromLoop($this->loop, null);
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $sender = Sender::createFromLoop($loop, null);
 
         $this->assertInstanceOf('React\Http\Io\Sender', $sender);
     }
@@ -35,7 +28,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->never())->method('connect');
 
-        $sender = new Sender(new HttpClient($this->loop, $connector));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
 
         $request = new Request('GET', 'www.google.com');
 
@@ -54,7 +47,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\reject(new \RuntimeException('Rejected')));
 
-        $sender = new Sender(new HttpClient($this->loop, $connector));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -381,7 +374,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn($promise);
 
-        $sender = new Sender(new HttpClient($this->loop, $connector));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
 
         $request = new Request('GET', 'http://www.google.com/');
 
@@ -404,7 +397,7 @@ class SenderTest extends TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($connection));
 
-        $sender = new Sender(new HttpClient($this->loop, $connector));
+        $sender = new Sender(new HttpClient(new ClientConnectionManager($connector)));
 
         $request = new Request('GET', 'http://www.google.com/');
 


### PR DESCRIPTION
This changeset adds optional support for HTTP keep-alive for the HTTP client (reusing persistent connections). This offers significant performance improvements when sending many requests to the same host as it avoids recreating the underlying TCP/IP connection and repeating the TLS handshake for secure HTTPS requests.

This improvement is especially noticeable when queuing many requests to the same host as discussed in https://github.com/reactphp/http#concurrency or following HTTP redirects on the same host. Depending on your network speed to the host, this may show anywhere from a few percent to 300% faster responses, but you're invited to run your own benchmarks and share your results!

**HTTP keep-alive is currently disabled by default** to not affect existing deployments and can easily be enabled like this:

```php
$browser = new React\Http\Browser();

// remove default `Connection: close` request header to enable HTTP keep-alive
$browser = $browser->withoutHeader('Connection');

$response = React\Async\await($browser->get('https://httpbingo.org/redirect/6'));
assert($response instanceof Psr\Http\Message\ResponseInterface);
```

There are future plans to enable HTTP keep-alive by default, but I'd like to get some feedback on this feature first before enabling this in a future version. Additionally, idle connections will currently only be kept alive for a maximum of 1ms between requests to make sure consumers of this library will not be affected negatively. By using a very short timeout period, the loop does not keep running noticeably longer than without this feature. This doesn't matter for long running scripts, but it's important for short running scripts to not appear to be "blocked". In the future, we should give more control over this timeout to allow reusing connections also for common use cases of periodically polling hosts using a longer interval. On top of this, we may want to introduce functions to explicitly soft-close and/or hard-close (idle) connections.

Applying these changes required a significant refactoring of the existing logic first. This does not otherwise affect the public `React\Http\Browser` class or any other public APIs, so this should be safe to apply. In particular, this changeset should not affect existing behavior if you do not change the `Connection` request header. The test suite confirms this has 100% code coverage and does not otherwise affect our public APIs.

Together with the preparations for this feature in #484, #482, #481, #480 and others you're looking at several weeks(!) of work, so I think this might be one of the largest feature additions in ReactPHP lately, enjoy! Special thanks to our sponsors for making this possible! If you'd like to support this development, consider [sponsoring ReactPHP](https://github.com/sponsors/reactphp)! ❤️

Builds on top of #484, #482, #481, #480 and others
Resolves #468 (HTTP keep-alive)
Also refs #376 (future support for HTTP upgrades)