### PR TITLE
Request in exception

### DIFF
--- a/src/Io/Transaction.php
+++ b/src/Io/Transaction.php
@@ -246,7 +246,7 @@ class Transaction
 
         // only status codes 200-399 are considered to be valid, reject otherwise
         if ($this->obeySuccessCode && ($response->getStatusCode() < 200 || $response->getStatusCode() >= 400)) {
-            throw new ResponseException($response);
+            throw new ResponseException($response, $request);
         }
 
         // resolve our initial promise

--- a/src/Message/ResponseException.php
+++ b/src/Message/ResponseException.php
@@ -2,6 +2,7 @@
 
 namespace React\Http\Message;
 
+use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Message/ResponseException.php
+++ b/src/Message/ResponseException.php
@@ -18,8 +18,15 @@ final class ResponseException extends RuntimeException
 {
     private $response;
 
-    public function __construct(ResponseInterface $response, $message = null, $code = null, $previous = null)
-    {
+    private $request;
+
+    public function __construct(
+        ResponseInterface $response,
+        RequestInterface $request,
+        $message = null,
+        $code = null,
+        $previous = null
+    ) {
         if ($message === null) {
             $message = 'HTTP status code ' . $response->getStatusCode() . ' (' . $response->getReasonPhrase() . ')';
         }
@@ -29,6 +36,7 @@ final class ResponseException extends RuntimeException
         parent::__construct($message, $code, $previous);
 
         $this->response = $response;
+        $this->request = $request;
     }
 
     /**
@@ -39,5 +47,13 @@ final class ResponseException extends RuntimeException
     public function getResponse()
     {
         return $this->response;
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
     }
 }

--- a/tests/Message/ResponseExceptionTest.php
+++ b/tests/Message/ResponseExceptionTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Http\Message;
 
 use React\Http\Message\ResponseException;
 use PHPUnit\Framework\TestCase;
+use RingCentral\Psr7\Request;
 use RingCentral\Psr7\Response;
 
 class ResponseExceptionTest extends TestCase
@@ -11,13 +12,15 @@ class ResponseExceptionTest extends TestCase
     public function testCtorDefaults()
     {
         $response = new Response();
+        $request = new Request('get', 'https://example.com/');
         $response = $response->withStatus(404, 'File not found');
 
-        $e = new ResponseException($response);
+        $e = new ResponseException($response, $request);
 
         $this->assertEquals(404, $e->getCode());
         $this->assertEquals('HTTP status code 404 (File not found)', $e->getMessage());
 
         $this->assertSame($response, $e->getResponse());
+        $this->assertSame($request, $e->getRequest());
     }
 }


### PR DESCRIPTION
I added the request object to the ResponseException so it can be used for logging and debugging of errors is easier.

In theory this would be a major break, as the new constructor param is not optional.
Is this okay or should I maybe move it to the end and make it nullable?