### PR TITLE
Validate outgoing HTTP message headers and reject invalid messages

### DIFF
--- a/src/Io/AbstractMessage.php
+++ b/src/Io/AbstractMessage.php
@@ -19,7 +19,7 @@ abstract class AbstractMessage implements MessageInterface
      * @internal
      * @var string
      */
-    const REGEX_HEADERS = '/^([^()<>@,;:\\\"\/\[\]?={}\x01-\x20\x7F]++):[\x20\x09]*+((?:[\x20\x09]*+[\x21-\x7E\x80-\xFF]++)*+)[\x20\x09]*+[\r]?+\n/m';
+    const REGEX_HEADERS = '/^([^()<>@,;:\\\"\/\[\]?={}\x00-\x20\x7F]++):[\x20\x09]*+((?:[\x20\x09]*+[\x21-\x7E\x80-\xFF]++)*+)[\x20\x09]*+[\r]?+\n/m';
 
     /** @var array<string,string[]> */
     private $headers = array();

--- a/src/Io/ClientRequestStream.php
+++ b/src/Io/ClientRequestStream.php
@@ -56,7 +56,25 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
     {
         $this->state = self::STATE_WRITING_HEAD;
 
-        $request = $this->request;
+        $expected = 0;
+        $headers = "{$this->request->getMethod()} {$this->request->getRequestTarget()} HTTP/{$this->request->getProtocolVersion()}\r\n";
+        foreach ($this->request->getHeaders() as $name => $values) {
+            if (\strpos($name, ':') !== false) {
+                $expected = -1;
+                break;
+            }
+            foreach ($values as $value) {
+                $headers .= "$name: $value\r\n";
+                ++$expected;
+            }
+        }
+
+        /** @var array $m legacy PHP 5.3 only */
+        if (!\preg_match('#^\S+ \S+ HTTP/1\.[01]\r\n#m', $headers) || \substr_count($headers, "\n") !== ($expected + 1) || (\PHP_VERSION_ID >= 50400 ? \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) : \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers, $m)) !== $expected) {
+            $this->closeError(new \InvalidArgumentException('Unable to send request with invalid request headers'));
+            return;
+        }
+
         $connectionRef = &$this->connection;
         $stateRef = &$this->state;
         $pendingWrites = &$this->pendingWrites;
@@ -64,7 +82,7 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
 
         $promise = $this->connectionManager->connect($this->request->getUri());
         $promise->then(
-            function (ConnectionInterface $connection) use ($request, &$connectionRef, &$stateRef, &$pendingWrites, $that) {
+            function (ConnectionInterface $connection) use ($headers, &$connectionRef, &$stateRef, &$pendingWrites, $that) {
                 $connectionRef = $connection;
                 assert($connectionRef instanceof ConnectionInterface);
 
@@ -73,14 +91,6 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
                 $connection->on('end', array($that, 'handleEnd'));
                 $connection->on('error', array($that, 'handleError'));
                 $connection->on('close', array($that, 'close'));
-
-                assert($request instanceof RequestInterface);
-                $headers = "{$request->getMethod()} {$request->getRequestTarget()} HTTP/{$request->getProtocolVersion()}\r\n";
-                foreach ($request->getHeaders() as $name => $values) {
-                    foreach ($values as $value) {
-                        $headers .= "$name: $value\r\n";
-                    }
-                }
 
                 $more = $connection->write($headers . "\r\n" . $pendingWrites);
 


### PR DESCRIPTION
This changeset ensures we validate all outgoing HTTP message headers and reject any invalid messages. In particular, this ensures outgoing HTTP messages do not contain any headers with newlines.

Note that this does not affect normal operation and would only affect you if you're using invalid HTTP header names or values (such as when using untrusted user input). Likewise, this has no effect on incoming HTTP message headers which already use similar validation logic anyway (see #520 and others). This change comes with 100% code coverage and does not otherwise affect the public API, so it should be safe to apply.

I've originally planned to integrate this into our PSR-7 implementation (#518 and #519), but decided against this to not introduce any potential BC breaks. The suggested change still allows you to construct messages that would contain potentially invalid HTTP message fields, but would only reject such messages when trying to send over the wire.