### PR TITLE
Update PSR dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=5.3.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "fig/http-message-util": "^1.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.3 || ^1.2.1",
         "react/socket": "^1.12",


### PR DESCRIPTION
Allow usage of psr/http-message v2.0.

When using reactphp/http `composer outdated` shows:
```
psr/http-message 1.1   2.0   Common interface for HTTP messages
```
and `composer why psr/http-message` says:
```
react/http       v1.9.0     requires psr/http-message (^1.0)
ringcentral/psr7 1.3.0      requires psr/http-message (~1.0)
```
So as long as #485 is not resolved (and ringcentral/psr7 is not updated), this PR does not change anything. 

For compatibility concerns see [PSR Meta Document](https://www.php-fig.org/psr/psr-7/meta/#7-errata). The new version restriction still allows to use psr/http-message v1.0 and v1.1 if e.g. newer versions are not compatible with your PHP version, but it also allows to use v2.0.