### PR TITLE
Add Dynamic HTTP Status Code for JSON Responses in React\Http\Message\Response

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -141,11 +141,11 @@ final class Response extends Psr7Response implements StatusCodeInterface
      * ```
      *
      * @param mixed $data
-     * @param int $status
+     * @param int|null $status
      * @return self
      * @throws \InvalidArgumentException when encoding fails
      */
-    public static function json($data, $status = null)
+    public static function json($data, $status = self::STATUS_OK)
     {
         $json = @\json_encode(
             $data,

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -145,7 +145,7 @@ final class Response extends Psr7Response implements StatusCodeInterface
      * @return self
      * @throws \InvalidArgumentException when encoding fails
      */
-    public static function json($data, int $status = 200)
+    public static function json($data, $status = null)
     {
         $json = @\json_encode(
             $data,
@@ -160,7 +160,7 @@ final class Response extends Psr7Response implements StatusCodeInterface
             );
         }
 
-        return new self($status, array('Content-Type' => 'application/json'), $json . "\n");
+        return new self($status ? $status : self::STATUS_OK, array('Content-Type' => 'application/json'), $json . "\n");
     }
 
     /**

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -141,10 +141,11 @@ final class Response extends Psr7Response implements StatusCodeInterface
      * ```
      *
      * @param mixed $data
+     * @param int $status
      * @return self
      * @throws \InvalidArgumentException when encoding fails
      */
-    public static function json($data)
+    public static function json($data, int $status = 200)
     {
         $json = @\json_encode(
             $data,
@@ -159,7 +160,7 @@ final class Response extends Psr7Response implements StatusCodeInterface
             );
         }
 
-        return new self(self::STATUS_OK, array('Content-Type' => 'application/json'), $json . "\n");
+        return new self($status, array('Content-Type' => 'application/json'), $json . "\n");
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the React\Http\Message\Response class  by introducing the ability to set dynamic HTTP status codes for JSON responses.

This feature provides developers with the flexibility to adapt status codes based on contextual requirements.