### PR TITLE
Hello `3.x` development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 Event-driven, streaming HTTP client and server implementation for [ReactPHP](https://reactphp.org/).
 
+> **Development version:** This branch contains the code for the upcoming v3
+> release. For the code of the current stable v1 release, check out the
+> [`1.x` branch](https://github.com/reactphp/http/tree/1.x).
+>
+> The upcoming v3 release will be the way forward for this package. However,
+> we will still actively support v1 for those not yet on the latest version.
+> See also [installation instructions](#install) for more details.
+
 This HTTP library provides re-usable implementations for an HTTP client and
 server based on ReactPHP's [`Socket`](https://github.com/reactphp/socket) and
 [`EventLoop`](https://github.com/reactphp/event-loop) components.
@@ -2982,11 +2990,11 @@ new React\Http\Middleware\RequestBodyParserMiddleware(10 * 1024, 100); // 100 fi
 The recommended way to install this library is [through Composer](https://getcomposer.org/).
 [New to Composer?](https://getcomposer.org/doc/00-intro.md)
 
-This project follows [SemVer](https://semver.org/).
-This will install the latest supported version:
+Once released, this project will follow [SemVer](https://semver.org/).
+At the moment, this will install the latest development version:
 
 ```bash
-composer require react/http:^1.10
+composer require react/http:^3@dev
 ```
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.


### PR DESCRIPTION
Once this PR is merged, we can start working on the new [v3.0.0 milestone](https://github.com/reactphp/http/milestone/37). The default branch will be `3.x` and the old `1.x` branch still stay in place at least until `3.0.0` is released.

Refs:
Road map ticket for http: #517
Plans for ReactPHP v3: https://github.com/orgs/reactphp/discussions/481 
PR templated from: https://github.com/friends-of-reactphp/mysql/pull/185