### PR TITLE
Drop deprecated alternative `Browser` constructor argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1869,11 +1869,7 @@ $browser = new React\Http\Browser();
 This class takes two optional arguments for more advanced usage:
 
 ```php
-// constructor signature as of v1.5.0
 $browser = new React\Http\Browser(?ConnectorInterface $connector = null, ?LoopInterface $loop = null);
-
-// legacy constructor signature before v1.5.0
-$browser = new React\Http\Browser(?LoopInterface $loop = null, ?ConnectorInterface $connector = null);
 ```
 
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -37,11 +37,7 @@ class Browser
      * This class takes two optional arguments for more advanced usage:
      *
      * ```php
-     * // constructor signature as of v1.5.0
      * $browser = new React\Http\Browser(?ConnectorInterface $connector = null, ?LoopInterface $loop = null);
-     *
-     * // legacy constructor signature before v1.5.0
-     * $browser = new React\Http\Browser(?LoopInterface $loop = null, ?ConnectorInterface $connector = null);
      * ```
      *
      * If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
@@ -69,23 +65,11 @@ class Browser
      * This value SHOULD NOT be given unless you're sure you want to explicitly use a
      * given event loop instance.
      *
-     * @param null|ConnectorInterface|LoopInterface $connector
-     * @param null|LoopInterface|ConnectorInterface $loop
-     * @throws \InvalidArgumentException for invalid arguments
+     * @param ?ConnectorInterface $connector
+     * @param ?LoopInterface $loop
      */
-    public function __construct($connector = null, $loop = null)
+    public function __construct(ConnectorInterface $connector = null, LoopInterface $loop = null)
     {
-        // swap arguments for legacy constructor signature
-        if (($connector instanceof LoopInterface || $connector === null) && ($loop instanceof ConnectorInterface || $loop === null)) {
-            $swap = $loop;
-            $loop = $connector;
-            $connector = $swap;
-        }
-
-        if (($connector !== null && !$connector instanceof ConnectorInterface) || ($loop !== null && !$loop instanceof LoopInterface)) {
-            throw new \InvalidArgumentException('Expected "?ConnectorInterface $connector" and "?LoopInterface $loop" arguments');
-        }
-
         $loop = $loop ?: Loop::get();
         $this->transaction = new Transaction(
             Sender::createFromLoop($loop, $connector),

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -70,35 +70,6 @@ class BrowserTest extends TestCase
         $this->assertSame($connector, $ret);
     }
 
-    public function testConstructWithConnectorWithLegacySignatureAssignsGivenConnector()
-    {
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-
-        $browser = new Browser(null, $connector);
-
-        $ref = new \ReflectionProperty($browser, 'transaction');
-        $ref->setAccessible(true);
-        $transaction = $ref->getValue($browser);
-
-        $ref = new \ReflectionProperty($transaction, 'sender');
-        $ref->setAccessible(true);
-        $sender = $ref->getValue($transaction);
-
-        $ref = new \ReflectionProperty($sender, 'http');
-        $ref->setAccessible(true);
-        $client = $ref->getValue($sender);
-
-        $ref = new \ReflectionProperty($client, 'connectionManager');
-        $ref->setAccessible(true);
-        $connectionManager = $ref->getValue($client);
-
-        $ref = new \ReflectionProperty($connectionManager, 'connector');
-        $ref->setAccessible(true);
-        $ret = $ref->getValue($connectionManager);
-
-        $this->assertSame($connector, $ret);
-    }
-
     public function testConstructWithLoopAssignsGivenLoop()
     {
         $browser = new Browser(null, $this->loop);
@@ -112,49 +83,6 @@ class BrowserTest extends TestCase
         $loop = $ref->getValue($transaction);
 
         $this->assertSame($this->loop, $loop);
-    }
-
-    public function testConstructWithLoopWithLegacySignatureAssignsGivenLoop()
-    {
-        $browser = new Browser($this->loop);
-
-        $ref = new \ReflectionProperty($browser, 'transaction');
-        $ref->setAccessible(true);
-        $transaction = $ref->getValue($browser);
-
-        $ref = new \ReflectionProperty($transaction, 'loop');
-        $ref->setAccessible(true);
-        $loop = $ref->getValue($transaction);
-
-        $this->assertSame($this->loop, $loop);
-    }
-
-    public function testConstructWithInvalidConnectorThrows()
-    {
-        $this->setExpectedException('InvalidArgumentException');
-        new Browser('foo');
-    }
-
-    public function testConstructWithInvalidLoopThrows()
-    {
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-
-        $this->setExpectedException('InvalidArgumentException');
-        new Browser($connector, 'foo');
-    }
-
-    public function testConstructWithConnectorTwiceThrows()
-    {
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-
-        $this->setExpectedException('InvalidArgumentException');
-        new Browser($connector, $connector);
-    }
-
-    public function testConstructWithLoopTwiceThrows()
-    {
-        $this->setExpectedException('InvalidArgumentException');
-        new Browser($this->loop, $this->loop);
     }
 
     public function testGetSendsGetRequest()


### PR DESCRIPTION
This simple changeset drops the deprecated alternative `Browser` constructor argument order. As of `v1.5.0`, we recommend using the new `Browser` signature with the optional `$connector` as first argument and optional `$loop` as second argument, so upgrading should be straightforward for most use cases:

```php
// unchanged
$browser = new React\Http\Browser();

// old (no longer supported)
$browser = new React\Http\Browser(null, $connector);
$browser = new React\Http\Browser($loop, $connector);

// new (already supported since v1.5.0)
$browser = new React\Http\Browser($connector);
$browser = new React\Http\Browser($connector, $loop);
```

The original deprecation message has been in place for a couple of years already, so this should be relatively safe to apply.

Note that this temporarily introduces an implicitly nullable type that should be removed in a follow-up as discussed in https://github.com/reactphp/promise/pull/260. Additionally, a follow-up PR should drop the entire `$loop` argument as discussed in #517.

Builds on top of #418, #528 and https://github.com/reactphp/socket/pull/315.