### PR TITLE
HTTP client: Fix empty streaming request body, omit `Transfer-Encoding: chunked`

### DIFF
--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -90,7 +90,7 @@ class Sender
         } elseif ($size === 0 && \in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
             // only assign a "Content-Length: 0" request header if the body is expected for certain methods
             $request = $request->withHeader('Content-Length', '0');
-        } elseif ($body instanceof ReadableStreamInterface && $body->isReadable() && !$request->hasHeader('Content-Length')) {
+        } elseif ($body instanceof ReadableStreamInterface && $size !== 0 && $body->isReadable() && !$request->hasHeader('Content-Length')) {
             // use "Transfer-Encoding: chunked" when this is a streaming body and body size is unknown
             $request = $request->withHeader('Transfer-Encoding', 'chunked');
         } else {

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Http\Io;
 use Psr\Http\Message\RequestInterface;
 use React\Http\Client\Client as HttpClient;
 use React\Http\Io\ClientConnectionManager;
+use React\Http\Io\EmptyBodyStream;
 use React\Http\Io\ReadableBodyStream;
 use React\Http\Io\Sender;
 use React\Http\Message\Request;
@@ -261,6 +262,21 @@ class SenderTest extends TestCase
         $sender = new Sender($client);
 
         $request = new Request('GET', 'http://www.google.com/');
+        $sender->send($request);
+    }
+
+    public function testSendGetWithEmptyBodyStreamWillNotPassContentLengthOrTransferEncodingHeader()
+    {
+        $client = $this->getMockBuilder('React\Http\Client\Client')->disableOriginalConstructor()->getMock();
+        $client->expects($this->once())->method('request')->with($this->callback(function (RequestInterface $request) {
+            return !$request->hasHeader('Content-Length') && !$request->hasHeader('Transfer-Encoding');
+        }))->willReturn($this->getMockBuilder('React\Http\Io\ClientRequestStream')->disableOriginalConstructor()->getMock());
+
+        $sender = new Sender($client);
+
+        $body = new EmptyBodyStream();
+        $request = new Request('GET', 'http://www.google.com/', array(), $body);
+
         $sender->send($request);
     }
 


### PR DESCRIPTION
This changeset fixes sending an outgoing streaming request body that is known to be empty. In this case, we do not want to send a `Content-Length: 0` or `Transfer-Encoding: chunked`. Prior to this change, we would send a `Transfer-Encoding: chunked` header without ever sending an end chunk, thus never signalling the end of the request body stream to the HTTP server. In other words, the updated version is now compliant with https://www.rfc-editor.org/rfc/rfc9112.html.

Resolves #497