### PR TITLE
Drop leftover RingCentral PSR-7 dependency, use own PSR-7 implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.3 || ^1.2.1",
         "react/socket": "^1.12",
-        "react/stream": "^1.2",
-        "ringcentral/psr7": "^1.2"
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/http-proxy-react": "^1.8",

--- a/examples/01-client-get-request.php
+++ b/examples/01-client-get-request.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $client = new Browser();
 
 $client->get('http://google.com/')->then(function (ResponseInterface $response) {
-    var_dump($response->getHeaders(), (string)$response->getBody());
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/02-client-concurrent-requests.php
+++ b/examples/02-client-concurrent-requests.php
@@ -8,19 +8,19 @@ require __DIR__ . '/../vendor/autoload.php';
 $client = new Browser();
 
 $client->head('http://www.github.com/clue/http-react')->then(function (ResponseInterface $response) {
-    var_dump($response->getHeaders(), (string)$response->getBody());
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 
 $client->get('http://google.com/')->then(function (ResponseInterface $response) {
-    var_dump($response->getHeaders(), (string)$response->getBody());
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 
 $client->get('http://www.lueck.tv/psocksd')->then(function (ResponseInterface $response) {
-    var_dump($response->getHeaders(), (string)$response->getBody());
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/04-client-post-json.php
+++ b/examples/04-client-post-json.php
@@ -22,7 +22,7 @@ $client->post(
     ),
     json_encode($data)
 )->then(function (ResponseInterface $response) {
-    echo (string)$response->getBody();
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/05-client-put-xml.php
+++ b/examples/05-client-put-xml.php
@@ -19,7 +19,7 @@ $client->put(
     ),
     $xml->asXML()
 )->then(function (ResponseInterface $response) {
-    echo (string)$response->getBody();
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/11-client-http-proxy.php
+++ b/examples/11-client-http-proxy.php
@@ -25,7 +25,7 @@ $browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
-    echo RingCentral\Psr7\str($response);
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -25,7 +25,7 @@ $browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
-    echo RingCentral\Psr7\str($response);
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -21,7 +21,7 @@ $browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('https://www.google.com/')->then(function (ResponseInterface $response) {
-    echo RingCentral\Psr7\str($response);
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/14-client-unix-domain-sockets.php
+++ b/examples/14-client-unix-domain-sockets.php
@@ -4,7 +4,6 @@ use Psr\Http\Message\ResponseInterface;
 use React\Http\Browser;
 use React\Socket\FixedUriConnector;
 use React\Socket\UnixConnector;
-use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -18,7 +17,7 @@ $browser = new Browser($connector);
 
 // demo fetching HTTP headers (or bail out otherwise)
 $browser->get('http://localhost/info')->then(function (ResponseInterface $response) {
-    echo Psr7\str($response);
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/21-client-request-streaming-to-stdout.php
+++ b/examples/21-client-request-streaming-to-stdout.php
@@ -4,7 +4,6 @@ use React\Http\Browser;
 use Psr\Http\Message\ResponseInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableResourceStream;
-use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -22,7 +21,7 @@ $url = isset($argv[1]) ? $argv[1] : 'http://google.com/';
 $info->write('Requesting ' . $url . '…' . PHP_EOL);
 
 $client->requestStreaming('GET', $url)->then(function (ResponseInterface $response) use ($info, $out) {
-    $info->write('Received' . PHP_EOL . Psr7\str($response));
+    $info->write('Received ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase() . PHP_EOL);
 
     $body = $response->getBody();
     assert($body instanceof ReadableStreamInterface);

--- a/examples/22-client-stream-upload-from-stdin.php
+++ b/examples/22-client-stream-upload-from-stdin.php
@@ -3,7 +3,6 @@
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Browser;
 use React\Stream\ReadableResourceStream;
-use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -20,7 +19,7 @@ $url = isset($argv[1]) ? $argv[1] : 'https://httpbingo.org/post';
 echo 'Sending STDIN as POST to ' . $url . '…' . PHP_EOL;
 
 $client->post($url, array('Content-Type' => 'text/plain'), $in)->then(function (ResponseInterface $response) {
-    echo 'Received' . PHP_EOL . Psr7\str($response);
+    echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -28,7 +28,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     // left up as an exercise: use an HTTP client to send the outgoing request
     // and forward the incoming response to the original client request
     return React\Http\Message\Response::plaintext(
-        RingCentral\Psr7\str($outgoing)
+        $outgoing->getMethod() . ' ' . $outgoing->getRequestTarget() . ' HTTP/' . $outgoing->getProtocolVersion() . "\r\n\r\n" . (string) $outgoing->getBody()
     );
 });
 

--- a/examples/91-client-benchmark-download.php
+++ b/examples/91-client-benchmark-download.php
@@ -29,8 +29,7 @@ $client = new Browser();
 echo 'Requesting ' . $url . '…' . PHP_EOL;
 
 $client->requestStreaming('GET', $url)->then(function (ResponseInterface $response) {
-    echo 'Headers received' . PHP_EOL;
-    echo RingCentral\Psr7\str($response);
+    echo 'Received ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase() . PHP_EOL;
 
     $stream = $response->getBody();
     assert($stream instanceof ReadableStreamInterface);

--- a/src/Io/ClientRequestStream.php
+++ b/src/Io/ClientRequestStream.php
@@ -277,7 +277,8 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
      */
     public function hasMessageKeepAliveEnabled(MessageInterface $message)
     {
-        $connectionOptions = \RingCentral\Psr7\normalize_header(\strtolower($message->getHeaderLine('Connection')));
+        // @link https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1
+        $connectionOptions = \array_map('trim', \explode(',', \strtolower($message->getHeaderLine('Connection'))));
 
         if (\in_array('close', $connectionOptions, true)) {
             return false;

--- a/tests/Middleware/RequestBodyBufferMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyBufferMiddlewareTest.php
@@ -4,13 +4,13 @@ namespace React\Tests\Http\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\Loop;
+use React\Http\Io\BufferedBody;
 use React\Http\Io\HttpBodyStream;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
-use RingCentral\Psr7\BufferStream;
 
 final class RequestBodyBufferMiddlewareTest extends TestCase
 {
@@ -45,8 +45,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
     {
         $size = 1024;
         $body = str_repeat('x', $size);
-        $stream = new BufferStream(1024);
-        $stream->write($body);
+        $stream = new BufferedBody($body);
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',


### PR DESCRIPTION
This changeset drops the legacy RingCentral PSR-7 dependency and ensures we exclusively use our own PSR-7 implementation. This is the final step to replace the dated RingCentral implementation (#331) and allows us to eventually support PSR-7 v2 (#513). This is a purely internal change that comes with 100% code coverage and does not otherwise affect the public API, so it should be safe to apply.

To re-iterate: Our own `Response`, `Request` and `ServerRequest` classes continue to work just like in previous versions. In particular, this builds on top of the recent PSR-7 changes for the `Response`, `Request`, `ServerRequest` and `Uri` classes (#518, #519, #520, #521). Unlike these PRs, this changeset doesn't show a noticeable impact on performance during my benchmarks. As a consequence, I consider this mostly an internal optimization (cleanup) only.

Given this changeset does not otherwise affect our public API, this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our APIs. If you want to explicitly install this dependency, you can still install it like this:

```bash
composer require ringcentral/psr7
```

If you enjoy this change and want to help us continue to ship more improvements, consider supporting this project, for example by [becoming a sponsor](https://github.com/sponsors/reactphp) ❤️

Builds on top of #521, #520, #519, #518, #480, #432, #431, #370, #170 and others