### PR TITLE
Refactor `Request` and `ServerRequest` classes to build on top of new PSR-7 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2642,8 +2642,7 @@ This is mostly used internally to represent each outgoing HTTP request
 message for the HTTP client implementation. Likewise, you can also use this
 class with other HTTP client implementations and for tests.
 
-> Internally, this implementation builds on top of an existing outgoing
-  request message and only adds support for streaming. This base class is
+> Internally, this implementation builds on top of a base class which is
   considered an implementation detail that may change in the future.
 
 #### ServerRequest

--- a/README.md
+++ b/README.md
@@ -2661,8 +2661,7 @@ This is mostly used internally to represent each incoming request message.
 Likewise, you can also use this class in test cases to test how your web
 application reacts to certain HTTP requests.
 
-> Internally, this implementation builds on top of an existing outgoing
-  request message and only adds required server methods. This base class is
+> Internally, this implementation builds on top of a base class which is
   considered an implementation detail that may change in the future.
 
 #### ResponseException

--- a/src/Io/AbstractRequest.php
+++ b/src/Io/AbstractRequest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace React\Http\Io;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use RingCentral\Psr7\Uri;
+
+/**
+ * [Internal] Abstract HTTP request base class (PSR-7)
+ *
+ * @internal
+ * @see RequestInterface
+ */
+abstract class AbstractRequest extends AbstractMessage implements RequestInterface
+{
+    /** @var ?string */
+    private $requestTarget;
+
+    /** @var string */
+    private $method;
+
+    /** @var UriInterface */
+    private $uri;
+
+    /**
+     * @param string $method
+     * @param string|UriInterface $uri
+     * @param array<string,string|string[]> $headers
+     * @param StreamInterface $body
+     * @param string unknown $protocolVersion
+     */
+    protected function __construct(
+        $method,
+        $uri,
+        array $headers,
+        StreamInterface $body,
+        $protocolVersion
+    ) {
+        if (\is_string($uri)) {
+            $uri = new Uri($uri);
+        } elseif (!$uri instanceof UriInterface) {
+            throw new \InvalidArgumentException(
+                'Argument #2 ($uri) expected string|Psr\Http\Message\UriInterface'
+            );
+        }
+
+        // assign default `Host` request header from URI unless already given explicitly
+        $host = $uri->getHost();
+        if ($host !== '') {
+            foreach ($headers as $name => $value) {
+                if (\strtolower($name) === 'host' && $value !== array()) {
+                    $host = '';
+                    break;
+                }
+            }
+            if ($host !== '') {
+                $port = $uri->getPort();
+                if ($port !== null && (!($port === 80 && $uri->getScheme() === 'http') || !($port === 443 && $uri->getScheme() === 'https'))) {
+                    $host .= ':' . $port;
+                }
+
+                $headers = array('Host' => $host) + $headers;
+            }
+        }
+
+        parent::__construct($protocolVersion, $headers, $body);
+
+        $this->method = $method;
+        $this->uri = $uri;
+    }
+
+    public function getRequestTarget()
+    {
+        if ($this->requestTarget !== null) {
+            return $this->requestTarget;
+        }
+
+        $target = $this->uri->getPath();
+        if ($target === '') {
+            $target = '/';
+        }
+        if (($query = $this->uri->getQuery()) !== '') {
+            $target .= '?' . $query;
+        }
+
+        return $target;
+    }
+
+    public function withRequestTarget($requestTarget)
+    {
+        if ((string) $requestTarget === $this->requestTarget) {
+            return $this;
+        }
+
+        $request = clone $this;
+        $request->requestTarget = (string) $requestTarget;
+
+        return $request;
+    }
+
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    public function withMethod($method)
+    {
+        if ((string) $method === $this->method) {
+            return $this;
+        }
+
+        $request = clone $this;
+        $request->method = (string) $method;
+
+        return $request;
+    }
+
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    public function withUri(UriInterface $uri, $preserveHost = false)
+    {
+        if ($uri === $this->uri) {
+            return $this;
+        }
+
+        $request = clone $this;
+        $request->uri = $uri;
+
+        $host = $uri->getHost();
+        $port = $uri->getPort();
+        if ($port !== null && $host !== '' && (!($port === 80 && $uri->getScheme() === 'http') || !($port === 443 && $uri->getScheme() === 'https'))) {
+            $host .= ':' . $port;
+        }
+
+        // update `Host` request header if URI contains a new host and `$preserveHost` is false
+        if ($host !== '' && (!$preserveHost || $request->getHeaderLine('Host') === '')) {
+            // first remove all headers before assigning `Host` header to ensure it always comes first
+            foreach (\array_keys($request->getHeaders()) as $name) {
+                $request = $request->withoutHeader($name);
+            }
+
+            // add `Host` header first, then all other original headers
+            $request = $request->withHeader('Host', $host);
+            foreach ($this->withoutHeader('Host')->getHeaders() as $name => $value) {
+                $request = $request->withHeader($name, $value);
+            }
+        }
+
+        return $request;
+    }
+}

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -5,10 +5,10 @@ namespace React\Http\Message;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use React\Http\Io\AbstractRequest;
 use React\Http\Io\BufferedBody;
 use React\Http\Io\ReadableBodyStream;
 use React\Stream\ReadableStreamInterface;
-use RingCentral\Psr7\Request as BaseRequest;
 
 /**
  * Respresents an outgoing HTTP request message.
@@ -22,13 +22,12 @@ use RingCentral\Psr7\Request as BaseRequest;
  * message for the HTTP client implementation. Likewise, you can also use this
  * class with other HTTP client implementations and for tests.
  *
- * > Internally, this implementation builds on top of an existing outgoing
- *   request message and only adds support for streaming. This base class is
+ * > Internally, this implementation builds on top of a base class which is
  *   considered an implementation detail that may change in the future.
  *
  * @see RequestInterface
  */
-final class Request extends BaseRequest implements RequestInterface
+final class Request extends AbstractRequest implements RequestInterface
 {
     /**
      * @param string                                         $method  HTTP method for the request.

--- a/tests/Io/AbstractRequestTest.php
+++ b/tests/Io/AbstractRequestTest.php
@@ -1,0 +1,449 @@
+<?php
+
+namespace React\Tests\Http\Io;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use React\Http\Io\AbstractRequest;
+use React\Tests\Http\TestCase;
+use RingCentral\Psr7\Uri;
+
+class RequestMock extends AbstractRequest
+{
+    /**
+     * @param string $method
+     * @param string|UriInterface $uri
+     * @param array<string,string|string[]> $headers
+     * @param StreamInterface $body
+     * @param string $protocolVersion
+     */
+    public function __construct(
+        $method,
+        $uri,
+        array $headers,
+        StreamInterface $body,
+        $protocolVersion
+    ) {
+        parent::__construct($method, $uri, $headers, $body, $protocolVersion);
+    }
+}
+
+class AbstractRequestTest extends TestCase
+{
+    public function testCtorWithInvalidUriThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new RequestMock(
+            'GET',
+            null,
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUri()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWithCustomHttpPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com:8080/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com:8080')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWithCustomPortHttpOnHttpsPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com:443/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com:443')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWithCustomPortHttpsOnHttpPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'https://example.com:80/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com:80')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWithoutDefaultHttpPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com:80/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWithoutDefaultHttpsPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'https://example.com:443/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriBeforeOtherHeadersExplicitlyGiven()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(
+                'User-Agent' => 'demo'
+            ),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com'), 'User-Agent' => array('demo')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromHeadersExplicitlyGiven()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://localhost/',
+            array(
+                'Host' => 'example.com:8080'
+            ),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com:8080')), $request->getHeaders());
+    }
+
+    public function testGetHeadersReturnsHostHeaderFromUriWhenHeadersExplicitlyGivenContainEmptyHostArray()
+    {
+        $request = new RequestMock(
+            'GET',
+            'https://example.com/',
+            array(
+                'Host' => array()
+            ),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+    }
+
+    public function testGetRequestTargetReturnsPathAndQueryFromUri()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/demo?name=Alice',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals('/demo?name=Alice', $request->getRequestTarget());
+    }
+
+    public function testGetRequestTargetReturnsSlashOnlyIfUriHasNoPathOrQuery()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertEquals('/', $request->getRequestTarget());
+    }
+
+    public function testGetRequestTargetReturnsRequestTargetInAbsoluteFormIfGivenExplicitly()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/demo?name=Alice',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+        $request = $request->withRequestTarget('http://example.com/demo?name=Alice');
+
+        $this->assertEquals('http://example.com/demo?name=Alice', $request->getRequestTarget());
+    }
+
+    public function testWithRequestTargetReturnsNewInstanceWhenRequestTargetIsChanged()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $new = $request->withRequestTarget('http://example.com/');
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://example.com/', $new->getRequestTarget());
+        $this->assertEquals('/', $request->getRequestTarget());
+    }
+
+    public function testWithRequestTargetReturnsSameInstanceWhenRequestTargetIsUnchanged()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+        $request = $request->withRequestTarget('/');
+
+        $new = $request->withRequestTarget('/');
+        $this->assertSame($request, $new);
+        $this->assertEquals('/', $request->getRequestTarget());
+    }
+
+    public function testWithMethodReturnsNewInstanceWhenMethodIsChanged()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $new = $request->withMethod('POST');
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('POST', $new->getMethod());
+        $this->assertEquals('GET', $request->getMethod());
+    }
+
+    public function testWithMethodReturnsSameInstanceWhenMethodIsUnchanged()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $new = $request->withMethod('GET');
+        $this->assertSame($request, $new);
+        $this->assertEquals('GET', $request->getMethod());
+    }
+
+    public function testGetUriReturnsUriInstanceGivenToCtor()
+    {
+        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+
+        $request = new RequestMock(
+            'GET',
+            $uri,
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $this->assertSame($uri, $request->getUri());
+    }
+
+    public function testGetUriReturnsUriInstanceForUriStringGivenToCtor()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = $request->getUri();
+        $this->assertInstanceOf('Psr\Http\Message\UriInterface', $uri);
+        $this->assertEquals('http://example.com/', (string) $uri);
+    }
+
+    public function testWithUriReturnsNewInstanceWhenUriIsChanged()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+        $new = $request->withUri($uri);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals($uri, $new->getUri());
+        $this->assertEquals('http://example.com/', (string) $request->getUri());
+    }
+
+    public function testWithUriReturnsSameInstanceWhenUriIsUnchanged()
+    {
+        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+
+        $request = new RequestMock(
+            'GET',
+            $uri,
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $new = $request->withUri($uri);
+        $this->assertSame($request, $new);
+        $this->assertEquals($uri, $request->getUri());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderChangedIfUriContainsHost()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = new Uri('http://localhost/');
+        $new = $request->withUri($uri);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://localhost/', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('localhost')), $new->getHeaders());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderChangedIfUriContainsHostWithCustomPort()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = new Uri('http://localhost:8080/');
+        $new = $request->withUri($uri);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://localhost:8080/', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('localhost:8080')), $new->getHeaders());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderAddedAsFirstHeaderBeforeOthersIfUriContainsHost()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(
+                'User-Agent' => 'test'
+            ),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+        $request = $request->withoutHeader('Host');
+
+        $uri = new Uri('http://localhost/');
+        $new = $request->withUri($uri);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://localhost/', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('localhost'), 'User-Agent' => array('test')), $new->getHeaders());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderUnchangedIfUriContainsNoHost()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = new Uri('/path');
+        $new = $request->withUri($uri);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('/path', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('example.com')), $new->getHeaders());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderUnchangedIfPreserveHostIsTrue()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+
+        $uri = new Uri('http://localhost/');
+        $new = $request->withUri($uri, true);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://localhost/', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('example.com')), $new->getHeaders());
+    }
+
+    public function testWithUriReturnsNewInstanceWithHostHeaderAddedAsFirstHeaderNoMatterIfPreserveHostIsTrue()
+    {
+        $request = new RequestMock(
+            'GET',
+            'http://example.com/',
+            array(
+                'User-Agent' => 'test'
+            ),
+            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            '1.1'
+        );
+        $request = $request->withoutHeader('Host');
+
+        $uri = new Uri('http://example.com/');
+        $new = $request->withUri($uri, true);
+
+        $this->assertNotSame($request, $new);
+        $this->assertEquals('http://example.com/', (string) $new->getUri());
+        $this->assertEquals(array('Host' => array('example.com'), 'User-Agent' => array('test')), $new->getHeaders());
+    }
+}

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -126,7 +126,7 @@ class StreamingServerTest extends TestCase
         $serverParams = $requestAssertion->getServerParams();
 
         $this->assertSame(1, $i);
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -159,7 +159,7 @@ class StreamingServerTest extends TestCase
         $serverParams = $requestAssertion->getServerParams();
 
         $this->assertSame(1, $i);
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -182,7 +182,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -204,7 +204,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -226,7 +226,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -248,7 +248,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -283,7 +283,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('*', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -316,7 +316,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:443', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -338,7 +338,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:443 HTTP/1.1\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:443', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -360,7 +360,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:80', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -382,7 +382,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:80', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -434,7 +434,7 @@ class StreamingServerTest extends TestCase
         $data = "GET /test HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://127.0.0.1/test', $requestAssertion->getUri());
@@ -455,7 +455,7 @@ class StreamingServerTest extends TestCase
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('http://example.com/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com/test', $requestAssertion->getUri());
@@ -477,7 +477,7 @@ class StreamingServerTest extends TestCase
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('http://example.com/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com/test', $requestAssertion->getUri());
@@ -511,7 +511,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('*', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com', $requestAssertion->getUri());
@@ -533,7 +533,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS http://example.com HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', array($data));
 
-        $this->assertInstanceOf('RingCentral\Psr7\Request', $requestAssertion);
+        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('http://example.com', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com', $requestAssertion->getUri());


### PR DESCRIPTION
This changeset refactors the `Request` and `ServerRequest` classes to build on top of a new PSR-7 implementation. This brings us one step closer to eventually replace the dated RingCentral implementation (#331) and eventually support PSR-7 v2 (#513). This is a purely internal change that comes with 100% code coverage and does not otherwise affect the public API, so it should be safe to apply.

This builds on top of the recent changes for the `Response` class (#518), but this time doesn't show a noticeable impact on performance during my benchmarks. As a consequence, I consider this mostly an internal refactoring only.

Once merged, I'll file follow-up PRs to refactor the `Uri` and internal parsing classes accordingly. If you enjoy this change and want to help us continue to ship more improvements, consider supporting this project, for example by [becoming a sponsor](https://github.com/sponsors/reactphp) ❤️

Builds on top of #518, #480, #170 and others