### PR TITLE
Unnecessary 'resume' of an input stream

### DIFF
--- a/src/Io/CloseProtectionStream.php
+++ b/src/Io/CloseProtectionStream.php
@@ -80,11 +80,7 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
          $this->input->removeListener('end', array($this, 'handleEnd'));
          $this->input->removeListener('close', array($this, 'close'));
 
-         // resume the stream to ensure we discard everything from incoming connection
-         if ($this->paused) {
-             $this->paused = false;
-             $this->input->resume();
-         }
+         $this->close();
 
          $this->emit('close');
          $this->removeAllListeners();

--- a/tests/Io/CloseProtectionStreamTest.php
+++ b/tests/Io/CloseProtectionStreamTest.php
@@ -48,7 +48,7 @@ class CloseProtectionStreamTest extends TestCase
     {
         $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
         $input->expects($this->once())->method('pause');
-        $input->expects($this->once())->method('resume');
+        $input->expects($this->never())->method('resume');
 
         $protection = new CloseProtectionStream($input);
         $protection->pause();


### PR DESCRIPTION
I have cleared up behavior here that I couldn't comprehend. A "resume" at this point leads to several streams that need to be managed again by the loop, which were previously removed by a `close`-event. With a high number of client requests, the number of possible streams becomes too high, leading to a crash. The streams added back to the loop here eventually disappear "automagically," but this is not really comprehensible to me. Additionally, there is a significant increase in memory usage.