### PR TITLE
Allow underscore character in Uri host

### DIFF
--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -55,7 +55,7 @@ final class Uri implements UriInterface
         }
         // @codeCoverageIgnoreEnd
 
-        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s_%+]#', $parts['host']))) {
+        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s%+]#', $parts['host']))) {
             throw new \InvalidArgumentException('Invalid URI given');
         }
 
@@ -173,7 +173,7 @@ final class Uri implements UriInterface
             return $this;
         }
 
-        if (\preg_match('#[\s_%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
+        if (\preg_match('#[\s%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
             throw new \InvalidArgumentException('Invalid URI host given');
         }
 

--- a/tests/Message/UriTest.php
+++ b/tests/Message/UriTest.php
@@ -120,6 +120,9 @@ class UriTest extends TestCase
             ),
             array(
                 'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
+            ),
+            array(
+                'http://docker_container/'
             )
         );
     }
@@ -335,6 +338,16 @@ class UriTest extends TestCase
         $new = $uri->withHost('example.com');
         $this->assertNotSame($uri, $new);
         $this->assertEquals('example.com', $new->getHost());
+        $this->assertEquals('localhost', $uri->getHost());
+    }
+
+    public function testWithHostReturnsNewInstanceWhenHostIsChangedWithUnderscore()
+    {
+        $uri = new Uri('http://localhost');
+
+        $new = $uri->withHost('docker_container');
+        $this->assertNotSame($uri, $new);
+        $this->assertEquals('docker_container', $new->getHost());
         $this->assertEquals('localhost', $uri->getHost());
     }
 


### PR DESCRIPTION
I don't understand why this validity check has been added. Has per rfc 2181 (https://datatracker.ietf.org/doc/html/rfc2181#section-11), underscore are valid character to use in an uri host.

For my specific usage, it broke for requests using docker internal hostnames.