### PR TITLE
Enable HTTP keep-alive by default for HTTP client

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -23,7 +23,6 @@ class Browser
     private $baseUrl;
     private $protocolVersion = '1.1';
     private $defaultHeaders = array(
-        'Connection' => 'close',
         'User-Agent' => 'ReactPHP/1'
     );
 

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -556,8 +556,6 @@ class BrowserTest extends TestCase
                 'user-Agent' => array('ABC'),
                 'another-header' => array('value'),
                 'custom-header' => array('data'),
-
-                'Connection' => array('close')
             );
 
             $that->assertEquals($expectedHeaders, $request->getHeaders());


### PR DESCRIPTION
This changeset enables HTTP keep-alive by default for the HTTP client. HTTP keep-alive (reusing persistent connections) offers significant performance improvements when sending many requests to the same host as it avoids recreating the underlying TCP/IP connection and repeating the TLS handshake for secure HTTPS requests.

**HTTP keep-alive is now enabled by default**. If you do not want to use HTTP keep-alive, you can disable this feature by sending a `Connection: close` HTTP request header or by using HTTP/1.0 like this:

```php
// not recommended: add `Connection: close` request header to disable HTTP keep-alive
$browser = $browser->withHeader('Connection', 'close');

// not recommended: use HTTP/1.0 to disable HTTP keep-alive
$browser = $browser->withProtocolVersion('1.0');
```

We've done some careful testing in PR #486 and our sophisticated test suite that covers tests against both well-behaving and misbehaving HTTP servers that might occur in the wild. On top of this, we've done some extensive tests in real-world applications in the past weeks after merging this feature. The test suite confirms this has 100% code coverage and does not otherwise affect our public APIs. If you encounter any issues with this in the wild, please confirm by disabling HTTP keep-alive and report a bug ticket in this case. If you'd like to support this development, consider [sponsoring ReactPHP](https://github.com/sponsors/reactphp)! ❤️

Builds on top of #486, #484 and others
Refs #488, #468 and others