### PR TITLE
Add Browser middleware

### DIFF
--- a/src/Browser/MiddlewareInterface.php
+++ b/src/Browser/MiddlewareInterface.php
@@ -11,7 +11,7 @@ interface MiddlewareInterface
     /**
      * @param RequestInterface $request
      * @param callable $next
-     * @return PromiseInterface<ResponseInterface>
+     * @return PromiseInterface<ResponseInterface>|ResponseInterface
      */
     public function __invoke(RequestInterface $request, callable $next);
 }

--- a/src/Browser/MiddlewareInterface.php
+++ b/src/Browser/MiddlewareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace React\Http\Browser;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+interface MiddlewareInterface
+{
+    /**
+     * @param RequestInterface $request
+     * @param callable $next
+     * @return PromiseInterface<ResponseInterface>
+     */
+    public function __invoke(RequestInterface $request, callable $next);
+}

--- a/src/Browser/MiddlewareRunner.php
+++ b/src/Browser/MiddlewareRunner.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace React\Http\Browser;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Http\Io\Transaction;
+use React\Promise\PromiseInterface;
+
+/**
+ * [Internal] Middleware runner to expose an array of middleware request handlers as a single request handler callable
+ *
+ * @internal
+ */
+final class MiddlewareRunner
+{
+    /** @var MiddlewareInterface[] */
+    private $middleware;
+
+    /** @var Transaction */
+    private $transaction;
+
+    /**
+     * @param MiddlewareInterface[] $middleware
+     */
+    public function __construct(array $middleware, Transaction $transaction)
+    {
+        $this->middleware = \array_values($middleware);
+        $this->transaction = $transaction;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return ResponseInterface|PromiseInterface<ResponseInterface>
+     * @throws \Exception
+     */
+    public function __invoke(RequestInterface $request)
+    {
+        return $this->call($request, 0);
+    }
+
+    /** @internal */
+    public function call(RequestInterface $request, $position)
+    {
+        if (count($this->middleware) === 0) {
+            return $this->transaction->send($request);
+        }
+
+        // final request handler will be invoked with transaction send callable
+        if (!isset($this->middleware[$position + 1])) {
+            $handler = $this->middleware[$position];
+            $that = $this;
+            return $handler($request, function () use ($that, $request) {
+                return $that->transaction->send($request);
+            });
+        }
+
+        $that = $this;
+        $next = function (RequestInterface $request) use ($that, $position) {
+            return $that->call($request, $position + 1);
+        };
+
+        // invoke middleware request handler with next handler
+        $handler = $this->middleware[$position];
+        return $handler($request, $next);
+    }
+}

--- a/tests/Browser/MiddlewareRunnerTest.php
+++ b/tests/Browser/MiddlewareRunnerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace React\Tests\Http\Browser;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use React\Http\Browser\MiddlewareRunner;
+use React\Http\Io\Transaction;
+use React\Http\Message\Request;
+use React\Http\Message\ServerRequest;
+use React\Tests\Http\BrowserMiddlewareStub;
+use React\Tests\Http\TestCase;
+use RingCentral\Psr7\Response;
+
+final class MiddlewareRunnerTest extends TestCase
+{
+    public function testEmptyMiddlewareStack()
+    {
+        $request = new Request('GET', 'https://example.com/');
+
+        /** @var Transaction&MockObject $transaction */
+        $transaction = $this->createMock(Transaction::class);
+        $response = new Response();
+        $transaction->expects(static::once())->method('send')->with($request)->willReturn($response);
+
+        $middlewares = array();
+        $middlewareStack = new MiddlewareRunner($middlewares, $transaction);
+
+        $actualResponse = $middlewareStack($request);
+        $this->assertSame($response, $actualResponse);
+    }
+
+    public function testWithMiddleware()
+    {
+        /** @var Transaction&MockObject $transaction */
+        $transaction = $this->createMock(Transaction::class);
+        $transaction->expects(static::never())->method('send');
+
+        $response = new Response();
+        $middlewareStack = new MiddlewareRunner(array(
+            new BrowserMiddlewareStub($response)
+        ), $transaction);
+
+        $request = new ServerRequest('GET', 'http://example.com/');
+
+        $actualResponse = $middlewareStack($request);
+        $this->assertSame($response, $actualResponse);
+    }
+}

--- a/tests/Browser/MiddlewareRunnerTest.php
+++ b/tests/Browser/MiddlewareRunnerTest.php
@@ -18,7 +18,9 @@ final class MiddlewareRunnerTest extends TestCase
         $request = new Request('GET', 'https://example.com/');
 
         /** @var Transaction&MockObject $transaction */
-        $transaction = $this->createMock('\React\Http\Io\Transaction');
+        $transaction = $this->getMockBuilder('\React\Http\Io\Transaction')
+            ->disableOriginalConstructor()
+            ->getMock();
         $response = new Response();
         $transaction->expects(static::once())->method('send')->with($request)->willReturn($response);
 
@@ -32,7 +34,9 @@ final class MiddlewareRunnerTest extends TestCase
     public function testWithMiddleware()
     {
         /** @var Transaction&MockObject $transaction */
-        $transaction = $this->createMock('\React\Http\Io\Transaction');
+        $transaction = $this->getMockBuilder('\React\Http\Io\Transaction')
+            ->disableOriginalConstructor()
+            ->getMock();
         $transaction->expects(static::never())->method('send');
 
         $response = new Response();

--- a/tests/Browser/MiddlewareRunnerTest.php
+++ b/tests/Browser/MiddlewareRunnerTest.php
@@ -18,7 +18,7 @@ final class MiddlewareRunnerTest extends TestCase
         $request = new Request('GET', 'https://example.com/');
 
         /** @var Transaction&MockObject $transaction */
-        $transaction = $this->createMock(Transaction::class);
+        $transaction = $this->createMock('\React\Http\Io\Transaction');
         $response = new Response();
         $transaction->expects(static::once())->method('send')->with($request)->willReturn($response);
 
@@ -32,7 +32,7 @@ final class MiddlewareRunnerTest extends TestCase
     public function testWithMiddleware()
     {
         /** @var Transaction&MockObject $transaction */
-        $transaction = $this->createMock(Transaction::class);
+        $transaction = $this->createMock('\React\Http\Io\Transaction');
         $transaction->expects(static::never())->method('send');
 
         $response = new Response();

--- a/tests/BrowserMiddlewareStub.php
+++ b/tests/BrowserMiddlewareStub.php
@@ -5,6 +5,7 @@ namespace React\Tests\Http;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Browser\MiddlewareInterface;
+use React\Promise\PromiseInterface;
 
 final class BrowserMiddlewareStub implements MiddlewareInterface
 {
@@ -16,6 +17,11 @@ final class BrowserMiddlewareStub implements MiddlewareInterface
         $this->response = $response;
     }
 
+    /**
+     * @param RequestInterface $request
+     * @param callable $next
+     * @return PromiseInterface<ResponseInterface>|ResponseInterface
+     */
     public function __invoke(RequestInterface $request, callable $next)
     {
         return $this->response;

--- a/tests/BrowserMiddlewareStub.php
+++ b/tests/BrowserMiddlewareStub.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace React\Tests\Http;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Http\Browser\MiddlewareInterface;
+
+final class BrowserMiddlewareStub implements MiddlewareInterface
+{
+    /** @var ResponseInterface */
+    private $response;
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    public function __invoke(RequestInterface $request, callable $next)
+    {
+        return $this->response;
+    }
+}


### PR DESCRIPTION
Inspired by [Guzzle middlewares](https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html#middleware) I added a middleware system to the Browser component.
I took the already existing \React\Http\Io\MiddlewareRunner as an example for this.

Example usage:
```
class MyCustomMiddleware implements \React\Http\Browser\MiddlewareInterface
{
  public function __invoke(RequestInterface $request, callable $next)
  {
    return $next($request->withHeader('X-Foo', 'Bar')); // I know this is also possible another way, but just as a demo
  }
}

$client = (new Browser())->withMiddleware(new MyCustomMiddleware());
$client->get('https://example.com/api/v1/demo');
```

My concrete use case right now is that I want to keep track of the last request for advanced logging. I do this by storing request information in a custom middleware.

Please let me know what you think and if I should apply some changes to my code in order for this to get merged :)