### PR TITLE
Template params can only have one argument

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -344,7 +344,7 @@ class Browser
      * @param string                         $url      URL for the request
      * @param array                          $headers  Additional request headers
      * @param string|ReadableStreamInterface $body     HTTP request body contents
-     * @return PromiseInterface<ResponseInterface,\Exception>
+     * @return PromiseInterface<ResponseInterface>
      */
     public function request($method, $url, array $headers = array(), $body = '')
     {
@@ -417,7 +417,7 @@ class Browser
      * @param string                         $url      URL for the request
      * @param array                          $headers  Additional request headers
      * @param string|ReadableStreamInterface $body     HTTP request body contents
-     * @return PromiseInterface<ResponseInterface,\Exception>
+     * @return PromiseInterface<ResponseInterface>
      */
     public function requestStreaming($method, $url, $headers = array(), $body = '')
     {
@@ -828,7 +828,7 @@ class Browser
      * @param string                         $url
      * @param array                          $headers
      * @param string|ReadableStreamInterface $body
-     * @return PromiseInterface<ResponseInterface,\Exception>
+     * @return PromiseInterface<ResponseInterface>
      */
     private function requestMayBeStreaming($method, $url, array $headers = array(), $body = '')
     {


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223