### PR TITLE
Update to require PHP 7.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
           - 7.3
           - 7.2
           - 7.1
-          - 7.0
-          - 5.6
-          - 5.5
-          - 5.4
-          - 5.3
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
@@ -36,19 +31,3 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
-      - name: Run hhvm composer.phar install
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm composer.phar install
-      - name: Run hhvm vendor/bin/phpunit
-        uses: docker://hhvm/hhvm:3.30-lts-latest
-        with:
-          args: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ Most importantly, this project provides a [`Browser`](#browser) object that
 offers several methods that resemble the HTTP protocol methods:
 
 ```php
-$browser->get($url, array $headers = array());
-$browser->head($url, array $headers = array());
-$browser->post($url, array $headers = array(), string|ReadableStreamInterface $body = '');
-$browser->delete($url, array $headers = array(), string|ReadableStreamInterface $body = '');
-$browser->put($url, array $headers = array(), string|ReadableStreamInterface $body = '');
-$browser->patch($url, array $headers = array(), string|ReadableStreamInterface $body = '');
+$browser->get($url, array $headers = []);
+$browser->head($url, array $headers = []);
+$browser->post($url, array $headers = [], string|ReadableStreamInterface $body = '');
+$browser->delete($url, array $headers = [], string|ReadableStreamInterface $body = '');
+$browser->put($url, array $headers = [], string|ReadableStreamInterface $body = '');
+$browser->patch($url, array $headers = [], string|ReadableStreamInterface $body = '');
 ```
 
 Each of these methods requires a `$url` and some optional parameters to send an
@@ -285,9 +285,9 @@ like this:
 ```php
 $browser = new React\Http\Browser(
     new React\Socket\Connector(
-        array(
+        [
             'timeout' => 5
-        )
+        ]
     )
 );
 ```
@@ -323,9 +323,9 @@ $token = 'abc123';
 
 $promise = $browser->get(
     'https://example.com/api',
-    array(
+    [
         'Authorization' => 'Bearer ' . $token
-    )
+    ]
 );
 ```
 
@@ -411,10 +411,10 @@ Similarly, you can also process multiple requests concurrently and await an arra
 use function React\Async\await;
 use function React\Promise\all;
 
-$promises = array(
+$promises = [
     $browser->get('http://example.com/'),
     $browser->get('http://www.example.org/'),
-);
+];
 
 $responses = await(all($promises));
 ```
@@ -540,7 +540,7 @@ You can invoke the following methods on the message body:
 $body->on($event, $callback);
 $body->eof();
 $body->isReadable();
-$body->pipe(React\Stream\WritableStreamInterface $dest, array $options = array());
+$body->pipe(React\Stream\WritableStreamInterface $dest, array $options = []);
 $body->close();
 $body->pause();
 $body->resume();
@@ -575,10 +575,10 @@ Consider looking into also using [react/promise-stream](https://github.com/react
 The resulting streaming code could look something like this:
 
 ```php
-use React\Promise\Stream;
+use function React\Promise\Stream\unwrapReadable;
 
 function download(Browser $browser, string $url): React\Stream\ReadableStreamInterface {
-    return Stream\unwrapReadable(
+    return unwrapReadable(
         $browser->requestStreaming('GET', $url)->then(function (Psr\Http\Message\ResponseInterface $response) {
             return $response->getBody();
         })
@@ -606,7 +606,7 @@ implementing [ReactPHP's `ReadableStreamInterface`](https://github.com/reactphp/
 to the [request methods](#request-methods) like this:
 
 ```php
-$browser->post($url, array(), $stream)->then(function (Psr\Http\Message\ResponseInterface $response) {
+$browser->post($url, [], $stream)->then(function (Psr\Http\Message\ResponseInterface $response) {
     echo 'Successfully sent.';
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
@@ -623,7 +623,7 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->post($url, array('Content-Length' => '11'), $body);
+$browser->post($url, ['Content-Length' => '11'], $body);
 ```
 
 If the streaming request body emits an `error` event or is explicitly closed
@@ -645,10 +645,10 @@ protocol, such as plain HTTP and TLS-encrypted HTTPS.
 ```php
 $proxy = new Clue\React\HttpProxy\ProxyConnector('127.0.0.1:8080');
 
-$connector = new React\Socket\Connector(array(
+$connector = new React\Socket\Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new React\Http\Browser($connector);
 ```
@@ -669,10 +669,10 @@ only, this can technically be used to tunnel any TCP/IP-based protocol.
 ```php
 $proxy = new Clue\React\Socks\Client('127.0.0.1:1080');
 
-$connector = new React\Socket\Connector(array(
+$connector = new React\Socket\Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new React\Http\Browser($connector);
 ```
@@ -698,10 +698,10 @@ plain HTTP and TLS-encrypted HTTPS.
 ```php
 $proxy = new Clue\React\SshProxy\SshSocksConnector('alice@example.com');
 
-$connector = new React\Socket\Connector(array(
+$connector = new React\Socket\Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new React\Http\Browser($connector);
 ```
@@ -931,11 +931,11 @@ using a secure TLS listen address, a certificate file and optional
 ```php
 $http = new React\Http\HttpServer($handler);
 
-$socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', array(
-    'tls' => array(
+$socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', [
+    'tls' => [
         'local_cert' => __DIR__ . '/localhost.pem'
-    )
-));
+    ]
+]);
 $http->listen($socket);
 ```
 
@@ -1456,9 +1456,9 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
 
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Content-Type' => 'text/plain'
-        ),
+        ],
         $stream
     );
 });
@@ -1558,10 +1558,10 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
 
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Content-Length' => '13',
             'Content-Type' => 'text/plain',
-        ),
+        ],
         $stream
     );
 });
@@ -1628,9 +1628,9 @@ a custom `Server` response header like this:
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Server' => 'PHP/3'
-        )
+        ]
     );
 });
 ```
@@ -1643,9 +1643,9 @@ string value like this:
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Server' => ''
-        )
+        ]
     );
 });
 ```
@@ -1658,9 +1658,9 @@ like this:
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Date' => gmdate('D, d M Y H:i:s \G\M\T')
-        )
+        ]
     );
 });
 ```
@@ -1673,9 +1673,9 @@ like this:
 $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Date' => ''
-        )
+        ]
     );
 });
 ```
@@ -1871,16 +1871,16 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(array(
+$connector = new React\Socket\Connector([
     'dns' => '127.0.0.1',
-    'tcp' => array(
+    'tcp' => [
         'bindto' => '192.168.10.1:0'
-    ),
-    'tls' => array(
+    ],
+    'tls' => [
         'verify_peer' => false,
         'verify_peer_name' => false
-    )
-));
+    ]
+]);
 
 $browser = new React\Http\Browser($connector);
 ```
@@ -1895,7 +1895,7 @@ given event loop instance.
 
 #### get()
 
-The `get(string $url, array $headers = array()): PromiseInterface<ResponseInterface>` method can be used to
+The `get(string $url, array $headers = []): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP GET request.
 
 ```php
@@ -1910,7 +1910,7 @@ See also [GET request client example](examples/01-client-get-request.php).
 
 #### post()
 
-The `post(string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `post(string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP POST request.
 
 ```php
@@ -1958,12 +1958,12 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->post($url, array('Content-Length' => '11'), $body);
+$browser->post($url, ['Content-Length' => '11'), $body);
 ```
 
 #### head()
 
-The `head(string $url, array $headers = array()): PromiseInterface<ResponseInterface>` method can be used to
+The `head(string $url, array $headers = []): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP HEAD request.
 
 ```php
@@ -1976,7 +1976,7 @@ $browser->head($url)->then(function (Psr\Http\Message\ResponseInterface $respons
 
 #### patch()
 
-The `patch(string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `patch(string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP PATCH request.
 
 ```php
@@ -2005,12 +2005,12 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->patch($url, array('Content-Length' => '11'), $body);
+$browser->patch($url, ['Content-Length' => '11'], $body);
 ```
 
 #### put()
 
-The `put(string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `put(string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP PUT request.
 
 ```php
@@ -2041,12 +2041,12 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->put($url, array('Content-Length' => '11'), $body);
+$browser->put($url, ['Content-Length' => '11'], $body);
 ```
 
 #### delete()
 
-The `delete(string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `delete(string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an HTTP DELETE request.
 
 ```php
@@ -2059,7 +2059,7 @@ $browser->delete($url)->then(function (Psr\Http\Message\ResponseInterface $respo
 
 #### request()
 
-The `request(string $method, string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `request(string $method, string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an arbitrary HTTP request.
 
 The preferred way to send an HTTP request is by using the above
@@ -2093,12 +2093,12 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->request('POST', $url, array('Content-Length' => '11'), $body);
+$browser->request('POST', $url, ['Content-Length' => '11'], $body);
 ```
 
 #### requestStreaming()
 
-The `requestStreaming(string $method, string $url, array $headers = array(), string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
+The `requestStreaming(string $method, string $url, array $headers = [], string|ReadableStreamInterface $body = ''): PromiseInterface<ResponseInterface>` method can be used to
 send an arbitrary HTTP request and receive a streaming response without buffering the response body.
 
 The preferred way to send an HTTP request is by using the above
@@ -2157,7 +2157,7 @@ Loop::addTimer(1.0, function () use ($body) {
     $body->end("hello world");
 });
 
-$browser->requestStreaming('POST', $url, array('Content-Length' => '11'), $body);
+$browser->requestStreaming('POST', $url, ['Content-Length' => '11'], $body);
 ```
 
 #### withTimeout()
@@ -2428,9 +2428,9 @@ represent an outgoing server response message.
 ```php
 $response = new React\Http\Message\Response(
     React\Http\Message\Response::STATUS_OK,
-    array(
+    [
         'Content-Type' => 'text/html'
-    ),
+    ],
     "<html>Hello world!</html>\n"
 );
 ```
@@ -2528,10 +2528,9 @@ values in the data must be encoded in UTF-8 (Unicode). If the encoding
 fails, this method will throw an `InvalidArgumentException`.
 
 By default, the given structured data will be encoded with the flags as
-shown above. This includes pretty printing (PHP 5.4+) and preserving
-zero fractions for `float` values (PHP 5.6.6+) to ease debugging. It is
-assumed any additional data overhead is usually compensated by using HTTP
-response compression.
+shown above. This includes pretty printing and preserving zero fractions
+for `float` values to ease debugging. It is assumed any additional data
+overhead is usually compensated by using HTTP response compression.
 
 If you want to use a different status code or custom HTTP response
 headers, you can manipulate the returned response object using the
@@ -2900,9 +2899,9 @@ $handler = function (Psr\Http\Message\ServerRequestInterface $request) {
 
     return new React\Http\Message\Response(
         React\Http\Message\Response::STATUS_OK,
-        array(
+        [
             'Content-Type' => 'text/plain'
-        ),
+        ],
         $name . ' uploaded ' . $uploaded
     );
 };

--- a/README.md
+++ b/README.md
@@ -2990,8 +2990,7 @@ composer require react/http:^3@dev
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
+extensions and supports running on PHP 7.1 through current PHP 8+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "fig/http-message-util": "^1.1",
         "psr/http-message": "^1.0",
@@ -39,8 +39,8 @@
         "clue/http-proxy-react": "^1.8",
         "clue/reactphp-ssh-proxy": "^1.4",
         "clue/socks-react": "^1.4",
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2",
+        "phpunit/phpunit": "^9.6 || ^5.7",
+        "react/async": "^4 || ^3",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.9"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "clue/http-proxy-react": "^1.8",
         "clue/reactphp-ssh-proxy": "^1.4",
         "clue/socks-react": "^1.4",
-        "phpunit/phpunit": "^9.6 || ^5.7",
+        "phpunit/phpunit": "^9.6 || ^7.5",
         "react/async": "^4 || ^3",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.9"

--- a/examples/03-client-request-any.php
+++ b/examples/03-client-request-any.php
@@ -10,13 +10,13 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $client = new Browser();
 
-$promises = array(
+$promises = [
     $client->head('http://www.github.com/clue/http-react'),
     $client->get('https://httpbingo.org/'),
     $client->get('https://google.com'),
     $client->get('http://www.lueck.tv/psocksd'),
     $client->get('http://httpbingo.org/absolute-redirect/5')
-);
+];
 
 React\Promise\any($promises)->then(function (ResponseInterface $response) use ($promises) {
     // first response arrived => cancel all other pending requests

--- a/examples/04-client-post-json.php
+++ b/examples/04-client-post-json.php
@@ -7,19 +7,19 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $client = new Browser();
 
-$data = array(
-    'name' => array(
+$data = [
+    'name' => [
         'first' => 'Alice',
         'name' => 'Smith'
-    ),
+    ],
     'email' => 'alice@example.com'
-);
+];
 
 $client->post(
     'https://httpbingo.org/post',
-    array(
+    [
         'Content-Type' => 'application/json'
-    ),
+    ],
     json_encode($data)
 )->then(function (ResponseInterface $response) {
     echo (string) $response->getBody();

--- a/examples/05-client-put-xml.php
+++ b/examples/05-client-put-xml.php
@@ -14,9 +14,9 @@ $child->name = 'Christian Lück';
 
 $client->put(
     'https://httpbingo.org/put',
-    array(
+    [
         'Content-Type' => 'text/xml'
-    ),
+    ],
     $xml->asXML()
 )->then(function (ResponseInterface $response) {
     echo (string) $response->getBody();

--- a/examples/11-client-http-proxy.php
+++ b/examples/11-client-http-proxy.php
@@ -16,10 +16,10 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new Clue\React\HttpProxy\ProxyConnector(getenv('http_proxy') ?: '127.0.0.1:8080');
 
 // create a Browser object that uses the HTTP CONNECT proxy client for connections
-$connector = new Connector(array(
+$connector = new Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new Browser($connector);
 

--- a/examples/12-client-socks-proxy.php
+++ b/examples/12-client-socks-proxy.php
@@ -16,10 +16,10 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new Clue\React\Socks\Client(getenv('socks_proxy') ?: '127.0.0.1:1080');
 
 // create a Browser object that uses the SOCKS proxy client for connections
-$connector = new Connector(array(
+$connector = new Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new Browser($connector);
 

--- a/examples/13-client-ssh-proxy.php
+++ b/examples/13-client-ssh-proxy.php
@@ -12,10 +12,10 @@ require __DIR__ . '/../vendor/autoload.php';
 $proxy = new Clue\React\SshProxy\SshSocksConnector(getenv('ssh_proxy') ?: 'alice@localhost');
 
 // create a Browser object that uses the SSH proxy client for connections
-$connector = new Connector(array(
+$connector = new Connector([
     'tcp' => $proxy,
     'dns' => false
-));
+]);
 
 $browser = new Browser($connector);
 

--- a/examples/21-client-request-streaming-to-stdout.php
+++ b/examples/21-client-request-streaming-to-stdout.php
@@ -17,7 +17,7 @@ $client = new Browser();
 $out = new WritableResourceStream(STDOUT);
 $info = new WritableResourceStream(STDERR);
 
-$url = isset($argv[1]) ? $argv[1] : 'http://google.com/';
+$url = $argv[1] ?? 'http://google.com/';
 $info->write('Requesting ' . $url . '…' . PHP_EOL);
 
 $client->requestStreaming('GET', $url)->then(function (ResponseInterface $response) use ($info, $out) {

--- a/examples/22-client-stream-upload-from-stdin.php
+++ b/examples/22-client-stream-upload-from-stdin.php
@@ -15,10 +15,10 @@ $client = new Browser();
 
 $in = new ReadableResourceStream(STDIN);
 
-$url = isset($argv[1]) ? $argv[1] : 'https://httpbingo.org/post';
+$url = $argv[1] ?? 'https://httpbingo.org/post';
 echo 'Sending STDIN as POST to ' . $url . '…' . PHP_EOL;
 
-$client->post($url, array('Content-Type' => 'text/plain'), $in)->then(function (ResponseInterface $response) {
+$client->post($url, ['Content-Type' => 'text/plain'], $in)->then(function (ResponseInterface $response) {
     echo (string) $response->getBody();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;

--- a/examples/51-server-hello-world.php
+++ b/examples/51-server-hello-world.php
@@ -8,7 +8,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/52-server-count-visitors.php
+++ b/examples/52-server-count-visitors.php
@@ -9,7 +9,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/53-server-whatsmyip.php
+++ b/examples/53-server-whatsmyip.php
@@ -10,7 +10,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/54-server-query-parameter.php
+++ b/examples/54-server-query-parameter.php
@@ -17,7 +17,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/55-server-cookie-handling.php
+++ b/examples/55-server-cookie-handling.php
@@ -18,7 +18,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     )->withHeader('Set-Cookie', $key . '=' . urlencode('Hello world!'));
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/56-server-sleep.php
+++ b/examples/56-server-sleep.php
@@ -18,7 +18,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     });
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/57-server-error-handling.php
+++ b/examples/57-server-error-handling.php
@@ -15,7 +15,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/58-server-stream-response.php
+++ b/examples/58-server-stream-response.php
@@ -32,14 +32,14 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
 
     return new Response(
         Response::STATUS_OK,
-        array(
+        [
             'Content-Type' => 'text/plain'
-        ),
+        ],
         $stream
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/59-server-json-api.php
+++ b/examples/59-server-json-api.php
@@ -12,30 +12,30 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
     if ($request->getHeaderLine('Content-Type') !== 'application/json') {
-        return Response::json(
-            array('error' => 'Only supports application/json')
-        )->withStatus(Response::STATUS_UNSUPPORTED_MEDIA_TYPE);
+        return Response::json([
+            'error' => 'Only supports application/json'
+        ])->withStatus(Response::STATUS_UNSUPPORTED_MEDIA_TYPE);
     }
 
     $input = json_decode($request->getBody()->getContents());
     if (json_last_error() !== JSON_ERROR_NONE) {
-        return Response::json(
-            array('error' => 'Invalid JSON data given')
-        )->withStatus(Response::STATUS_BAD_REQUEST);
+        return Response::json([
+            'error' => 'Invalid JSON data given'
+        ])->withStatus(Response::STATUS_BAD_REQUEST);
     }
 
     if (!isset($input->name) || !is_string($input->name)) {
-        return Response::json(
-            array('error' => 'JSON data does not contain a string "name" property')
-        )->withStatus(Response::STATUS_UNPROCESSABLE_ENTITY);
+        return Response::json([
+            'error' => 'JSON data does not contain a string "name" property'
+        ])->withStatus(Response::STATUS_UNPROCESSABLE_ENTITY);
     }
 
-    return Response::json(
-        array('message' => 'Hello ' . $input->name)
-    );
+    return Response::json([
+        'message' => 'Hello ' . $input->name
+    ]);
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/61-server-hello-world-https.php
+++ b/examples/61-server-hello-world-https.php
@@ -8,12 +8,12 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$uri = 'tls://' . (isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
-$socket = new React\Socket\SocketServer($uri, array(
-    'tls' => array(
-        'local_cert' => isset($argv[2]) ? $argv[2] : __DIR__ . '/localhost.pem'
-    )
-));
+$uri = 'tls://' . ($argv[1] ?? '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($uri, [
+    'tls' => [
+        'local_cert' => $argv[2] ?? __DIR__ . '/localhost.pem'
+    ]
+]);
 $http->listen($socket);
 
 $socket->on('error', function (Exception $e) {

--- a/examples/62-server-form-upload.php
+++ b/examples/62-server-form-upload.php
@@ -124,7 +124,7 @@ $http = new React\Http\HttpServer(
     $handler
 );
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/63-server-streaming-request.php
+++ b/examples/63-server-streaming-request.php
@@ -38,7 +38,7 @@ $http->on('error', function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/71-server-http-proxy.php
+++ b/examples/71-server-http-proxy.php
@@ -32,7 +32,7 @@ $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterf
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/72-server-http-connect-proxy.php
+++ b/examples/72-server-http-connect-proxy.php
@@ -20,10 +20,10 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     if ($request->getMethod() !== 'CONNECT') {
         return new Response(
             Response::STATUS_METHOD_NOT_ALLOWED,
-            array(
+            [
                 'Content-Type' => 'text/plain',
                 'Allow' => 'CONNECT'
-            ),
+            ],
             'This is an HTTP CONNECT (secure HTTPS) proxy'
         );
     }
@@ -34,23 +34,23 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
             // connection established => forward data
             return new Response(
                 Response::STATUS_OK,
-                array(),
+                [],
                 $remote
             );
         },
         function (Exception $e) {
             return new Response(
                 Response::STATUS_BAD_GATEWAY,
-                array(
+                [
                     'Content-Type' => 'text/plain'
-                ),
+                ],
                 'Unable to connect: ' . $e->getMessage()
             );
         }
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/81-server-upgrade-echo.php
+++ b/examples/81-server-upgrade-echo.php
@@ -31,9 +31,9 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
     if ($request->getHeaderLine('Upgrade') !== 'echo' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             Response::STATUS_UPGRADE_REQUIRED,
-            array(
+            [
                 'Upgrade' => 'echo'
-            ),
+            ],
             '"Upgrade: echo" required'
         );
     }
@@ -49,14 +49,14 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
 
     return new Response(
         Response::STATUS_SWITCHING_PROTOCOLS,
-        array(
+        [
             'Upgrade' => 'echo'
-        ),
+        ],
         $stream
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/82-server-upgrade-chat.php
+++ b/examples/82-server-upgrade-chat.php
@@ -39,9 +39,9 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
     if ($request->getHeaderLine('Upgrade') !== 'chat' || $request->getProtocolVersion() === '1.0') {
         return new Response(
             Response::STATUS_UPGRADE_REQUIRED,
-            array(
+            [
                 'Upgrade' => 'chat'
-            ),
+            ],
             '"Upgrade: chat" required'
         );
     }
@@ -77,14 +77,14 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) use
 
     return new Response(
         Response::STATUS_SWITCHING_PROTOCOLS,
-        array(
+        [
             'Upgrade' => 'chat'
-        ),
+        ],
         $stream
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/examples/91-client-benchmark-download.php
+++ b/examples/91-client-benchmark-download.php
@@ -16,7 +16,7 @@ use React\EventLoop\Loop;
 use React\Http\Browser;
 use React\Stream\ReadableStreamInterface;
 
-$url = isset($argv[1]) ? $argv[1] : 'http://google.com/';
+$url = $argv[1] ?? 'http://google.com/';
 
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/examples/92-client-benchmark-upload.php
+++ b/examples/92-client-benchmark-upload.php
@@ -55,7 +55,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
         $this->paused = false;
         while ($this->position < $this->count && !$this->paused) {
             ++$this->position;
-            $this->emit('data', array($this->chunk));
+            $this->emit('data', [$this->chunk]);
         }
 
         // end once the last chunk has been written
@@ -65,7 +65,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
         }
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         return Util::pipe($this, $dest, $options);
     }
@@ -95,8 +95,8 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
 
 $client = new Browser();
 
-$url = isset($argv[1]) ? $argv[1] : 'http://httpbin.org/post';
-$n = isset($argv[2]) ? $argv[2] : 10;
+$url = $argv[1] ?? 'http://httpbin.org/post';
+$n = $argv[2] ?? 10;
 $source = new ChunkRepeater(str_repeat('x', 1000000), $n);
 Loop::futureTick(function () use ($source) {
     $source->resume();
@@ -109,7 +109,7 @@ $report = Loop::addPeriodicTimer(0.05, function () use ($source, $start) {
     printf("\r%d bytes in %0.3fs...", $source->getPosition(), microtime(true) - $start);
 });
 
-$client->post($url, array('Content-Length' => $n * 1000000), $source)->then(function (ResponseInterface $response) use ($source, $report, $start) {
+$client->post($url, ['Content-Length' => $n * 1000000], $source)->then(function (ResponseInterface $response) use ($source, $report, $start) {
     $now = microtime(true);
     Loop::cancelTimer($report);
 

--- a/examples/99-server-benchmark-download.php
+++ b/examples/99-server-benchmark-download.php
@@ -52,7 +52,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
         $this->paused = false;
         while ($this->position < $this->count && !$this->paused) {
             ++$this->position;
-            $this->emit('data', array($this->chunk));
+            $this->emit('data', [$this->chunk]);
         }
 
         // end once the last chunk has been written
@@ -62,7 +62,7 @@ class ChunkRepeater extends EventEmitter implements ReadableStreamInterface
         }
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         return;
     }
@@ -106,19 +106,19 @@ $http = new React\Http\HttpServer(function (ServerRequestInterface $request) {
             return new Response(Response::STATUS_NOT_FOUND);
     }
 
-    React\EventLoop\Loop::addTimer(0, array($stream, 'resume'));
+    React\EventLoop\Loop::addTimer(0, [$stream, 'resume']);
 
     return new Response(
         Response::STATUS_OK,
-        array(
+        [
             'Content-Type' => 'application/octet-data',
             'Content-Length' => $stream->getSize()
-        ),
+        ],
         $stream
     );
 });
 
-$socket = new React\Socket\SocketServer(isset($argv[1]) ? $argv[1] : '0.0.0.0:0');
+$socket = new React\Socket\SocketServer($argv[1] ?? '0.0.0.0:0');
 $http->listen($socket);
 
 echo 'Listening on ' . str_replace('tcp:', 'http:', $socket->getAddress()) . PHP_EOL;

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -2,7 +2,7 @@
 
 <!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -22,9 +22,9 @@ class Browser
     private $transaction;
     private $baseUrl;
     private $protocolVersion = '1.1';
-    private $defaultHeaders = array(
+    private $defaultHeaders = [
         'User-Agent' => 'ReactPHP/1'
-    );
+    ];
 
     /**
      * The `Browser` is responsible for sending HTTP requests to your HTTP server
@@ -45,16 +45,16 @@ class Browser
      * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
      *
      * ```php
-     * $connector = new React\Socket\Connector(array(
+     * $connector = new React\Socket\Connector([
      *     'dns' => '127.0.0.1',
-     *     'tcp' => array(
+     *     'tcp' => [
      *         'bindto' => '192.168.10.1:0'
-     *     ),
-     *     'tls' => array(
+     *     ],
+     *     'tls' => [
      *         'verify_peer' => false,
      *         'verify_peer_name' => false
-     *     )
-     * ));
+     *     ]
+     * ]);
      *
      * $browser = new React\Http\Browser($connector);
      * ```
@@ -70,7 +70,7 @@ class Browser
      */
     public function __construct(ConnectorInterface $connector = null, LoopInterface $loop = null)
     {
-        $loop = $loop ?: Loop::get();
+        $loop = $loop ?? Loop::get();
         $this->transaction = new Transaction(
             Sender::createFromLoop($loop, $connector),
             $loop
@@ -94,7 +94,7 @@ class Browser
      * @param array  $headers
      * @return PromiseInterface<ResponseInterface>
      */
-    public function get($url, array $headers = array())
+    public function get($url, array $headers = [])
     {
         return $this->requestMayBeStreaming('GET', $url, $headers);
     }
@@ -147,7 +147,7 @@ class Browser
      *     $body->end("hello world");
      * });
      *
-     * $browser->post($url, array('Content-Length' => '11'), $body);
+     * $browser->post($url, ['Content-Length' => '11'], $body);
      * ```
      *
      * @param string                         $url      URL for the request.
@@ -155,7 +155,7 @@ class Browser
      * @param string|ReadableStreamInterface $body
      * @return PromiseInterface<ResponseInterface>
      */
-    public function post($url, array $headers = array(), $body = '')
+    public function post($url, array $headers = [], $body = '')
     {
         return $this->requestMayBeStreaming('POST', $url, $headers, $body);
     }
@@ -175,7 +175,7 @@ class Browser
      * @param array  $headers
      * @return PromiseInterface<ResponseInterface>
      */
-    public function head($url, array $headers = array())
+    public function head($url, array $headers = [])
     {
         return $this->requestMayBeStreaming('HEAD', $url, $headers);
     }
@@ -209,7 +209,7 @@ class Browser
      *     $body->end("hello world");
      * });
      *
-     * $browser->patch($url, array('Content-Length' => '11'), $body);
+     * $browser->patch($url, ['Content-Length' => '11'], $body);
      * ```
      *
      * @param string                         $url      URL for the request.
@@ -217,7 +217,7 @@ class Browser
      * @param string|ReadableStreamInterface $body
      * @return PromiseInterface<ResponseInterface>
      */
-    public function patch($url, array $headers = array(), $body = '')
+    public function patch($url, array $headers = [], $body = '')
     {
         return $this->requestMayBeStreaming('PATCH', $url , $headers, $body);
     }
@@ -253,7 +253,7 @@ class Browser
      *     $body->end("hello world");
      * });
      *
-     * $browser->put($url, array('Content-Length' => '11'), $body);
+     * $browser->put($url, ['Content-Length' => '11'], $body);
      * ```
      *
      * @param string                         $url      URL for the request.
@@ -261,7 +261,7 @@ class Browser
      * @param string|ReadableStreamInterface $body
      * @return PromiseInterface<ResponseInterface>
      */
-    public function put($url, array $headers = array(), $body = '')
+    public function put($url, array $headers = [], $body = '')
     {
         return $this->requestMayBeStreaming('PUT', $url, $headers, $body);
     }
@@ -282,7 +282,7 @@ class Browser
      * @param string|ReadableStreamInterface $body
      * @return PromiseInterface<ResponseInterface>
      */
-    public function delete($url, array $headers = array(), $body = '')
+    public function delete($url, array $headers = [], $body = '')
     {
         return $this->requestMayBeStreaming('DELETE', $url, $headers, $body);
     }
@@ -321,7 +321,7 @@ class Browser
      *     $body->end("hello world");
      * });
      *
-     * $browser->request('POST', $url, array('Content-Length' => '11'), $body);
+     * $browser->request('POST', $url, ['Content-Length' => '11'], $body);
      * ```
      *
      * @param string                         $method   HTTP request method, e.g. GET/HEAD/POST etc.
@@ -330,9 +330,9 @@ class Browser
      * @param string|ReadableStreamInterface $body     HTTP request body contents
      * @return PromiseInterface<ResponseInterface>
      */
-    public function request($method, $url, array $headers = array(), $body = '')
+    public function request($method, $url, array $headers = [], $body = '')
     {
-        return $this->withOptions(array('streaming' => false))->requestMayBeStreaming($method, $url, $headers, $body);
+        return $this->withOptions(['streaming' => false])->requestMayBeStreaming($method, $url, $headers, $body);
     }
 
     /**
@@ -394,7 +394,7 @@ class Browser
      *     $body->end("hello world");
      * });
      *
-     * $browser->requestStreaming('POST', $url, array('Content-Length' => '11'), $body);
+     * $browser->requestStreaming('POST', $url, ['Content-Length' => '11'], $body);
      * ```
      *
      * @param string                         $method   HTTP request method, e.g. GET/HEAD/POST etc.
@@ -403,9 +403,9 @@ class Browser
      * @param string|ReadableStreamInterface $body     HTTP request body contents
      * @return PromiseInterface<ResponseInterface>
      */
-    public function requestStreaming($method, $url, $headers = array(), $body = '')
+    public function requestStreaming($method, $url, $headers = [], $body = '')
     {
-        return $this->withOptions(array('streaming' => true))->requestMayBeStreaming($method, $url, $headers, $body);
+        return $this->withOptions(['streaming' => true])->requestMayBeStreaming($method, $url, $headers, $body);
     }
 
     /**
@@ -450,9 +450,9 @@ class Browser
             $timeout = 0;
         }
 
-        return $this->withOptions(array(
+        return $this->withOptions([
             'timeout' => $timeout,
-        ));
+        ]);
     }
 
     /**
@@ -512,10 +512,10 @@ class Browser
      */
     public function withFollowRedirects($followRedirects)
     {
-        return $this->withOptions(array(
+        return $this->withOptions([
             'followRedirects' => $followRedirects !== false,
             'maxRedirects' => \is_bool($followRedirects) ? null : $followRedirects
-        ));
+        ]);
     }
 
     /**
@@ -566,9 +566,9 @@ class Browser
      */
     public function withRejectErrorResponse($obeySuccessCode)
     {
-        return $this->withOptions(array(
+        return $this->withOptions([
             'obeySuccessCode' => $obeySuccessCode,
-        ));
+        ]);
     }
 
     /**
@@ -618,7 +618,7 @@ class Browser
         }
 
         $browser->baseUrl = new Uri($baseUrl);
-        if (!\in_array($browser->baseUrl->getScheme(), array('http', 'https')) || $browser->baseUrl->getHost() === '') {
+        if (!\in_array($browser->baseUrl->getScheme(), ['http', 'https']) || $browser->baseUrl->getHost() === '') {
             throw new \InvalidArgumentException('Base URL must be absolute');
         }
 
@@ -653,7 +653,7 @@ class Browser
      */
     public function withProtocolVersion($protocolVersion)
     {
-        if (!\in_array($protocolVersion, array('1.0', '1.1'), true)) {
+        if (!\in_array($protocolVersion, ['1.0', '1.1'], true)) {
             throw new InvalidArgumentException('Invalid HTTP protocol version, must be one of "1.1" or "1.0"');
         }
 
@@ -706,9 +706,9 @@ class Browser
      */
     public function withResponseBuffer($maximumSize)
     {
-        return $this->withOptions(array(
+        return $this->withOptions([
             'maximumSize' => $maximumSize
-        ));
+        ]);
     }
 
     /**
@@ -777,13 +777,13 @@ class Browser
      *
      * ```php
      * // deprecated
-     * $newBrowser = $browser->withOptions(array(
+     * $newBrowser = $browser->withOptions([
      *     'timeout' => null, // see withTimeout() instead
      *     'followRedirects' => true, // see withFollowRedirects() instead
      *     'maxRedirects' => 10, // see withFollowRedirects() instead
      *     'obeySuccessCode' => true, // see withRejectErrorResponse() instead
      *     'streaming' => false, // deprecated, see requestStreaming() instead
-     * ));
+     * ]);
      * ```
      *
      * See also [timeouts](#timeouts), [redirects](#redirects) and
@@ -814,7 +814,7 @@ class Browser
      * @param string|ReadableStreamInterface $body
      * @return PromiseInterface<ResponseInterface>
      */
-    private function requestMayBeStreaming($method, $url, array $headers = array(), $body = '')
+    private function requestMayBeStreaming($method, $url, array $headers = [], $body = '')
     {
         if ($this->baseUrl !== null) {
             // ensure we're actually below the base URL

--- a/src/HttpServer.php
+++ b/src/HttpServer.php
@@ -27,9 +27,9 @@ use React\Socket\ServerInterface;
  * $http = new React\Http\HttpServer(function (Psr\Http\Message\ServerRequestInterface $request) {
  *     return new React\Http\Message\Response(
  *         React\Http\Message\Response::STATUS_OK,
- *         array(
+ *         [
  *             'Content-Type' => 'text/plain'
- *         ),
+ *         ],
  *         "Hello World!\n"
  *     );
  * });
@@ -222,7 +222,7 @@ final class HttpServer extends EventEmitter
             }
         }
 
-        $middleware = array();
+        $middleware = [];
         if (!$streaming) {
             $maxSize = $this->getMaxRequestSize();
             $concurrency = $this->getConcurrentRequestsLimit(\ini_get('memory_limit'), $maxSize);
@@ -253,9 +253,8 @@ final class HttpServer extends EventEmitter
 
         $this->streamingServer = new StreamingServer($loop, new MiddlewareRunner($middleware));
 
-        $that = $this;
-        $this->streamingServer->on('error', function ($error) use ($that) {
-            $that->emit('error', array($error));
+        $this->streamingServer->on('error', function ($error) {
+            $this->emit('error', [$error]);
         });
     }
 
@@ -299,11 +298,11 @@ final class HttpServer extends EventEmitter
      * ```php
      * $http = new React\Http\HttpServer($handler);
      *
-     * $socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', array(
-     *     'tls' => array(
+     * $socket = new React\Socket\SocketServer('tls://0.0.0.0:8443', [
+     *     'tls' => [
      *         'local_cert' => __DIR__ . '/localhost.pem'
-     *     )
-     * ));
+     *     ]
+     * ]);
      * $http->listen($socket);
      * ```
      *
@@ -340,7 +339,7 @@ final class HttpServer extends EventEmitter
      */
     private function getMaxRequestSize($post_max_size = null)
     {
-        $maxSize = IniUtil::iniSizeToBytes($post_max_size === null ? \ini_get('post_max_size') : $post_max_size);
+        $maxSize = IniUtil::iniSizeToBytes($post_max_size ?? \ini_get('post_max_size'));
 
         return ($maxSize === 0 || $maxSize >= self::MAXIMUM_BUFFER_SIZE) ? self::MAXIMUM_BUFFER_SIZE : $maxSize;
     }

--- a/src/Io/AbstractMessage.php
+++ b/src/Io/AbstractMessage.php
@@ -22,10 +22,10 @@ abstract class AbstractMessage implements MessageInterface
     const REGEX_HEADERS = '/^([^()<>@,;:\\\"\/\[\]?={}\x00-\x20\x7F]++):[\x20\x09]*+((?:[\x20\x09]*+[\x21-\x7E\x80-\xFF]++)*+)[\x20\x09]*+[\r]?+\n/m';
 
     /** @var array<string,string[]> */
-    private $headers = array();
+    private $headers = [];
 
     /** @var array<string,string> */
-    private $headerNamesLowerCase = array();
+    private $headerNamesLowerCase = [];
 
     /** @var string */
     private $protocolVersion;
@@ -41,13 +41,13 @@ abstract class AbstractMessage implements MessageInterface
     protected function __construct($protocolVersion, array $headers, StreamInterface $body)
     {
         foreach ($headers as $name => $value) {
-            if ($value !== array()) {
+            if ($value !== []) {
                 if (\is_array($value)) {
                     foreach ($value as &$one) {
                         $one = (string) $one;
                     }
                 } else {
-                    $value = array((string) $value);
+                    $value = [(string) $value];
                 }
 
                 $lower = \strtolower($name);
@@ -95,7 +95,7 @@ abstract class AbstractMessage implements MessageInterface
     public function getHeader($name)
     {
         $lower = \strtolower($name);
-        return isset($this->headerNamesLowerCase[$lower]) ? $this->headers[$this->headerNamesLowerCase[$lower]] : array();
+        return isset($this->headerNamesLowerCase[$lower]) ? $this->headers[$this->headerNamesLowerCase[$lower]] : [];
     }
 
     public function getHeaderLine($name)
@@ -105,14 +105,14 @@ abstract class AbstractMessage implements MessageInterface
 
     public function withHeader($name, $value)
     {
-        if ($value === array()) {
+        if ($value === []) {
             return $this->withoutHeader($name);
         } elseif (\is_array($value)) {
             foreach ($value as &$one) {
                 $one = (string) $one;
             }
         } else {
-            $value = array((string) $value);
+            $value = [(string) $value];
         }
 
         $lower = \strtolower($name);
@@ -133,11 +133,11 @@ abstract class AbstractMessage implements MessageInterface
 
     public function withAddedHeader($name, $value)
     {
-        if ($value === array()) {
+        if ($value === []) {
             return $this;
         }
 
-        return $this->withHeader($name, \array_merge($this->getHeader($name), \is_array($value) ? $value : array($value)));
+        return $this->withHeader($name, \array_merge($this->getHeader($name), \is_array($value) ? $value : [$value]));
     }
 
     public function withoutHeader($name)

--- a/src/Io/AbstractRequest.php
+++ b/src/Io/AbstractRequest.php
@@ -50,7 +50,7 @@ abstract class AbstractRequest extends AbstractMessage implements RequestInterfa
         $host = $uri->getHost();
         if ($host !== '') {
             foreach ($headers as $name => $value) {
-                if (\strtolower($name) === 'host' && $value !== array()) {
+                if (\strtolower($name) === 'host' && $value !== []) {
                     $host = '';
                     break;
                 }
@@ -61,7 +61,7 @@ abstract class AbstractRequest extends AbstractMessage implements RequestInterfa
                     $host .= ':' . $port;
                 }
 
-                $headers = array('Host' => $host) + $headers;
+                $headers = ['Host' => $host] + $headers;
             }
         }
 

--- a/src/Io/BufferedBody.php
+++ b/src/Io/BufferedBody.php
@@ -174,6 +174,6 @@ class BufferedBody implements StreamInterface
 
     public function getMetadata($key = null)
     {
-        return $key === null ? array() : null;
+        return $key === null ? [] : null;
     }
 }

--- a/src/Io/ChunkedDecoder.php
+++ b/src/Io/ChunkedDecoder.php
@@ -31,10 +31,10 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
     {
         $this->input = $input;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'close'));
+        $this->input->on('data', [$this, 'handleData']);
+        $this->input->on('end', [$this, 'handleEnd']);
+        $this->input->on('error', [$this, 'handleError']);
+        $this->input->on('close', [$this, 'close']);
     }
 
     public function isReadable()
@@ -52,7 +52,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
         $this->input->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -86,7 +86,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
     /** @internal */
     public function handleError(Exception $e)
     {
-        $this->emit('error', array($e));
+        $this->emit('error', [$e]);
         $this->close();
     }
 
@@ -139,7 +139,7 @@ class ChunkedDecoder extends EventEmitter implements ReadableStreamInterface
 
             if ($chunk !== '') {
                 $this->transferredSize += \strlen($chunk);
-                $this->emit('data', array($chunk));
+                $this->emit('data', [$chunk]);
                 $this->buffer = (string)\substr($this->buffer, \strlen($chunk));
             }
 

--- a/src/Io/ChunkedEncoder.php
+++ b/src/Io/ChunkedEncoder.php
@@ -23,10 +23,10 @@ class ChunkedEncoder extends EventEmitter implements ReadableStreamInterface
     {
         $this->input = $input;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'close'));
+        $this->input->on('data', [$this, 'handleData']);
+        $this->input->on('end', [$this, 'handleEnd']);
+        $this->input->on('error', [$this, 'handleError']);
+        $this->input->on('close', [$this, 'close']);
     }
 
     public function isReadable()
@@ -44,7 +44,7 @@ class ChunkedEncoder extends EventEmitter implements ReadableStreamInterface
         $this->input->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         return Util::pipe($this, $dest, $options);
     }
@@ -66,23 +66,23 @@ class ChunkedEncoder extends EventEmitter implements ReadableStreamInterface
     public function handleData($data)
     {
         if ($data !== '') {
-            $this->emit('data', array(
+            $this->emit('data', [
                 \dechex(\strlen($data)) . "\r\n" . $data . "\r\n"
-            ));
+            ]);
         }
     }
 
     /** @internal */
     public function handleError(\Exception $e)
     {
-        $this->emit('error', array($e));
+        $this->emit('error', [$e]);
         $this->close();
     }
 
     /** @internal */
     public function handleEnd()
     {
-        $this->emit('data', array("0\r\n\r\n"));
+        $this->emit('data', ["0\r\n\r\n"]);
 
         if (!$this->closed) {
             $this->emit('end');

--- a/src/Io/ClientRequestStream.php
+++ b/src/Io/ClientRequestStream.php
@@ -69,8 +69,7 @@ class ClientRequestStream extends EventEmitter implements WritableStreamInterfac
             }
         }
 
-        /** @var array $m legacy PHP 5.3 only */
-        if (!\preg_match('#^\S+ \S+ HTTP/1\.[01]\r\n#m', $headers) || \substr_count($headers, "\n") !== ($expected + 1) || (\PHP_VERSION_ID >= 50400 ? \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) : \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers, $m)) !== $expected) {
+        if (!\preg_match('#^\S+ \S+ HTTP/1\.[01]\r\n#m', $headers) || \substr_count($headers, "\n") !== ($expected + 1) || \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) !== $expected) {
             $this->closeError(new \InvalidArgumentException('Unable to send request with invalid request headers'));
             return;
         }

--- a/src/Io/Clock.php
+++ b/src/Io/Clock.php
@@ -42,10 +42,9 @@ class Clock
             $this->now = \microtime(true);
 
             // remember clock for current loop tick only and update on next tick
-            $now =& $this->now;
-            $this->loop->futureTick(function () use (&$now) {
-                assert($now !== null);
-                $now = null;
+            $this->loop->futureTick(function () {
+                assert($this->now !== null);
+                $this->now = null;
             });
         }
 

--- a/src/Io/CloseProtectionStream.php
+++ b/src/Io/CloseProtectionStream.php
@@ -28,10 +28,10 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
     {
         $this->input = $input;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'close'));
+        $this->input->on('data', [$this, 'handleData']);
+        $this->input->on('end', [$this, 'handleEnd']);
+        $this->input->on('error', [$this, 'handleError']);
+        $this->input->on('close', [$this, 'close']);
     }
 
     public function isReadable()
@@ -59,7 +59,7 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
         $this->input->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -75,10 +75,10 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
          $this->closed = true;
 
          // stop listening for incoming events
-         $this->input->removeListener('data', array($this, 'handleData'));
-         $this->input->removeListener('error', array($this, 'handleError'));
-         $this->input->removeListener('end', array($this, 'handleEnd'));
-         $this->input->removeListener('close', array($this, 'close'));
+         $this->input->removeListener('data', [$this, 'handleData']);
+         $this->input->removeListener('error', [$this, 'handleError']);
+         $this->input->removeListener('end', [$this, 'handleEnd']);
+         $this->input->removeListener('close', [$this, 'close']);
 
          // resume the stream to ensure we discard everything from incoming connection
          if ($this->paused) {
@@ -93,7 +93,7 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
      /** @internal */
      public function handleData($data)
      {
-        $this->emit('data', array($data));
+        $this->emit('data', [$data]);
      }
 
      /** @internal */
@@ -106,6 +106,6 @@ class CloseProtectionStream extends EventEmitter implements ReadableStreamInterf
      /** @internal */
      public function handleError(\Exception $e)
      {
-         $this->emit('error', array($e));
+         $this->emit('error', [$e]);
      }
 }

--- a/src/Io/EmptyBodyStream.php
+++ b/src/Io/EmptyBodyStream.php
@@ -44,7 +44,7 @@ class EmptyBodyStream extends EventEmitter implements StreamInterface, ReadableS
         // NOOP
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -137,6 +137,6 @@ class EmptyBodyStream extends EventEmitter implements StreamInterface, ReadableS
     /** @ignore */
     public function getMetadata($key = null)
     {
-        return ($key === null) ? array() : null;
+        return ($key === null) ? [] : null;
     }
 }

--- a/src/Io/HttpBodyStream.php
+++ b/src/Io/HttpBodyStream.php
@@ -39,10 +39,10 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         $this->input = $input;
         $this->size = $size;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'close'));
+        $this->input->on('data', [$this, 'handleData']);
+        $this->input->on('end', [$this, 'handleEnd']);
+        $this->input->on('error', [$this, 'handleError']);
+        $this->input->on('close', [$this, 'close']);
     }
 
     public function isReadable()
@@ -60,7 +60,7 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
         $this->input->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -161,13 +161,13 @@ class HttpBodyStream extends EventEmitter implements StreamInterface, ReadableSt
     /** @internal */
     public function handleData($data)
     {
-        $this->emit('data', array($data));
+        $this->emit('data', [$data]);
     }
 
     /** @internal */
     public function handleError(\Exception $e)
     {
-        $this->emit('error', array($e));
+        $this->emit('error', [$e]);
         $this->close();
     }
 

--- a/src/Io/LengthLimitedStream.php
+++ b/src/Io/LengthLimitedStream.php
@@ -27,10 +27,10 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
         $this->stream = $stream;
         $this->maxLength = $maxLength;
 
-        $this->stream->on('data', array($this, 'handleData'));
-        $this->stream->on('end', array($this, 'handleEnd'));
-        $this->stream->on('error', array($this, 'handleError'));
-        $this->stream->on('close', array($this, 'close'));
+        $this->stream->on('data', [$this, 'handleData']);
+        $this->stream->on('end', [$this, 'handleEnd']);
+        $this->stream->on('error', [$this, 'handleError']);
+        $this->stream->on('close', [$this, 'close']);
     }
 
     public function isReadable()
@@ -48,7 +48,7 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
         $this->stream->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -79,21 +79,21 @@ class LengthLimitedStream extends EventEmitter implements ReadableStreamInterfac
 
         if ($data !== '') {
             $this->transferredLength += \strlen($data);
-            $this->emit('data', array($data));
+            $this->emit('data', [$data]);
         }
 
         if ($this->transferredLength === $this->maxLength) {
             // 'Content-Length' reached, stream will end
             $this->emit('end');
             $this->close();
-            $this->stream->removeListener('data', array($this, 'handleData'));
+            $this->stream->removeListener('data', [$this, 'handleData']);
         }
     }
 
     /** @internal */
     public function handleError(\Exception $e)
     {
-        $this->emit('error', array($e));
+        $this->emit('error', [$e]);
         $this->close();
     }
 

--- a/src/Io/MiddlewareRunner.php
+++ b/src/Io/MiddlewareRunner.php
@@ -40,8 +40,7 @@ final class MiddlewareRunner
         return $this->call($request, 0);
     }
 
-    /** @internal */
-    public function call(ServerRequestInterface $request, $position)
+    private function call(ServerRequestInterface $request, $position)
     {
         // final request handler will be invoked without a next handler
         if (!isset($this->middleware[$position + 1])) {
@@ -49,9 +48,8 @@ final class MiddlewareRunner
             return $handler($request);
         }
 
-        $that = $this;
-        $next = function (ServerRequestInterface $request) use ($that, $position) {
-            return $that->call($request, $position + 1);
+        $next = function (ServerRequestInterface $request) use ($position) {
+            return $this->call($request, $position + 1);
         };
 
         // invoke middleware request handler with next handler

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -166,7 +166,7 @@ final class MultipartParser
             $this->parseFile(
                 $name,
                 $filename,
-                isset($headers['content-type'][0]) ? $headers['content-type'][0] : null,
+                $headers['content-type'][0] ?? null,
                 $body
             );
         } else {
@@ -268,7 +268,7 @@ final class MultipartParser
 
     private function parseHeaders($header)
     {
-        $headers = array();
+        $headers = [];
 
         foreach (\explode("\r\n", \trim($header)) as $line) {
             $parts = \explode(':', $line, 2);
@@ -315,12 +315,12 @@ final class MultipartParser
             $previousChunkKey = $chunkKey;
 
             if ($previousChunkKey === '') {
-                $parent[] = array();
+                $parent[] = [];
                 \end($parent);
                 $parent = &$parent[\key($parent)];
             } else {
                 if (!isset($parent[$previousChunkKey]) || !\is_array($parent[$previousChunkKey])) {
-                    $parent[$previousChunkKey] = array();
+                    $parent[$previousChunkKey] = [];
                 }
                 $parent = &$parent[$previousChunkKey];
             }

--- a/src/Io/MultipartParser.php
+++ b/src/Io/MultipartParser.php
@@ -36,7 +36,7 @@ final class MultipartParser
     /**
      * ini setting "max_input_vars"
      *
-     * Does not exist in PHP < 5.3.9 or HHVM, so assume PHP's default 1000 here.
+     * Assume PHP' default of 1000 here.
      *
      * @var int
      * @link http://php.net/manual/en/info.configuration.php#ini.max-input-vars
@@ -46,7 +46,7 @@ final class MultipartParser
     /**
      * ini setting "max_input_nesting_level"
      *
-     * Does not exist in HHVM, but assumes hard coded to 64 (PHP's default).
+     * Assume PHP's default of 64 here.
      *
      * @var int
      * @link http://php.net/manual/en/info.configuration.php#ini.max-input-nesting-level
@@ -81,14 +81,8 @@ final class MultipartParser
      */
     public function __construct($uploadMaxFilesize = null, $maxFileUploads = null)
     {
-        $var = \ini_get('max_input_vars');
-        if ($var !== false) {
-            $this->maxInputVars = (int)$var;
-        }
-        $var = \ini_get('max_input_nesting_level');
-        if ($var !== false) {
-            $this->maxInputNestingLevel = (int)$var;
-        }
+        $this->maxInputVars = (int) \ini_get('max_input_vars');
+        $this->maxInputNestingLevel = (int) \ini_get('max_input_nesting_level');
 
         if ($uploadMaxFilesize === null) {
             $uploadMaxFilesize = \ini_get('upload_max_filesize');

--- a/src/Io/PauseBufferStream.php
+++ b/src/Io/PauseBufferStream.php
@@ -36,10 +36,10 @@ class PauseBufferStream extends EventEmitter implements ReadableStreamInterface
     {
         $this->input = $input;
 
-        $this->input->on('data', array($this, 'handleData'));
-        $this->input->on('end', array($this, 'handleEnd'));
-        $this->input->on('error', array($this, 'handleError'));
-        $this->input->on('close', array($this, 'handleClose'));
+        $this->input->on('data', [$this, 'handleData']);
+        $this->input->on('end', [$this, 'handleEnd']);
+        $this->input->on('error', [$this, 'handleError']);
+        $this->input->on('close', [$this, 'handleClose']);
     }
 
     /**
@@ -91,12 +91,12 @@ class PauseBufferStream extends EventEmitter implements ReadableStreamInterface
         $this->implicit = false;
 
         if ($this->dataPaused !== '') {
-            $this->emit('data', array($this->dataPaused));
+            $this->emit('data', [$this->dataPaused]);
             $this->dataPaused = '';
         }
 
         if ($this->errorPaused) {
-            $this->emit('error', array($this->errorPaused));
+            $this->emit('error', [$this->errorPaused]);
             return $this->close();
         }
 
@@ -114,7 +114,7 @@ class PauseBufferStream extends EventEmitter implements ReadableStreamInterface
         $this->input->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = array())
+    public function pipe(WritableStreamInterface $dest, array $options = [])
     {
         Util::pipe($this, $dest, $options);
 
@@ -146,7 +146,7 @@ class PauseBufferStream extends EventEmitter implements ReadableStreamInterface
             return;
         }
 
-        $this->emit('data', array($data));
+        $this->emit('data', [$data]);
     }
 
     /** @internal */
@@ -157,7 +157,7 @@ class PauseBufferStream extends EventEmitter implements ReadableStreamInterface
             return;
         }
 
-        $this->emit('error', array($e));
+        $this->emit('error', [$e]);
         $this->close();
     }
 

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -40,7 +40,7 @@ class Sender
      * settings. You can use this method manually like this:
      *
      * ```php
-     * $connector = new \React\Socket\Connector(array(), $loop);
+     * $connector = new \React\Socket\Connector([], $loop);
      * $sender = \React\Http\Io\Sender::createFromLoop($loop, $connector);
      * ```
      *
@@ -51,7 +51,7 @@ class Sender
     public static function createFromLoop(LoopInterface $loop, ConnectorInterface $connector = null)
     {
         if ($connector === null) {
-            $connector = new Connector(array(), $loop);
+            $connector = new Connector([], $loop);
         }
 
         return new self(new HttpClient(new ClientConnectionManager($connector, $loop)));
@@ -79,7 +79,7 @@ class Sender
     public function send(RequestInterface $request)
     {
         // support HTTP/1.1 and HTTP/1.0 only, ensured by `Browser` already
-        assert(\in_array($request->getProtocolVersion(), array('1.0', '1.1'), true));
+        assert(\in_array($request->getProtocolVersion(), ['1.0', '1.1'], true));
 
         $body = $request->getBody();
         $size = $body->getSize();
@@ -87,7 +87,7 @@ class Sender
         if ($size !== null && $size !== 0) {
             // automatically assign a "Content-Length" request header if the body size is known and non-empty
             $request = $request->withHeader('Content-Length', (string)$size);
-        } elseif ($size === 0 && \in_array($request->getMethod(), array('POST', 'PUT', 'PATCH'))) {
+        } elseif ($size === 0 && \in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'])) {
             // only assign a "Content-Length: 0" request header if the body is expected for certain methods
             $request = $request->withHeader('Content-Length', '0');
         } elseif ($body instanceof ReadableStreamInterface && $size !== 0 && $body->isReadable() && !$request->hasHeader('Content-Length')) {

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -346,8 +346,7 @@ final class StreamingServer extends EventEmitter
             }
         }
 
-        /** @var array $m legacy PHP 5.3 only */
-        if ($code < 100 || $code > 999 || \substr_count($headers, "\n") !== ($expected + 1) || (\PHP_VERSION_ID >= 50400 ? \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) : \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers, $m)) !== $expected) {
+        if ($code < 100 || $code > 999 || \substr_count($headers, "\n") !== ($expected + 1) || \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) !== $expected) {
             $this->emit('error', array(new \InvalidArgumentException('Unable to send response with invalid response headers')));
             $this->writeError($connection, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
             return;

--- a/src/Io/StreamingServer.php
+++ b/src/Io/StreamingServer.php
@@ -8,12 +8,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
-use React\Promise;
 use React\Promise\PromiseInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ServerInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 /**
  * The internal `StreamingServer` class is responsible for handling incoming connections and then
@@ -31,9 +32,9 @@ use React\Stream\WritableStreamInterface;
  * $server = new StreamingServer($loop, function (ServerRequestInterface $request) {
  *     return new Response(
  *         Response::STATUS_OK,
- *         array(
+ *         [
  *             'Content-Type' => 'text/plain'
- *         ),
+ *         ],
  *         "Hello World!\n"
  *     );
  * });
@@ -55,7 +56,7 @@ use React\Stream\WritableStreamInterface;
  * ```php
  * $server = new StreamingServer($loop, $handler);
  *
- * $socket = new React\Socket\SocketServer('0.0.0.0:8080', array(), $loop);
+ * $socket = new React\Socket\SocketServer('0.0.0.0:8080', [], $loop);
  * $server->listen($socket);
  * ```
  *
@@ -109,16 +110,15 @@ final class StreamingServer extends EventEmitter
         $this->clock = new Clock($loop);
         $this->parser = new RequestHeaderParser($this->clock);
 
-        $that = $this;
-        $this->parser->on('headers', function (ServerRequestInterface $request, ConnectionInterface $conn) use ($that) {
-            $that->handleRequest($conn, $request);
+        $this->parser->on('headers', function (ServerRequestInterface $request, ConnectionInterface $conn) {
+            $this->handleRequest($conn, $request);
         });
 
-        $this->parser->on('error', function(\Exception $e, ConnectionInterface $conn) use ($that) {
-            $that->emit('error', array($e));
+        $this->parser->on('error', function(\Exception $e, ConnectionInterface $conn) {
+            $this->emit('error', [$e]);
 
             // parsing failed => assume dummy request and send appropriate error
-            $that->writeError(
+            $this->writeError(
                 $conn,
                 $e->getCode() !== 0 ? $e->getCode() : Response::STATUS_BAD_REQUEST,
                 new ServerRequest('GET', '/')
@@ -134,7 +134,7 @@ final class StreamingServer extends EventEmitter
      */
     public function listen(ServerInterface $socket)
     {
-        $socket->on('connection', array($this->parser, 'handle'));
+        $socket->on('connection', [$this->parser, 'handle']);
     }
 
     /** @internal */
@@ -145,15 +145,11 @@ final class StreamingServer extends EventEmitter
         }
 
         // execute request handler callback
-        $callback = $this->callback;
         try {
-            $response = $callback($request);
-        } catch (\Exception $error) {
+            $response = ($this->callback)($request);
+        } catch (\Throwable $error) {
             // request handler callback throws an Exception
-            $response = Promise\reject($error);
-        } catch (\Throwable $error) { // @codeCoverageIgnoreStart
-            // request handler callback throws a PHP7+ Error
-            $response = Promise\reject($error); // @codeCoverageIgnoreEnd
+            $response = reject($error);
         }
 
         // cancel pending promise once connection closes
@@ -177,23 +173,22 @@ final class StreamingServer extends EventEmitter
 
         // did not return a promise? this is an error, convert into one for rejection below.
         if (!$response instanceof PromiseInterface) {
-            $response = Promise\resolve($response);
+            $response = resolve($response);
         }
 
-        $that = $this;
         $response->then(
-            function ($response) use ($that, $conn, $request) {
+            function ($response) use ($conn, $request) {
                 if (!$response instanceof ResponseInterface) {
                     $message = 'The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but resolved with "%s" instead.';
                     $message = \sprintf($message, \is_object($response) ? \get_class($response) : \gettype($response));
                     $exception = new \RuntimeException($message);
 
-                    $that->emit('error', array($exception));
-                    return $that->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
+                    $this->emit('error', [$exception]);
+                    return $this->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
                 }
-                $that->handleResponse($conn, $request, $response);
+                $this->handleResponse($conn, $request, $response);
             },
-            function ($error) use ($that, $conn, $request) {
+            function ($error) use ($conn, $request) {
                 $message = 'The response callback is expected to resolve with an object implementing Psr\Http\Message\ResponseInterface, but rejected with "%s" instead.';
                 $message = \sprintf($message, \is_object($error) ? \get_class($error) : \gettype($error));
 
@@ -205,8 +200,8 @@ final class StreamingServer extends EventEmitter
 
                 $exception = new \RuntimeException($message, 0, $previous);
 
-                $that->emit('error', array($exception));
-                return $that->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
+                $this->emit('error', [$exception]);
+                return $this->writeError($conn, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
             }
         )->then($connectionOnCloseResponseCancelerHandler, $connectionOnCloseResponseCancelerHandler);
     }
@@ -216,10 +211,10 @@ final class StreamingServer extends EventEmitter
     {
         $response = new Response(
             $code,
-            array(
+            [
                 'Content-Type' => 'text/plain',
                 'Connection' => 'close' // we do not want to keep the connection open after an error
-            ),
+            ],
             'Error ' . $code
         );
 
@@ -347,7 +342,7 @@ final class StreamingServer extends EventEmitter
         }
 
         if ($code < 100 || $code > 999 || \substr_count($headers, "\n") !== ($expected + 1) || \preg_match_all(AbstractMessage::REGEX_HEADERS, $headers) !== $expected) {
-            $this->emit('error', array(new \InvalidArgumentException('Unable to send response with invalid response headers')));
+            $this->emit('error', [new \InvalidArgumentException('Unable to send response with invalid response headers')]);
             $this->writeError($connection, Response::STATUS_INTERNAL_SERVER_ERROR, $request);
             return;
         }
@@ -387,15 +382,14 @@ final class StreamingServer extends EventEmitter
         // Close response stream once connection closes.
         // Note that this TCP/IP close detection may take some time,
         // in particular this may only fire on a later read/write attempt.
-        $connection->on('close', array($body, 'close'));
+        $connection->on('close', [$body, 'close']);
 
         // write streaming body and then wait for next request over persistent connection
         if ($persist) {
-            $body->pipe($connection, array('end' => false));
-            $parser = $this->parser;
-            $body->on('end', function () use ($connection, $parser, $body) {
-                $connection->removeListener('close', array($body, 'close'));
-                $parser->handle($connection);
+            $body->pipe($connection, ['end' => false]);
+            $body->on('end', function () use ($connection, $body) {
+                $connection->removeListener('close', [$body, 'close']);
+                $this->parser->handle($connection);
             });
         } else {
             $body->pipe($connection);

--- a/src/Io/UploadedFile.php
+++ b/src/Io/UploadedFile.php
@@ -57,7 +57,7 @@ final class UploadedFile implements UploadedFileInterface
         $this->stream = $stream;
         $this->size = $size;
 
-        if (!\is_int($error) || !\in_array($error, array(
+        if (!\is_int($error) || !\in_array($error, [
             \UPLOAD_ERR_OK,
             \UPLOAD_ERR_INI_SIZE,
             \UPLOAD_ERR_FORM_SIZE,
@@ -66,7 +66,7 @@ final class UploadedFile implements UploadedFileInterface
             \UPLOAD_ERR_NO_TMP_DIR,
             \UPLOAD_ERR_CANT_WRITE,
             \UPLOAD_ERR_EXTENSION,
-        ))) {
+        ])) {
             throw new InvalidArgumentException(
                 'Invalid error code, must be an UPLOAD_ERR_* constant'
             );

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -40,7 +40,7 @@ final class Request extends AbstractRequest implements RequestInterface
     public function __construct(
         $method,
         $url,
-        array $headers = array(),
+        array $headers = [],
         $body = '',
         $version = '1.1'
     ) {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -16,9 +16,9 @@ use React\Stream\ReadableStreamInterface;
  * ```php
  * $response = new React\Http\Message\Response(
  *     React\Http\Message\Response::STATUS_OK,
- *     array(
+ *     [
  *         'Content-Type' => 'text/html'
- *     ),
+ *     ],
  *     "<html>Hello world!</html>\n"
  * );
  * ```
@@ -90,7 +90,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public static function html($html)
     {
-        return new self(self::STATUS_OK, array('Content-Type' => 'text/html; charset=utf-8'), $html);
+        return new self(self::STATUS_OK, ['Content-Type' => 'text/html; charset=utf-8'], $html);
     }
 
     /**
@@ -124,10 +124,9 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      * fails, this method will throw an `InvalidArgumentException`.
      *
      * By default, the given structured data will be encoded with the flags as
-     * shown above. This includes pretty printing (PHP 5.4+) and preserving
-     * zero fractions for `float` values (PHP 5.6.6+) to ease debugging. It is
-     * assumed any additional data overhead is usually compensated by using HTTP
-     * response compression.
+     * shown above. This includes pretty printing and preserving zero fractions
+     * for `float` values to ease debugging. It is assumed any additional data
+     * overhead is usually compensated by using HTTP response compression.
      *
      * If you want to use a different status code or custom HTTP response
      * headers, you can manipulate the returned response object using the
@@ -146,19 +145,19 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public static function json($data)
     {
-        $json = @\json_encode(
+        $json = \json_encode(
             $data,
-            (\defined('JSON_PRETTY_PRINT') ? \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE : 0) | (\defined('JSON_PRESERVE_ZERO_FRACTION') ? \JSON_PRESERVE_ZERO_FRACTION : 0)
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION
         );
 
         if ($json === false) {
             throw new \InvalidArgumentException(
-                'Unable to encode given data as JSON' . (\function_exists('json_last_error_msg') ? ': ' . \json_last_error_msg() : ''),
+                'Unable to encode given data as JSON: ' . \json_last_error_msg(),
                 \json_last_error()
             );
         }
 
-        return new self(self::STATUS_OK, array('Content-Type' => 'application/json'), $json . "\n");
+        return new self(self::STATUS_OK, ['Content-Type' => 'application/json'], $json . "\n");
     }
 
     /**
@@ -201,7 +200,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public static function plaintext($text)
     {
-        return new self(self::STATUS_OK, array('Content-Type' => 'text/plain; charset=utf-8'), $text);
+        return new self(self::STATUS_OK, ['Content-Type' => 'text/plain; charset=utf-8'], $text);
     }
 
     /**
@@ -253,7 +252,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public static function xml($xml)
     {
-        return new self(self::STATUS_OK, array('Content-Type' => 'application/xml'), $xml);
+        return new self(self::STATUS_OK, ['Content-Type' => 'application/xml'], $xml);
     }
 
     /**
@@ -275,7 +274,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      * @see self::STATUS_*
      * @see self::getReasonPhraseForStatusCode()
      */
-    private static $phrasesMap = array(
+    private static $phrasesMap = [
         200 => 'OK',
         203 => 'Non-Authoritative Information',
         207 => 'Multi-Status',
@@ -283,7 +282,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
         414 => 'URI Too Large',
         418 => 'I\'m a teapot',
         505 => 'HTTP Version Not Supported'
-    );
+    ];
 
     /** @var int */
     private $statusCode;
@@ -301,7 +300,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public function __construct(
         $status = self::STATUS_OK,
-        array $headers = array(),
+        array $headers = [],
         $body = '',
         $version = '1.1',
         $reason = null
@@ -366,7 +365,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
             }
         }
 
-        return isset(self::$phrasesMap[$code]) ? self::$phrasesMap[$code] : '';
+        return self::$phrasesMap[$code] ?? '';
     }
 
     /**
@@ -379,7 +378,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
      */
     public static function parseMessage($message)
     {
-        $start = array();
+        $start = [];
         if (!\preg_match('#^HTTP/(?<version>\d\.\d) (?<status>\d{3})(?: (?<reason>[^\r\n]*+))?[\r]?+\n#m', $message, $start)) {
             throw new \InvalidArgumentException('Unable to parse invalid status-line');
         }
@@ -390,14 +389,14 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
         }
 
         // check number of valid header fields matches number of lines + status line
-        $matches = array();
+        $matches = [];
         $n = \preg_match_all(self::REGEX_HEADERS, $message, $matches, \PREG_SET_ORDER);
         if (\substr_count($message, "\n") !== $n + 1) {
             throw new \InvalidArgumentException('Unable to parse invalid response header fields');
         }
 
         // format all header fields into associative array
-        $headers = array();
+        $headers = [];
         foreach ($matches as $match) {
             $headers[$match[1]][] = $match[2];
         }
@@ -407,7 +406,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
             $headers,
             '',
             $start['version'],
-            isset($start['reason']) ? $start['reason'] : ''
+            $start['reason'] ?? ''
         );
     }
 }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -151,8 +151,7 @@ final class Response extends AbstractMessage implements ResponseInterface, Statu
             (\defined('JSON_PRETTY_PRINT') ? \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE : 0) | (\defined('JSON_PRESERVE_ZERO_FRACTION') ? \JSON_PRESERVE_ZERO_FRACTION : 0)
         );
 
-        // throw on error, now `false` but used to be `(string) "null"` before PHP 5.5
-        if ($json === false || (\PHP_VERSION_ID < 50500 && \json_last_error() !== \JSON_ERROR_NONE)) {
+        if ($json === false) {
             throw new \InvalidArgumentException(
                 'Unable to encode given data as JSON' . (\function_exists('json_last_error_msg') ? ': ' . \json_last_error_msg() : ''),
                 \json_last_error()

--- a/src/Message/ServerRequest.php
+++ b/src/Message/ServerRequest.php
@@ -31,12 +31,12 @@ use React\Stream\ReadableStreamInterface;
  */
 final class ServerRequest extends AbstractRequest implements ServerRequestInterface
 {
-    private $attributes = array();
+    private $attributes = [];
 
     private $serverParams;
-    private $fileParams = array();
-    private $cookies = array();
-    private $queryParams = array();
+    private $fileParams = [];
+    private $cookies = [];
+    private $queryParams = [];
     private $parsedBody;
 
     /**
@@ -51,10 +51,10 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
     public function __construct(
         $method,
         $url,
-        array $headers = array(),
+        array $headers = [],
         $body = '',
         $version = '1.1',
-        $serverParams = array()
+        $serverParams = []
     ) {
         if (\is_string($body)) {
             $body = new BufferedBody($body);
@@ -174,7 +174,7 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
     private function parseCookie($cookie)
     {
         $cookieArray = \explode(';', $cookie);
-        $result = array();
+        $result = [];
 
         foreach ($cookieArray as $pair) {
             $pair = \trim($pair);
@@ -202,7 +202,7 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
     public static function parseMessage($message, array $serverParams)
     {
         // parse request line like "GET /path HTTP/1.1"
-        $start = array();
+        $start = [];
         if (!\preg_match('#^(?<method>[^ ]+) (?<target>[^ ]+) HTTP/(?<version>\d\.\d)#m', $message, $start)) {
             throw new \InvalidArgumentException('Unable to parse invalid request-line');
         }
@@ -213,7 +213,7 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
         }
 
         // check number of valid header fields matches number of lines + request line
-        $matches = array();
+        $matches = [];
         $n = \preg_match_all(self::REGEX_HEADERS, $message, $matches, \PREG_SET_ORDER);
         if (\substr_count($message, "\n") !== $n + 1) {
             throw new \InvalidArgumentException('Unable to parse invalid request header fields');
@@ -221,7 +221,7 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
 
         // format all header fields into associative array
         $host = null;
-        $headers = array();
+        $headers = [];
         foreach ($matches as $match) {
             $headers[$match[1]][] = $match[2];
 

--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -54,8 +54,8 @@ final class Uri implements UriInterface
             $this->scheme = \strtolower($parts['scheme']);
         }
 
-        if (isset($parts['user']) || isset($parts['pass'])) {
-            $this->userInfo = $this->encode(isset($parts['user']) ? $parts['user'] : '', \PHP_URL_USER) . (isset($parts['pass']) ? ':' . $this->encode($parts['pass'], \PHP_URL_PASS) : '');
+        if (isset($parts['user'])) {
+            $this->userInfo = $this->encode($parts['user'], \PHP_URL_USER) . (isset($parts['pass']) ? ':' . $this->encode($parts['pass'], \PHP_URL_PASS) : '');
         }
 
         if (isset($parts['host'])) {
@@ -301,7 +301,7 @@ final class Uri implements UriInterface
         if ($rel->getAuthority() !== '') {
             $reset = true;
             $userInfo = \explode(':', $rel->getUserInfo(), 2);
-            $new = $base->withUserInfo($userInfo[0], isset($userInfo[1]) ? $userInfo[1]: null)->withHost($rel->getHost())->withPort($rel->getPort());
+            $new = $base->withUserInfo($userInfo[0], $userInfo[1] ?? null)->withHost($rel->getHost())->withPort($rel->getPort());
         }
 
         if ($reset && $rel->getPath() === '') {
@@ -334,7 +334,7 @@ final class Uri implements UriInterface
      */
     private static function removeDotSegments($path)
     {
-        $segments = array();
+        $segments = [];
         foreach (\explode('/', $path) as $segment) {
             if ($segment === '..') {
                 \array_pop($segments);

--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -45,16 +45,7 @@ final class Uri implements UriInterface
      */
     public function __construct($uri)
     {
-        // @codeCoverageIgnoreStart
-        if (\PHP_VERSION_ID < 50407 && \strpos($uri, '//') === 0) {
-            // @link https://3v4l.org/UrAQP
-            $parts = \parse_url('http:' . $uri);
-            unset($parts['schema']);
-        } else {
-            $parts = \parse_url($uri);
-        }
-        // @codeCoverageIgnoreEnd
-
+        $parts = \parse_url($uri);
         if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s_%+]#', $parts['host']))) {
             throw new \InvalidArgumentException('Invalid URI given');
         }

--- a/src/Middleware/RequestBodyBufferMiddleware.php
+++ b/src/Middleware/RequestBodyBufferMiddleware.php
@@ -76,11 +76,8 @@ final class RequestBodyBufferMiddleware
                 try {
                     // resolve with result of next handler
                     $resolve($next($request->withBody(new BufferedBody($buffer))));
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $reject($e);
-                } catch (\Throwable $e) { // @codeCoverageIgnoreStart
-                    // reject Errors just like Exceptions (PHP 7+)
-                    $reject($e); // @codeCoverageIgnoreEnd
                 }
             });
 

--- a/src/Middleware/RequestBodyParserMiddleware.php
+++ b/src/Middleware/RequestBodyParserMiddleware.php
@@ -21,7 +21,7 @@ final class RequestBodyParserMiddleware
     public function __invoke(ServerRequestInterface $request, $next)
     {
         $type = \strtolower($request->getHeaderLine('Content-Type'));
-        list ($type) = \explode(';', $type);
+        [$type] = \explode(';', $type);
 
         if ($type === 'application/x-www-form-urlencoded') {
             return $next($this->parseFormUrlencoded($request));
@@ -38,7 +38,7 @@ final class RequestBodyParserMiddleware
     {
         // parse string into array structure
         // ignore warnings due to excessive data structures (max_input_vars and max_input_nesting_level)
-        $ret = array();
+        $ret = [];
         @\parse_str((string)$request->getBody(), $ret);
 
         return $request->withParsedBody($ret);

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -87,9 +87,8 @@ class BrowserTest extends TestCase
 
     public function testGetSendsGetRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('GET', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('GET', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -98,9 +97,8 @@ class BrowserTest extends TestCase
 
     public function testPostSendsPostRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('POST', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('POST', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -109,9 +107,8 @@ class BrowserTest extends TestCase
 
     public function testHeadSendsHeadRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('HEAD', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('HEAD', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -120,9 +117,8 @@ class BrowserTest extends TestCase
 
     public function testPatchSendsPatchRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('PATCH', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('PATCH', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -131,9 +127,8 @@ class BrowserTest extends TestCase
 
     public function testPutSendsPutRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('PUT', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('PUT', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -142,9 +137,8 @@ class BrowserTest extends TestCase
 
     public function testDeleteSendsDeleteRequest()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('DELETE', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('DELETE', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -153,11 +147,10 @@ class BrowserTest extends TestCase
 
     public function testRequestOptionsSendsPutRequestWithStreamingExplicitlyDisabled()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('streaming' => false))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['streaming' => false])->willReturnSelf();
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('OPTIONS', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('OPTIONS', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -166,11 +159,10 @@ class BrowserTest extends TestCase
 
     public function testRequestStreamingGetSendsGetRequestWithStreamingExplicitlyEnabled()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('streaming' => true))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['streaming' => true])->willReturnSelf();
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('GET', $request->getMethod());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('GET', $request->getMethod());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -179,77 +171,77 @@ class BrowserTest extends TestCase
 
     public function testWithTimeoutTrueSetsDefaultTimeoutOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => null))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['timeout' => null])->willReturnSelf();
 
         $this->browser->withTimeout(true);
     }
 
     public function testWithTimeoutFalseSetsNegativeTimeoutOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => -1))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['timeout' => -1])->willReturnSelf();
 
         $this->browser->withTimeout(false);
     }
 
     public function testWithTimeout10SetsTimeoutOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => 10))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['timeout' => 10])->willReturnSelf();
 
         $this->browser->withTimeout(10);
     }
 
     public function testWithTimeoutNegativeSetsZeroTimeoutOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('timeout' => null))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['timeout' => null])->willReturnSelf();
 
         $this->browser->withTimeout(-10);
     }
 
     public function testWithFollowRedirectsTrueSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => null))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['followRedirects' => true, 'maxRedirects' => null])->willReturnSelf();
 
         $this->browser->withFollowRedirects(true);
     }
 
     public function testWithFollowRedirectsFalseSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => false, 'maxRedirects' => null))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['followRedirects' => false, 'maxRedirects' => null])->willReturnSelf();
 
         $this->browser->withFollowRedirects(false);
     }
 
     public function testWithFollowRedirectsTenSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => 10))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['followRedirects' => true, 'maxRedirects' => 10])->willReturnSelf();
 
         $this->browser->withFollowRedirects(10);
     }
 
     public function testWithFollowRedirectsZeroSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('followRedirects' => true, 'maxRedirects' => 0))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['followRedirects' => true, 'maxRedirects' => 0])->willReturnSelf();
 
         $this->browser->withFollowRedirects(0);
     }
 
     public function testWithRejectErrorResponseTrueSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('obeySuccessCode' => true))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['obeySuccessCode' => true])->willReturnSelf();
 
         $this->browser->withRejectErrorResponse(true);
     }
 
     public function testWithRejectErrorResponseFalseSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('obeySuccessCode' => false))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['obeySuccessCode' => false])->willReturnSelf();
 
         $this->browser->withRejectErrorResponse(false);
     }
 
     public function testWithResponseBufferThousandSetsSenderOption()
     {
-        $this->sender->expects($this->once())->method('withOptions')->with(array('maximumSize' => 1000))->willReturnSelf();
+        $this->sender->expects($this->once())->method('withOptions')->with(['maximumSize' => 1000])->willReturnSelf();
 
         $this->browser->withResponseBuffer(1000);
     }
@@ -264,103 +256,103 @@ class BrowserTest extends TestCase
 
     public function provideOtherUris()
     {
-        return array(
-            'empty returns base' => array(
+        return [
+            'empty returns base' => [
                 'http://example.com/base',
                 '',
                 'http://example.com/base',
-            ),
-            'absolute same as base returns base' => array(
+            ],
+            'absolute same as base returns base' => [
                 'http://example.com/base',
                 'http://example.com/base',
                 'http://example.com/base',
-            ),
-            'absolute below base returns absolute' => array(
+            ],
+            'absolute below base returns absolute' => [
                 'http://example.com/base',
                 'http://example.com/base/another',
                 'http://example.com/base/another',
-            ),
-            'slash returns base without path' => array(
+            ],
+            'slash returns base without path' => [
                 'http://example.com/base',
                 '/',
                 'http://example.com/',
-            ),
-            'relative is added behind base' => array(
+            ],
+            'relative is added behind base' => [
                 'http://example.com/base/',
                 'test',
                 'http://example.com/base/test',
-            ),
-            'relative is added behind base without path' => array(
+            ],
+            'relative is added behind base without path' => [
                 'http://example.com/base',
                 'test',
                 'http://example.com/test',
-            ),
-            'relative level up is added behind parent path' => array(
+            ],
+            'relative level up is added behind parent path' => [
                 'http://example.com/base/foo/',
                 '../bar',
                 'http://example.com/base/bar',
-            ),
-            'absolute with slash is added behind base without path' => array(
+            ],
+            'absolute with slash is added behind base without path' => [
                 'http://example.com/base',
                 '/test',
                 'http://example.com/test',
-            ),
-            'query string is added behind base' => array(
+            ],
+            'query string is added behind base' => [
                 'http://example.com/base',
                 '?key=value',
                 'http://example.com/base?key=value',
-            ),
-            'query string is added behind base with slash' => array(
+            ],
+            'query string is added behind base with slash' => [
                 'http://example.com/base/',
                 '?key=value',
                 'http://example.com/base/?key=value',
-            ),
-            'query string with slash is added behind base without path' => array(
+            ],
+            'query string with slash is added behind base without path' => [
                 'http://example.com/base',
                 '/?key=value',
                 'http://example.com/?key=value',
-            ),
-            'absolute with query string below base is returned as-is' => array(
+            ],
+            'absolute with query string below base is returned as-is' => [
                 'http://example.com/base',
                 'http://example.com/base?test',
                 'http://example.com/base?test',
-            ),
-            'urlencoded special chars will stay as-is' => array(
+            ],
+            'urlencoded special chars will stay as-is' => [
                 'http://example.com/%7Bversion%7D/',
                 '',
                 'http://example.com/%7Bversion%7D/'
-            ),
-            'special chars will be urlencoded' => array(
+            ],
+            'special chars will be urlencoded' => [
                 'http://example.com/{version}/',
                 '',
                 'http://example.com/%7Bversion%7D/'
-            ),
-            'other domain' => array(
+            ],
+            'other domain' => [
                 'http://example.com/base/',
                 'http://example.org/base/',
                 'http://example.org/base/'
-            ),
-            'other scheme' => array(
+            ],
+            'other scheme' => [
                 'http://example.com/base/',
                 'https://example.com/base/',
                 'https://example.com/base/'
-            ),
-            'other port' => array(
+            ],
+            'other port' => [
                 'http://example.com/base/',
                 'http://example.com:81/base/',
                 'http://example.com:81/base/'
-            ),
-            'other path' => array(
+            ],
+            'other path' => [
                 'http://example.com/base/',
                 'http://example.com/other/',
                 'http://example.com/other/'
-            ),
-            'other path due to missing slash' => array(
+            ],
+            'other path due to missing slash' => [
                 'http://example.com/base/',
                 'http://example.com/other',
                 'http://example.com/other'
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -372,9 +364,8 @@ class BrowserTest extends TestCase
     {
         $browser = $this->browser->withBase($base);
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($expectedAbsolute, $that) {
-            $that->assertEquals($expectedAbsolute, $request->getUri());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($expectedAbsolute) {
+            $this->assertEquals($expectedAbsolute, $request->getUri());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -397,9 +388,8 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withBase('http://example.com')->withBase(null);
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('path', $request->getUri());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('path', $request->getUri());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -410,9 +400,8 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withProtocolVersion('1.0');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals('1.0', $request->getProtocolVersion());
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals('1.0', $request->getProtocolVersion());
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -443,9 +432,8 @@ class BrowserTest extends TestCase
         $this->browser = $this->browser->withHeader('User-Agent', 'ACMC'); //should be overwritten
         $this->browser = $this->browser->withHeader('user-agent', 'ABC'); //should be the user-agent
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array('ABC'), $request->getHeader('UsEr-AgEnT'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals(['ABC'], $request->getHeader('UsEr-AgEnT'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -456,13 +444,12 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withHeader('User-Agent', 'ACMC');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array('ABC'), $request->getHeader('UsEr-AgEnT'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals(['ABC'], $request->getHeader('UsEr-AgEnT'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
-        $this->browser->get('http://example.com/', array('user-Agent' => 'ABC')); //should win
+        $this->browser->get('http://example.com/', ['user-Agent' => 'ABC']); //should win
     }
 
     public function testWithMultipleHeadersShouldBeMergedCorrectlyWithMultipleDefaultHeaders()
@@ -472,28 +459,27 @@ class BrowserTest extends TestCase
         $this->browser = $this->browser->withHeader('Custom-HEADER', 'custom');
         $this->browser = $this->browser->withHeader('just-a-header', 'header-value');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $expectedHeaders = array(
-                'Host' => array('example.com'),
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $expectedHeaders = [
+                'Host' => ['example.com'],
 
-                'User-Test' => array('Test'),
-                'just-a-header' => array('header-value'),
+                'User-Test' => ['Test'],
+                'just-a-header' => ['header-value'],
 
-                'user-Agent' => array('ABC'),
-                'another-header' => array('value'),
-                'custom-header' => array('data'),
-            );
+                'user-Agent' => ['ABC'],
+                'another-header' => ['value'],
+                'custom-header' => ['data'],
+            ];
 
-            $that->assertEquals($expectedHeaders, $request->getHeaders());
+            $this->assertEquals($expectedHeaders, $request->getHeaders());
             return true;
         }))->willReturn(new Promise(function () { }));
 
-        $headers = array(
+        $headers = [
             'user-Agent' => 'ABC', //should overwrite: 'User-Agent', 'ACMC'
             'another-header' => 'value',
             'custom-header' => 'data', //should overwrite: 'Custom-header', 'custom'
-        );
+        ];
         $this->browser->get('http://example.com/', $headers);
     }
 
@@ -502,9 +488,8 @@ class BrowserTest extends TestCase
         $this->browser = $this->browser->withHeader('User-Agent', 'ACMC');
         $this->browser = $this->browser->withoutHeader('UsEr-AgEnT'); //should remove case-insensitive header
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array(), $request->getHeader('user-agent'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals([], $request->getHeader('user-agent'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -515,9 +500,8 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withoutHeader('Connection');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array(), $request->getHeader('Connection'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals([], $request->getHeader('Connection'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -528,9 +512,8 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withHeader('Connection', 'keep-alive');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array('keep-alive'), $request->getHeader('Connection'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals(['keep-alive'], $request->getHeader('Connection'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -539,9 +522,8 @@ class BrowserTest extends TestCase
 
     public function testBrowserShouldSendDefaultUserAgentHeader()
     {
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array(0 => 'ReactPHP/1'), $request->getHeader('user-agent'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals([0 => 'ReactPHP/1'], $request->getHeader('user-agent'));
             return true;
         }))->willReturn(new Promise(function () { }));
 
@@ -552,9 +534,8 @@ class BrowserTest extends TestCase
     {
         $this->browser = $this->browser->withoutHeader('UsEr-AgEnT');
 
-        $that = $this;
-        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) use ($that) {
-            $that->assertEquals(array(), $request->getHeader('User-Agent'));
+        $this->sender->expects($this->once())->method('send')->with($this->callback(function (RequestInterface $request) {
+            $this->assertEquals([], $request->getHeader('User-Agent'));
             return true;
         }))->willReturn(new Promise(function () { }));
 

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -134,9 +134,6 @@ class FunctionalIntegrationTest extends TestCase
     /** @group internet */
     public function testSuccessfulResponseEmitsEnd()
     {
-        // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
-        ini_set('xdebug.max_nesting_level', 256);
-
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
@@ -155,9 +152,6 @@ class FunctionalIntegrationTest extends TestCase
     /** @group internet */
     public function testCancelPendingConnectionEmitsClose()
     {
-        // max_nesting_level was set to 100 for PHP Versions < 5.4 which resulted in failing test for legacy PHP
-        ini_set('xdebug.max_nesting_level', 256);
-
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
         $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));

--- a/tests/Client/FunctionalIntegrationTest.php
+++ b/tests/Client/FunctionalIntegrationTest.php
@@ -7,14 +7,15 @@ use React\EventLoop\Loop;
 use React\Http\Client\Client;
 use React\Http\Io\ClientConnectionManager;
 use React\Http\Message\Request;
-use React\Promise\Deferred;
 use React\Promise\Promise;
-use React\Promise\Stream;
 use React\Socket\ConnectionInterface;
 use React\Socket\Connector;
 use React\Socket\SocketServer;
 use React\Stream\ReadableStreamInterface;
 use React\Tests\Http\TestCase;
+use function React\Async\await;
+use function React\Promise\Stream\first;
+use function React\Promise\Timer\timeout;
 
 class FunctionalIntegrationTest extends TestCase
 {
@@ -49,12 +50,12 @@ class FunctionalIntegrationTest extends TestCase
         $port = parse_url($socket->getAddress(), PHP_URL_PORT);
 
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
-        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.0'));
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, [], '', '1.0'));
 
-        $promise = Stream\first($request, 'close');
+        $promise = first($request, 'close');
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+        await(timeout($promise, self::TIMEOUT_LOCAL));
     }
 
     public function testRequestToLocalhostWillConnectAndCloseConnectionAfterResponseWhenKeepAliveTimesOut()
@@ -74,11 +75,11 @@ class FunctionalIntegrationTest extends TestCase
         $port = parse_url($socket->getAddress(), PHP_URL_PORT);
 
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
-        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, [], '', '1.1'));
 
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+        await(timeout($promise, self::TIMEOUT_LOCAL));
     }
 
     public function testRequestToLocalhostWillReuseExistingConnectionForSecondRequest()
@@ -96,17 +97,17 @@ class FunctionalIntegrationTest extends TestCase
 
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
-        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
-        $promise = Stream\first($request, 'close');
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, [], '', '1.1'));
+        $promise = first($request, 'close');
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+        await(timeout($promise, self::TIMEOUT_LOCAL));
 
-        $request = $client->request(new Request('GET', 'http://localhost:' . $port, array(), '', '1.1'));
-        $promise = Stream\first($request, 'close');
+        $request = $client->request(new Request('GET', 'http://localhost:' . $port, [], '', '1.1'));
+        $promise = first($request, 'close');
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+        await(timeout($promise, self::TIMEOUT_LOCAL));
     }
 
     public function testRequestLegacyHttpServerWithOnlyLineFeedReturnsSuccessfulResponse()
@@ -118,17 +119,17 @@ class FunctionalIntegrationTest extends TestCase
         });
 
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
-        $request = $client->request(new Request('GET', str_replace('tcp:', 'http:', $socket->getAddress()), array(), '', '1.0'));
+        $request = $client->request(new Request('GET', str_replace('tcp:', 'http:', $socket->getAddress()), [], '', '1.0'));
 
         $once = $this->expectCallableOnceWith('body');
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($once) {
             $body->on('data', $once);
         });
 
-        $promise = Stream\first($request, 'close');
+        $promise = first($request, 'close');
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_LOCAL));
+        await(timeout($promise, self::TIMEOUT_LOCAL));
     }
 
     /** @group internet */
@@ -136,17 +137,17 @@ class FunctionalIntegrationTest extends TestCase
     {
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
-        $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
+        $request = $client->request(new Request('GET', 'http://www.google.com/', [], '', '1.0'));
 
         $once = $this->expectCallableOnce();
         $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($once) {
             $body->on('end', $once);
         });
 
-        $promise = Stream\first($request, 'close');
+        $promise = first($request, 'close');
         $request->end();
 
-        \React\Async\await(\React\Promise\Timer\timeout($promise, self::TIMEOUT_REMOTE));
+        await(timeout($promise, self::TIMEOUT_REMOTE));
     }
 
     /** @group internet */
@@ -154,7 +155,7 @@ class FunctionalIntegrationTest extends TestCase
     {
         $client = new Client(new ClientConnectionManager(new Connector(), Loop::get()));
 
-        $request = $client->request(new Request('GET', 'http://www.google.com/', array(), '', '1.0'));
+        $request = $client->request(new Request('GET', 'http://www.google.com/', [], '', '1.0'));
         $request->on('error', $this->expectCallableNever());
         $request->on('close', $this->expectCallableOnce());
         $request->end();

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -389,10 +389,6 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testCanAccessHttps()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         \React\Async\await($this->browser->get('https://www.google.com/'));
     }
 
@@ -401,10 +397,6 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testVerifyPeerEnabledForBadSslRejects()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => true
@@ -423,10 +415,6 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testVerifyPeerDisabledForBadSslResolves()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $connector = new Connector(array(
             'tls' => array(
                 'verify_peer' => false

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -176,7 +176,8 @@ class FunctionalBrowserTest extends TestCase
     {
         $promise = $this->browser->get('delay');
 
-        $this->setExpectedException('InvalidArgumentException', 'Invalid request URL given');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid request URL given');
         await($promise);
     }
 
@@ -201,7 +202,7 @@ class FunctionalBrowserTest extends TestCase
         $promise = $this->browser->get($this->base . 'get');
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($promise);
     }
 
@@ -212,13 +213,13 @@ class FunctionalBrowserTest extends TestCase
         });
         $promise->cancel();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($promise);
     }
 
     public function testRequestWithoutAuthenticationFails()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($this->browser->get($this->base . 'basic-auth/user/pass'));
     }
 
@@ -269,7 +270,8 @@ class FunctionalBrowserTest extends TestCase
             $promise->cancel();
         });
 
-        $this->setExpectedException('RuntimeException', 'Request cancelled');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request cancelled');
         await($promise);
     }
 
@@ -277,7 +279,8 @@ class FunctionalBrowserTest extends TestCase
     {
         $promise = $this->browser->withTimeout(0.1)->get($this->base . 'delay/10');
 
-        $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request timed out after 0.1 seconds');
         await($promise);
     }
 
@@ -287,7 +290,8 @@ class FunctionalBrowserTest extends TestCase
         $promise = $this->browser->withTimeout(0.1)->post($this->base . 'delay/10', [], $stream);
         $stream->end();
 
-        $this->setExpectedException('RuntimeException', 'Request timed out after 0.1 seconds');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Request timed out after 0.1 seconds');
         await($promise);
     }
 
@@ -329,7 +333,7 @@ class FunctionalBrowserTest extends TestCase
     {
         $browser = $this->browser->withFollowRedirects(0);
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($browser->get($this->base . 'redirect-to?url=get'));
     }
 
@@ -367,11 +371,9 @@ class FunctionalBrowserTest extends TestCase
     {
         $promise = $this->browser->withResponseBuffer(4)->get($this->base . 'get');
 
-        $this->setExpectedException(
-            'OverflowException',
-            'Response body size of 5 bytes exceeds maximum of 4 bytes',
-            defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0
-        );
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Response body size of 5 bytes exceeds maximum of 4 bytes');
+        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0);
         await($promise);
     }
 
@@ -379,11 +381,9 @@ class FunctionalBrowserTest extends TestCase
     {
         $promise = $this->browser->withResponseBuffer(4)->get($this->base . 'stream/1');
 
-        $this->setExpectedException(
-            'OverflowException',
-            'Response body size exceeds maximum of 4 bytes',
-            defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0
-        );
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Response body size exceeds maximum of 4 bytes');
+        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0);
         await($promise);
     }
 
@@ -409,7 +409,7 @@ class FunctionalBrowserTest extends TestCase
 
         $browser = new Browser($connector);
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($browser->get('https://self-signed.badssl.com/'));
     }
 
@@ -435,7 +435,7 @@ class FunctionalBrowserTest extends TestCase
      */
     public function testInvalidPort()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         await($this->browser->get('http://www.google.com:443/'));
     }
 
@@ -447,7 +447,7 @@ class FunctionalBrowserTest extends TestCase
         } catch (ResponseException $e) {
             $this->assertEquals(404, $e->getCode());
 
-            $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $e->getResponse());
+            $this->assertInstanceOf(ResponseInterface::class, $e->getResponse());
             $this->assertEquals(404, $e->getResponse()->getStatusCode());
         }
     }
@@ -762,7 +762,7 @@ class FunctionalBrowserTest extends TestCase
         $body = $response->getBody();
         $this->assertEquals(5, $body->getSize());
         $this->assertEquals('', (string) $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
     }
 
     public function testRequestStreamingGetReceivesResponseWithStreamingBodyAndUnknownSizeFromStreamingEndpoint()
@@ -773,7 +773,7 @@ class FunctionalBrowserTest extends TestCase
         $body = $response->getBody();
         $this->assertNull($body->getSize());
         $this->assertEquals('', (string) $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
     }
 
     public function testRequestStreamingGetReceivesStreamingResponseBody()

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -122,10 +122,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsOnRandomPort()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
         ));
@@ -155,10 +151,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsReturnsData()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $http = new HttpServer(function (RequestInterface $request) {
             return new Response(
                 200,
@@ -193,10 +185,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsOnRandomPortWithoutHostHeaderUsesSocketUri()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $connector = new Connector(array(
             'tls' => array('verify_peer' => false)
         ));
@@ -284,10 +272,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsOnStandardPortReturnsUriWithNoPort()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         try {
             $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -322,10 +306,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsOnStandardPortWithoutHostHeaderUsesSocketUri()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         try {
             $socket = new SocketServer('tls://127.0.0.1:443', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -389,10 +369,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testSecureHttpsOnHttpStandardPortReturnsUriWithPort()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         try {
             $socket = new SocketServer('tls://127.0.0.1:80', array('tls' => array(
                 'local_cert' => __DIR__ . '/../examples/localhost.pem'
@@ -726,10 +702,6 @@ class FunctionalHttpServerTest extends TestCase
 
     public function testLimitConcurrentRequestsMiddlewareRequestStreamPausing()
     {
-        if (defined('HHVM_VERSION') && !interface_exists('React\Promise\PromisorInterface')) {
-            $this->markTestSkipped('Not supported on legacy HHVM with Promise v3');
-        }
-
         $connector = new Connector();
 
         $http = new HttpServer(

--- a/tests/FunctionalHttpServerTest.php
+++ b/tests/FunctionalHttpServerTest.php
@@ -43,8 +43,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
 
         $socket->close();
     }
@@ -70,7 +70,7 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 404 Not Found", $response);
+        $this->assertStringContainsString("HTTP/1.0 404 Not Found", $response);
 
         $socket->close();
     }
@@ -94,8 +94,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://' . noScheme($socket->getAddress()) . '/', $response);
 
         $socket->close();
     }
@@ -119,8 +119,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://localhost:1000/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://localhost:1000/', $response);
 
         $socket->close();
     }
@@ -150,8 +150,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
 
         $socket->close();
     }
@@ -181,8 +181,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString("\r\nContent-Length: 33000\r\n", $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString("\r\nContent-Length: 33000\r\n", $response);
         $this->assertStringEndsWith("\r\n". str_repeat('.', 33000), $response);
 
         $socket->close();
@@ -211,8 +211,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('https://' . noScheme($socket->getAddress()) . '/', $response);
 
         $socket->close();
     }
@@ -240,8 +240,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://127.0.0.1/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://127.0.0.1/', $response);
 
         $socket->close();
     }
@@ -269,8 +269,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://127.0.0.1/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://127.0.0.1/', $response);
 
         $socket->close();
     }
@@ -303,8 +303,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('https://127.0.0.1/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('https://127.0.0.1/', $response);
 
         $socket->close();
     }
@@ -337,8 +337,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('https://127.0.0.1/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('https://127.0.0.1/', $response);
 
         $socket->close();
     }
@@ -366,8 +366,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('http://127.0.0.1:443/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('http://127.0.0.1:443/', $response);
 
         $socket->close();
     }
@@ -400,8 +400,8 @@ class FunctionalHttpServerTest extends TestCase
 
         $response = await(timeout($result, 1.0));
 
-        $this->assertContainsString("HTTP/1.0 200 OK", $response);
-        $this->assertContainsString('https://127.0.0.1:80/', $response);
+        $this->assertStringContainsString("HTTP/1.0 200 OK", $response);
+        $this->assertStringContainsString('https://127.0.0.1:80/', $response);
 
         $socket->close();
     }
@@ -743,7 +743,7 @@ class FunctionalHttpServerTest extends TestCase
         $responses = await(timeout(all($result), 1.0));
 
         foreach ($responses as $response) {
-            $this->assertContainsString("HTTP/1.0 200 OK", $response, $response);
+            $this->assertStringContainsString("HTTP/1.0 200 OK", $response, $response);
             $this->assertTrue(substr($response, -4) == 1024, $response);
         }
 

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -87,9 +87,6 @@ final class HttpServerTest extends TestCase
         $this->assertSame(1, $called);
     }
 
-    /**
-     * @requires PHP 5.4
-     */
     public function testSimpleRequestCallsArrayRequestHandlerOnce()
     {
         $this->called = null;

--- a/tests/Io/AbstractMessageTest.php
+++ b/tests/Io/AbstractMessageTest.php
@@ -26,7 +26,7 @@ class AbstractMessageTest extends TestCase
         $message = new MessageMock(
             '1.1',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $new = $message->withProtocolVersion('1.0');
@@ -40,7 +40,7 @@ class AbstractMessageTest extends TestCase
         $message = new MessageMock(
             '1.1',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $new = $message->withProtocolVersion('1.1');
@@ -55,7 +55,7 @@ class AbstractMessageTest extends TestCase
             [
                 'Content-Type' => 'text/plain'
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
@@ -109,7 +109,7 @@ class AbstractMessageTest extends TestCase
                     'b=2'
                 ]
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2']], $message->getHeaders());
@@ -152,7 +152,7 @@ class AbstractMessageTest extends TestCase
             [
                 'Content-Type' => []
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $this->assertEquals([], $message->getHeaders());
@@ -183,7 +183,7 @@ class AbstractMessageTest extends TestCase
                 'set-cookie' => ['b=2'],
                 'set-COOKIE' => []
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
+            $this->createMock(StreamInterface::class)
         );
 
         $this->assertEquals(['set-cookie' => ['a=1', 'b=2']], $message->getHeaders());
@@ -192,14 +192,14 @@ class AbstractMessageTest extends TestCase
 
     public function testWithBodyReturnsNewInstanceWhenBodyIsChanged()
     {
-        $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
+        $body = $this->createMock(StreamInterface::class);
         $message = new MessageMock(
             '1.1',
             [],
             $body
         );
 
-        $body2 = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
+        $body2 = $this->createMock(StreamInterface::class);
         $new = $message->withBody($body2);
         $this->assertNotSame($message, $new);
         $this->assertSame($body2, $new->getBody());
@@ -208,7 +208,7 @@ class AbstractMessageTest extends TestCase
 
     public function testWithBodyReturnsSameInstanceWhenBodyIsUnchanged()
     {
-        $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
+        $body = $this->createMock(StreamInterface::class);
         $message = new MessageMock(
             '1.1',
             [],

--- a/tests/Io/AbstractMessageTest.php
+++ b/tests/Io/AbstractMessageTest.php
@@ -25,7 +25,7 @@ class AbstractMessageTest extends TestCase
     {
         $message = new MessageMock(
             '1.1',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
@@ -39,7 +39,7 @@ class AbstractMessageTest extends TestCase
     {
         $message = new MessageMock(
             '1.1',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
@@ -52,16 +52,16 @@ class AbstractMessageTest extends TestCase
     {
         $message = new MessageMock(
             '1.1',
-            array(
+            [
                 'Content-Type' => 'text/plain'
-            ),
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
-        $this->assertEquals(array('Content-Type' => array('text/plain')), $message->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
 
-        $this->assertEquals(array('text/plain'), $message->getHeader('Content-Type'));
-        $this->assertEquals(array('text/plain'), $message->getHeader('CONTENT-type'));
+        $this->assertEquals(['text/plain'], $message->getHeader('Content-Type'));
+        $this->assertEquals(['text/plain'], $message->getHeader('CONTENT-type'));
 
         $this->assertEquals('text/plain', $message->getHeaderLine('Content-Type'));
         $this->assertEquals('text/plain', $message->getHeaderLine('CONTENT-Type'));
@@ -72,50 +72,50 @@ class AbstractMessageTest extends TestCase
         $new = $message->withHeader('Content-Type', 'text/plain');
         $this->assertSame($message, $new);
 
-        $new = $message->withHeader('Content-Type', array('text/plain'));
+        $new = $message->withHeader('Content-Type', ['text/plain']);
         $this->assertSame($message, $new);
 
         $new = $message->withHeader('content-type', 'text/plain');
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('content-type' => array('text/plain')), $new->getHeaders());
-        $this->assertEquals(array('Content-Type' => array('text/plain')), $message->getHeaders());
+        $this->assertEquals(['content-type' => ['text/plain']], $new->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
 
         $new = $message->withHeader('Content-Type', 'text/html');
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('Content-Type' => array('text/html')), $new->getHeaders());
-        $this->assertEquals(array('Content-Type' => array('text/plain')), $message->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/html']], $new->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
 
-        $new = $message->withHeader('Content-Type', array('text/html'));
+        $new = $message->withHeader('Content-Type', ['text/html']);
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('Content-Type' => array('text/html')), $new->getHeaders());
-        $this->assertEquals(array('Content-Type' => array('text/plain')), $message->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/html']], $new->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
 
-        $new = $message->withAddedHeader('Content-Type', array());
+        $new = $message->withAddedHeader('Content-Type', []);
         $this->assertSame($message, $new);
 
         $new = $message->withoutHeader('Content-Type');
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array(), $new->getHeaders());
-        $this->assertEquals(array('Content-Type' => array('text/plain')), $message->getHeaders());
+        $this->assertEquals([], $new->getHeaders());
+        $this->assertEquals(['Content-Type' => ['text/plain']], $message->getHeaders());
     }
 
     public function testHeaderWithMultipleValues()
     {
         $message = new MessageMock(
             '1.1',
-            array(
-                'Set-Cookie' => array(
+            [
+                'Set-Cookie' => [
                     'a=1',
                     'b=2'
-                )
-            ),
+                ]
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2')), $message->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2']], $message->getHeaders());
 
-        $this->assertEquals(array('a=1', 'b=2'), $message->getHeader('Set-Cookie'));
-        $this->assertEquals(array('a=1', 'b=2'), $message->getHeader('Set-Cookie'));
+        $this->assertEquals(['a=1', 'b=2'], $message->getHeader('Set-Cookie'));
+        $this->assertEquals(['a=1', 'b=2'], $message->getHeader('Set-Cookie'));
 
         $this->assertEquals('a=1, b=2', $message->getHeaderLine('Set-Cookie'));
         $this->assertEquals('a=1, b=2', $message->getHeaderLine('Set-Cookie'));
@@ -123,49 +123,49 @@ class AbstractMessageTest extends TestCase
         $this->assertTrue($message->hasHeader('Set-Cookie'));
         $this->assertTrue($message->hasHeader('Set-Cookie'));
 
-        $new = $message->withHeader('Set-Cookie', array('a=1', 'b=2'));
+        $new = $message->withHeader('Set-Cookie', ['a=1', 'b=2']);
         $this->assertSame($message, $new);
 
-        $new = $message->withHeader('Set-Cookie', array('a=1', 'b=2', 'c=3'));
+        $new = $message->withHeader('Set-Cookie', ['a=1', 'b=2', 'c=3']);
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2', 'c=3')), $new->getHeaders());
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2')), $message->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2', 'c=3']], $new->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2']], $message->getHeaders());
 
-        $new = $message->withAddedHeader('Set-Cookie', array());
+        $new = $message->withAddedHeader('Set-Cookie', []);
         $this->assertSame($message, $new);
 
         $new = $message->withAddedHeader('Set-Cookie', 'c=3');
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2', 'c=3')), $new->getHeaders());
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2')), $message->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2', 'c=3']], $new->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2']], $message->getHeaders());
 
-        $new = $message->withAddedHeader('Set-Cookie', array('c=3'));
+        $new = $message->withAddedHeader('Set-Cookie', ['c=3']);
         $this->assertNotSame($message, $new);
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2', 'c=3')), $new->getHeaders());
-        $this->assertEquals(array('Set-Cookie' => array('a=1', 'b=2')), $message->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2', 'c=3']], $new->getHeaders());
+        $this->assertEquals(['Set-Cookie' => ['a=1', 'b=2']], $message->getHeaders());
     }
 
     public function testHeaderWithEmptyValue()
     {
         $message = new MessageMock(
             '1.1',
-            array(
-                'Content-Type' => array()
-            ),
+            [
+                'Content-Type' => []
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
-        $this->assertEquals(array(), $message->getHeaders());
+        $this->assertEquals([], $message->getHeaders());
 
-        $this->assertEquals(array(), $message->getHeader('Content-Type'));
+        $this->assertEquals([], $message->getHeader('Content-Type'));
         $this->assertEquals('', $message->getHeaderLine('Content-Type'));
         $this->assertFalse($message->hasHeader('Content-Type'));
 
-        $new = $message->withHeader('Empty', array());
+        $new = $message->withHeader('Empty', []);
         $this->assertSame($message, $new);
         $this->assertFalse($new->hasHeader('Empty'));
 
-        $new = $message->withAddedHeader('Empty', array());
+        $new = $message->withAddedHeader('Empty', []);
         $this->assertSame($message, $new);
         $this->assertFalse($new->hasHeader('Empty'));
 
@@ -178,16 +178,16 @@ class AbstractMessageTest extends TestCase
     {
         $message = new MessageMock(
             '1.1',
-            array(
+            [
                 'SET-Cookie' => 'a=1',
-                'set-cookie' => array('b=2'),
-                'set-COOKIE' => array()
-            ),
+                'set-cookie' => ['b=2'],
+                'set-COOKIE' => []
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock()
         );
 
-        $this->assertEquals(array('set-cookie' => array('a=1', 'b=2')), $message->getHeaders());
-        $this->assertEquals(array('a=1', 'b=2'), $message->getHeader('Set-Cookie'));
+        $this->assertEquals(['set-cookie' => ['a=1', 'b=2']], $message->getHeaders());
+        $this->assertEquals(['a=1', 'b=2'], $message->getHeader('Set-Cookie'));
     }
 
     public function testWithBodyReturnsNewInstanceWhenBodyIsChanged()
@@ -195,7 +195,7 @@ class AbstractMessageTest extends TestCase
         $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
         $message = new MessageMock(
             '1.1',
-            array(),
+            [],
             $body
         );
 
@@ -211,7 +211,7 @@ class AbstractMessageTest extends TestCase
         $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
         $message = new MessageMock(
             '1.1',
-            array(),
+            [],
             $body
         );
 

--- a/tests/Io/AbstractRequestTest.php
+++ b/tests/Io/AbstractRequestTest.php
@@ -32,12 +32,12 @@ class AbstractRequestTest extends TestCase
 {
     public function testCtorWithInvalidUriThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new RequestMock(
             'GET',
             null,
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
     }
@@ -48,7 +48,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -61,7 +61,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com:8080/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -74,7 +74,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com:443/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -87,7 +87,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'https://example.com:80/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -100,7 +100,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com:80/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -113,7 +113,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'https://example.com:443/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -128,7 +128,7 @@ class AbstractRequestTest extends TestCase
             [
                 'User-Agent' => 'demo'
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -143,7 +143,7 @@ class AbstractRequestTest extends TestCase
             [
                 'Host' => 'example.com:8080'
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -158,7 +158,7 @@ class AbstractRequestTest extends TestCase
             [
                 'Host' => []
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -171,7 +171,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/demo?name=Alice',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -184,7 +184,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -197,7 +197,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/demo?name=Alice',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
         $request = $request->withRequestTarget('http://example.com/demo?name=Alice');
@@ -211,7 +211,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -227,7 +227,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
         $request = $request->withRequestTarget('/');
@@ -243,7 +243,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -259,7 +259,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -270,13 +270,13 @@ class AbstractRequestTest extends TestCase
 
     public function testGetUriReturnsUriInstanceGivenToCtor()
     {
-        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+        $uri = $this->createMock(UriInterface::class);
 
         $request = new RequestMock(
             'GET',
             $uri,
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -289,12 +289,12 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
         $uri = $request->getUri();
-        $this->assertInstanceOf('Psr\Http\Message\UriInterface', $uri);
+        $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertEquals('http://example.com/', (string) $uri);
     }
 
@@ -304,11 +304,11 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
-        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+        $uri = $this->createMock(UriInterface::class);
         $new = $request->withUri($uri);
 
         $this->assertNotSame($request, $new);
@@ -318,13 +318,13 @@ class AbstractRequestTest extends TestCase
 
     public function testWithUriReturnsSameInstanceWhenUriIsUnchanged()
     {
-        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+        $uri = $this->createMock(UriInterface::class);
 
         $request = new RequestMock(
             'GET',
             $uri,
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -339,7 +339,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -357,7 +357,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -377,7 +377,7 @@ class AbstractRequestTest extends TestCase
             [
                 'User-Agent' => 'test'
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
         $request = $request->withoutHeader('Host');
@@ -396,7 +396,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -414,7 +414,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             'http://example.com/',
             [],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
 
@@ -434,7 +434,7 @@ class AbstractRequestTest extends TestCase
             [
                 'User-Agent' => 'test'
             ],
-            $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
+            $this->createMock(StreamInterface::class),
             '1.1'
         );
         $request = $request->withoutHeader('Host');

--- a/tests/Io/AbstractRequestTest.php
+++ b/tests/Io/AbstractRequestTest.php
@@ -36,7 +36,7 @@ class AbstractRequestTest extends TestCase
         new RequestMock(
             'GET',
             null,
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -47,12 +47,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWithCustomHttpPort()
@@ -60,12 +60,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com:8080/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com:8080')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com:8080']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWithCustomPortHttpOnHttpsPort()
@@ -73,12 +73,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com:443/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com:443')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com:443']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWithCustomPortHttpsOnHttpPort()
@@ -86,12 +86,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'https://example.com:80/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com:80')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com:80']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWithoutDefaultHttpPort()
@@ -99,12 +99,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com:80/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWithoutDefaultHttpsPort()
@@ -112,12 +112,12 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'https://example.com:443/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriBeforeOtherHeadersExplicitlyGiven()
@@ -125,14 +125,14 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(
+            [
                 'User-Agent' => 'demo'
-            ),
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com'), 'User-Agent' => array('demo')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com'], 'User-Agent' => ['demo']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromHeadersExplicitlyGiven()
@@ -140,14 +140,14 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://localhost/',
-            array(
+            [
                 'Host' => 'example.com:8080'
-            ),
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com:8080')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com:8080']], $request->getHeaders());
     }
 
     public function testGetHeadersReturnsHostHeaderFromUriWhenHeadersExplicitlyGivenContainEmptyHostArray()
@@ -155,14 +155,14 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'https://example.com/',
-            array(
-                'Host' => array()
-            ),
+            [
+                'Host' => []
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
 
-        $this->assertEquals(array('Host' => array('example.com')), $request->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $request->getHeaders());
     }
 
     public function testGetRequestTargetReturnsPathAndQueryFromUri()
@@ -170,7 +170,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/demo?name=Alice',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -183,7 +183,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -196,7 +196,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/demo?name=Alice',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -210,7 +210,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -226,7 +226,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -242,7 +242,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -258,7 +258,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -275,7 +275,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             $uri,
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -288,7 +288,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -303,7 +303,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -323,7 +323,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             $uri,
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -338,7 +338,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -348,7 +348,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('http://localhost/', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('localhost')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['localhost']], $new->getHeaders());
     }
 
     public function testWithUriReturnsNewInstanceWithHostHeaderChangedIfUriContainsHostWithCustomPort()
@@ -356,7 +356,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -366,7 +366,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('http://localhost:8080/', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('localhost:8080')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['localhost:8080']], $new->getHeaders());
     }
 
     public function testWithUriReturnsNewInstanceWithHostHeaderAddedAsFirstHeaderBeforeOthersIfUriContainsHost()
@@ -374,9 +374,9 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(
+            [
                 'User-Agent' => 'test'
-            ),
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -387,7 +387,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('http://localhost/', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('localhost'), 'User-Agent' => array('test')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['localhost'], 'User-Agent' => ['test']], $new->getHeaders());
     }
 
     public function testWithUriReturnsNewInstanceWithHostHeaderUnchangedIfUriContainsNoHost()
@@ -395,7 +395,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -405,7 +405,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('/path', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('example.com')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $new->getHeaders());
     }
 
     public function testWithUriReturnsNewInstanceWithHostHeaderUnchangedIfPreserveHostIsTrue()
@@ -413,7 +413,7 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(),
+            [],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -423,7 +423,7 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('http://localhost/', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('example.com')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['example.com']], $new->getHeaders());
     }
 
     public function testWithUriReturnsNewInstanceWithHostHeaderAddedAsFirstHeaderNoMatterIfPreserveHostIsTrue()
@@ -431,9 +431,9 @@ class AbstractRequestTest extends TestCase
         $request = new RequestMock(
             'GET',
             'http://example.com/',
-            array(
+            [
                 'User-Agent' => 'test'
-            ),
+            ],
             $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock(),
             '1.1'
         );
@@ -444,6 +444,6 @@ class AbstractRequestTest extends TestCase
 
         $this->assertNotSame($request, $new);
         $this->assertEquals('http://example.com/', (string) $new->getUri());
-        $this->assertEquals(array('Host' => array('example.com'), 'User-Agent' => array('test')), $new->getHeaders());
+        $this->assertEquals(['Host' => ['example.com'], 'User-Agent' => ['test']], $new->getHeaders());
     }
 }

--- a/tests/Io/BufferedBodyTest.php
+++ b/tests/Io/BufferedBodyTest.php
@@ -91,7 +91,7 @@ class BufferedBodyTest extends TestCase
         } catch (\RuntimeException $e) {
             $this->assertSame(0, $stream->tell());
 
-            $this->setExpectedException('RuntimeException');
+            $this->expectException(\RuntimeException::class);
             throw $e;
         }
     }
@@ -100,7 +100,7 @@ class BufferedBodyTest extends TestCase
     {
         $stream = new BufferedBody('hello');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $stream->seek(1, 12345);
     }
 
@@ -109,7 +109,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->seek(0);
     }
 
@@ -118,7 +118,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->tell();
     }
 
@@ -136,7 +136,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->rewind();
     }
 
@@ -180,7 +180,7 @@ class BufferedBodyTest extends TestCase
     {
         $stream = new BufferedBody('hello');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $stream->read(0);
     }
 
@@ -189,7 +189,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->read(10);
     }
 
@@ -218,7 +218,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->getContents();
     }
 
@@ -280,7 +280,7 @@ class BufferedBodyTest extends TestCase
         $stream = new BufferedBody('hello');
         $stream->close();
 
-        $this->setExpectedException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $stream->write('foo');
     }
 

--- a/tests/Io/BufferedBodyTest.php
+++ b/tests/Io/BufferedBodyTest.php
@@ -288,7 +288,7 @@ class BufferedBodyTest extends TestCase
     {
         $stream = new BufferedBody('hello');
 
-        $this->assertEquals(array(), $stream->getMetadata());
+        $this->assertEquals([], $stream->getMetadata());
     }
 
     public function testGetMetadataWithKeyReturnsNull()

--- a/tests/Io/ChunkedDecoderTest.php
+++ b/tests/Io/ChunkedDecoderTest.php
@@ -26,12 +26,12 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("5\r\nhello\r\n"));
+        $this->input->emit('data', ["5\r\nhello\r\n"]);
     }
 
     public function testTwoChunks()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -39,9 +39,9 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n"));
+        $this->input->emit('data', ["5\r\nhello\r\n3\r\nbla\r\n"]);
 
-        $this->assertEquals(array('hello', 'bla'), $buffer);
+        $this->assertEquals(['hello', 'bla'], $buffer);
     }
 
     public function testEnd()
@@ -50,12 +50,12 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("0\r\n\r\n"));
+        $this->input->emit('data', ["0\r\n\r\n"]);
     }
 
     public function testParameterWithEnd()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -64,9 +64,9 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"));
+        $this->input->emit('data', ["5\r\nhello\r\n3\r\nbla\r\n0\r\n\r\n"]);
 
-        $this->assertEquals(array('hello', 'bla'), $buffer);
+        $this->assertEquals(['hello', 'bla'], $buffer);
     }
 
     public function testInvalidChunk()
@@ -76,7 +76,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("bla\r\n"));
+        $this->input->emit('data', ["bla\r\n"]);
     }
 
     public function testNeverEnd()
@@ -85,7 +85,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("0\r\n"));
+        $this->input->emit('data', ["0\r\n"]);
     }
 
     public function testWrongChunkHex()
@@ -94,7 +94,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('end', $this->expectCallableNever());
 
-        $this->input->emit('data', array("2\r\na\r\n5\r\nhello\r\n"));
+        $this->input->emit('data', ["2\r\na\r\n5\r\nhello\r\n"]);
     }
 
     public function testSplittedChunk()
@@ -104,8 +104,8 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4\r\n"));
-        $this->input->emit('data', array("welt\r\n"));
+        $this->input->emit('data', ["4\r\n"]);
+        $this->input->emit('data', ["welt\r\n"]);
     }
 
     public function testSplittedHeader()
@@ -115,8 +115,8 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());#
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4"));
-        $this->input->emit('data', array("\r\nwelt\r\n"));
+        $this->input->emit('data', ["4"]);
+        $this->input->emit('data', ["\r\nwelt\r\n"]);
     }
 
     public function testSplittedBoth()
@@ -126,14 +126,14 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("welt\r\n"));
+        $this->input->emit('data', ["4"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["welt\r\n"]);
     }
 
     public function testCompletlySplitted()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -142,17 +142,17 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("we"));
-        $this->input->emit('data', array("lt\r\n"));
+        $this->input->emit('data', ["4"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["we"]);
+        $this->input->emit('data', ["lt\r\n"]);
 
-        $this->assertEquals(array('we', 'lt'), $buffer);
+        $this->assertEquals(['we', 'lt'], $buffer);
     }
 
     public function testMixed()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -161,17 +161,17 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("welt\r\n"));
-        $this->input->emit('data', array("5\r\nhello\r\n"));
+        $this->input->emit('data', ["4"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["welt\r\n"]);
+        $this->input->emit('data', ["5\r\nhello\r\n"]);
 
-        $this->assertEquals(array('welt', 'hello'), $buffer);
+        $this->assertEquals(['welt', 'hello'], $buffer);
     }
 
     public function testBigger()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -180,18 +180,18 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("1"));
-        $this->input->emit('data', array("0"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("abcdeabcdeabcdea\r\n"));
-        $this->input->emit('data', array("5\r\nhello\r\n"));
+        $this->input->emit('data', ["1"]);
+        $this->input->emit('data', ["0"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["abcdeabcdeabcdea\r\n"]);
+        $this->input->emit('data', ["5\r\nhello\r\n"]);
 
-        $this->assertEquals(array('abcdeabcdeabcdea', 'hello'), $buffer);
+        $this->assertEquals(['abcdeabcdeabcdea', 'hello'], $buffer);
     }
 
     public function testOneUnfinished()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -200,11 +200,11 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("3\r\n"));
-        $this->input->emit('data', array("bla\r\n"));
-        $this->input->emit('data', array("5\r\nhello"));
+        $this->input->emit('data', ["3\r\n"]);
+        $this->input->emit('data', ["bla\r\n"]);
+        $this->input->emit('data', ["5\r\nhello"]);
 
-        $this->assertEquals(array('bla', 'hello'), $buffer);
+        $this->assertEquals(['bla', 'hello'], $buffer);
     }
 
     public function testChunkIsBiggerThenExpected()
@@ -214,8 +214,8 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("5\r\n"));
-        $this->input->emit('data', array("hello world\r\n"));
+        $this->input->emit('data', ["5\r\n"]);
+        $this->input->emit('data', ["hello world\r\n"]);
     }
 
     public function testHandleUnexpectedEnd()
@@ -235,7 +235,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("3;hello=world;foo=bar\r\nbla"));
+        $this->input->emit('data', ["3;hello=world;foo=bar\r\nbla"]);
     }
 
     public function testChunkHeaderIsTooBig()
@@ -249,7 +249,7 @@ class ChunkedDecoderTest extends TestCase
         for ($i = 0; $i < 1025; $i++) {
             $data .= 'a';
         }
-        $this->input->emit('data', array($data));
+        $this->input->emit('data', [$data]);
     }
 
     public function testChunkIsMaximumSize()
@@ -265,7 +265,7 @@ class ChunkedDecoderTest extends TestCase
         }
         $data .= "\r\n";
 
-        $this->input->emit('data', array($data));
+        $this->input->emit('data', [$data]);
     }
 
     public function testLateCrlf()
@@ -275,9 +275,9 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("4\r\nlate"));
-        $this->input->emit('data', array("\r"));
-        $this->input->emit('data', array("\n"));
+        $this->input->emit('data', ["4\r\nlate"]);
+        $this->input->emit('data', ["\r"]);
+        $this->input->emit('data', ["\n"]);
     }
 
     public function testNoCrlfInChunk()
@@ -287,7 +287,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("2\r\nno crlf"));
+        $this->input->emit('data', ["2\r\nno crlf"]);
     }
 
     public function testNoCrlfInChunkSplitted()
@@ -297,10 +297,10 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("2\r\n"));
-        $this->input->emit('data', array("no"));
-        $this->input->emit('data', array("further"));
-        $this->input->emit('data', array("clrf"));
+        $this->input->emit('data', ["2\r\n"]);
+        $this->input->emit('data', ["no"]);
+        $this->input->emit('data', ["further"]);
+        $this->input->emit('data', ["clrf"]);
     }
 
     public function testEmitEmptyChunkBody()
@@ -310,9 +310,9 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("2\r\n"));
-        $this->input->emit('data', array(""));
-        $this->input->emit('data', array(""));
+        $this->input->emit('data', ["2\r\n"]);
+        $this->input->emit('data', [""]);
+        $this->input->emit('data', [""]);
     }
 
     public function testEmitCrlfAsChunkBody()
@@ -322,9 +322,9 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableNever());
 
-        $this->input->emit('data', array("2\r\n"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("\r\n"));
+        $this->input->emit('data', ["2\r\n"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["\r\n"]);
     }
 
     public function testNegativeHeader()
@@ -334,7 +334,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("-2\r\n"));
+        $this->input->emit('data', ["-2\r\n"]);
     }
 
     public function testHexDecimalInBodyIsPotentialThread()
@@ -344,7 +344,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("4\r\ntest5\r\nworld"));
+        $this->input->emit('data', ["4\r\ntest5\r\nworld"]);
     }
 
     public function testHexDecimalInBodyIsPotentialThreadSplitted()
@@ -354,17 +354,17 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('error', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("4"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("test"));
-        $this->input->emit('data', array("5"));
-        $this->input->emit('data', array("\r\n"));
-        $this->input->emit('data', array("world"));
+        $this->input->emit('data', ["4"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["test"]);
+        $this->input->emit('data', ["5"]);
+        $this->input->emit('data', ["\r\n"]);
+        $this->input->emit('data', ["world"]);
     }
 
     public function testEmitSingleCharacter()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -375,10 +375,10 @@ class ChunkedDecoderTest extends TestCase
         $array = str_split("4\r\ntest\r\n0\r\n\r\n");
 
         foreach ($array as $character) {
-            $this->input->emit('data', array($character));
+            $this->input->emit('data', [$character]);
         }
 
-        $this->assertEquals(array('t', 'e', 's', 't'), $buffer);
+        $this->assertEquals(['t', 'e', 's', 't'], $buffer);
     }
 
     public function testHandleError()
@@ -387,7 +387,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
         $this->parser->on('end', $this->expectCallableNever());
 
-        $this->input->emit('error', array(new \RuntimeException()));
+        $this->input->emit('error', [new \RuntimeException()]);
 
         $this->assertFalse($this->parser->isReadable());
     }
@@ -425,7 +425,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('close', $this->expectCallableOnce());
 
         $this->input->close();
-        $this->input->emit('end', array());
+        $this->input->emit('end', []);
 
     	$this->assertFalse($this->parser->isReadable());
     }
@@ -445,7 +445,7 @@ class ChunkedDecoderTest extends TestCase
 
     public function testLeadingZerosWillBeIgnored()
     {
-        $buffer = array();
+        $buffer = [];
         $this->parser->on('data', function ($data) use (&$buffer) {
             $buffer[] = $data;
         });
@@ -454,10 +454,10 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("00005\r\nhello\r\n"));
-        $this->input->emit('data', array("0000b\r\nhello world\r\n"));
+        $this->input->emit('data', ["00005\r\nhello\r\n"]);
+        $this->input->emit('data', ["0000b\r\nhello world\r\n"]);
 
-        $this->assertEquals(array('hello', 'hello world'), $buffer);
+        $this->assertEquals(['hello', 'hello world'], $buffer);
     }
 
     public function testLeadingZerosInEndChunkWillBeIgnored()
@@ -467,7 +467,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("0000\r\n\r\n"));
+        $this->input->emit('data', ["0000\r\n\r\n"]);
     }
 
     public function testAdditionalWhitespaceInEndChunkWillBeIgnored()
@@ -477,7 +477,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array(" 0 \r\n\r\n"));
+        $this->input->emit('data', [" 0 \r\n\r\n"]);
     }
 
     public function testEndChunkWithTrailersWillBeIgnored()
@@ -487,7 +487,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("0\r\nFoo: bar\r\n\r\n"));
+        $this->input->emit('data', ["0\r\nFoo: bar\r\n\r\n"]);
     }
 
     public function testEndChunkWithMultipleTrailersWillBeIgnored()
@@ -497,7 +497,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableOnce());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("0\r\nFoo: a\r\nBar: b\r\nBaz: c\r\n\r\n"));
+        $this->input->emit('data', ["0\r\nFoo: a\r\nBar: b\r\nBaz: c\r\n\r\n"]);
     }
 
     public function testLeadingZerosInInvalidChunk()
@@ -507,7 +507,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("0000hello\r\n\r\n"));
+        $this->input->emit('data', ["0000hello\r\n\r\n"]);
     }
 
     public function testEmptyHeaderLeadsToError()
@@ -517,7 +517,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("\r\n\r\n"));
+        $this->input->emit('data', ["\r\n\r\n"]);
     }
 
     public function testEmptyHeaderAndFilledBodyLeadsToError()
@@ -527,7 +527,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("\r\nhello\r\n"));
+        $this->input->emit('data', ["\r\nhello\r\n"]);
     }
 
     public function testUpperCaseHexWillBeHandled()
@@ -537,7 +537,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("A\r\n0123456790\r\n"));
+        $this->input->emit('data', ["A\r\n0123456790\r\n"]);
     }
 
     public function testLowerCaseHexWillBeHandled()
@@ -547,7 +547,7 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("a\r\n0123456790\r\n"));
+        $this->input->emit('data', ["a\r\n0123456790\r\n"]);
     }
 
     public function testMixedUpperAndLowerCaseHexValuesInHeaderWillBeHandled()
@@ -559,6 +559,6 @@ class ChunkedDecoderTest extends TestCase
         $this->parser->on('end', $this->expectCallableNever());
         $this->parser->on('close', $this->expectCallableNever());
 
-        $this->input->emit('data', array("aA\r\n" . $data . "\r\n"));
+        $this->input->emit('data', ["aA\r\n" . $data . "\r\n"]);
     }
 }

--- a/tests/Io/ChunkedDecoderTest.php
+++ b/tests/Io/ChunkedDecoderTest.php
@@ -3,7 +3,9 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\ChunkedDecoder;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class ChunkedDecoderTest extends TestCase
@@ -394,7 +396,7 @@ class ChunkedDecoderTest extends TestCase
 
     public function testPauseStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $parser = new ChunkedDecoder($input);
@@ -403,7 +405,7 @@ class ChunkedDecoderTest extends TestCase
 
     public function testResumeStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $parser = new ChunkedDecoder($input);
@@ -413,7 +415,7 @@ class ChunkedDecoderTest extends TestCase
 
     public function testPipeStream()
     {
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $this->parser->pipe($dest);
 

--- a/tests/Io/ChunkedEncoderTest.php
+++ b/tests/Io/ChunkedEncoderTest.php
@@ -3,7 +3,9 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\ChunkedEncoder;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class ChunkedEncoderTest extends TestCase
@@ -59,7 +61,7 @@ class ChunkedEncoderTest extends TestCase
 
     public function testPauseStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $parser = new ChunkedEncoder($input);
@@ -68,7 +70,7 @@ class ChunkedEncoderTest extends TestCase
 
     public function testResumeStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $parser = new ChunkedEncoder($input);
@@ -78,7 +80,7 @@ class ChunkedEncoderTest extends TestCase
 
     public function testPipeStream()
     {
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $this->chunkedStream->pipe($dest);
 

--- a/tests/Io/ChunkedEncoderTest.php
+++ b/tests/Io/ChunkedEncoderTest.php
@@ -23,19 +23,19 @@ class ChunkedEncoderTest extends TestCase
     public function testChunked()
     {
         $this->chunkedStream->on('data', $this->expectCallableOnceWith("5\r\nhello\r\n"));
-        $this->input->emit('data', array('hello'));
+        $this->input->emit('data', ['hello']);
     }
 
     public function testEmptyString()
     {
         $this->chunkedStream->on('data', $this->expectCallableNever());
-        $this->input->emit('data', array(''));
+        $this->input->emit('data', ['']);
     }
 
     public function testBiggerStringToCheckHexValue()
     {
         $this->chunkedStream->on('data', $this->expectCallableOnceWith("1a\r\nabcdefghijklmnopqrstuvwxyz\r\n"));
-        $this->input->emit('data', array('abcdefghijklmnopqrstuvwxyz'));
+        $this->input->emit('data', ['abcdefghijklmnopqrstuvwxyz']);
     }
 
     public function testHandleClose()
@@ -52,7 +52,7 @@ class ChunkedEncoderTest extends TestCase
         $this->chunkedStream->on('error', $this->expectCallableOnce());
         $this->chunkedStream->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('error', array(new \RuntimeException()));
+        $this->input->emit('error', [new \RuntimeException()]);
 
         $this->assertFalse($this->chunkedStream->isReadable());
     }

--- a/tests/Io/ClientConnectionManagerTest.php
+++ b/tests/Io/ClientConnectionManagerTest.php
@@ -2,10 +2,14 @@
 
 namespace React\Tests\Http\Io;
 
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 use React\Http\Io\ClientConnectionManager;
 use React\Http\Message\Uri;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
+use React\Socket\ConnectionInterface;
+use React\Socket\ConnectorInterface;
 use React\Tests\Http\TestCase;
 use function React\Promise\resolve;
 
@@ -14,10 +18,10 @@ class ClientConnectionManagerTest extends TestCase
     public function testConnectWithHttpsUriShouldConnectToTlsWithDefaultPort()
     {
         $promise = new Promise(function () { });
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn($promise);
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -30,10 +34,10 @@ class ClientConnectionManagerTest extends TestCase
     public function testConnectWithHttpUriShouldConnectToTcpWithDefaultPort()
     {
         $promise = new Promise(function () { });
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('reactphp.org:80')->willReturn($promise);
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -44,10 +48,10 @@ class ClientConnectionManagerTest extends TestCase
     public function testConnectWithExplicitPortShouldConnectWithGivenPort()
     {
         $promise = new Promise(function () { });
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('reactphp.org:8080')->willReturn($promise);
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -57,10 +61,10 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectWithInvalidSchemeShouldRejectWithException()
     {
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->never())->method('connect');
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -71,16 +75,16 @@ class ClientConnectionManagerTest extends TestCase
             $exception = $reason;
         });
 
-        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
         $this->assertEquals('Invalid request URL given', $exception->getMessage());
     }
 
     public function testConnectWithoutSchemeShouldRejectWithException()
     {
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->never())->method('connect');
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -91,13 +95,13 @@ class ClientConnectionManagerTest extends TestCase
             $exception = $reason;
         });
 
-        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
         $this->assertEquals('Invalid request URL given', $exception->getMessage());
     }
 
     public function testConnectReusesIdleConnectionFromPreviousKeepAliveCallWithoutUsingConnectorAndWillAddAndRemoveStreamEventsAndAddAndCancelIdleTimer()
     {
-        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connectionToReuse = $this->createMock(ConnectionInterface::class);
 
         $streamHandler = null;
         $connectionToReuse->expects($this->exactly(3))->method('on')->withConsecutive(
@@ -148,11 +152,11 @@ class ClientConnectionManagerTest extends TestCase
             ]
         );
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->never())->method('connect');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -173,13 +177,13 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectReusesIdleConnectionFromPreviousKeepAliveCallWithoutUsingConnectorAlsoWhenUriPathAndQueryAndFragmentIsDifferent()
     {
-        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connectionToReuse = $this->createMock(ConnectionInterface::class);
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->never())->method('connect');
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -200,13 +204,13 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectUsesConnectorWithSameUriAndReturnsPromiseForNewConnectionFromConnectorWhenPreviousKeepAliveCallUsedDifferentUri()
     {
-        $connectionToReuse = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connectionToReuse = $this->createMock(ConnectionInterface::class);
 
         $promise = new Promise(function () { });
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn($promise);
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
 
@@ -220,14 +224,14 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectUsesConnectorForNewConnectionWhenPreviousConnectReusedIdleConnectionFromPreviousKeepAliveCall()
     {
-        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $firstConnection = $this->createMock(ConnectionInterface::class);
+        $secondConnection = $this->createMock(ConnectionInterface::class);
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 
@@ -251,12 +255,12 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testKeepAliveAddsTimerAndDoesNotCloseConnectionImmediately()
     {
-        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->never())->method('close');
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
 
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything());
 
         $connectionManager = new ClientConnectionManager($connector, $loop);
@@ -266,14 +270,14 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testKeepAliveClosesConnectionAfterIdleTimeout()
     {
-        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())->method('close');
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
 
         $timerCallback = null;
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timerCallback) {
             $timerCallback = $cb;
             return true;
@@ -291,18 +295,18 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectUsesConnectorForNewConnectionWhenIdleConnectionFromPreviousKeepAliveCallHasAlreadyTimedOut()
     {
-        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $firstConnection = $this->createMock(ConnectionInterface::class);
         $firstConnection->expects($this->once())->method('close');
 
-        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $secondConnection = $this->createMock(ConnectionInterface::class);
         $secondConnection->expects($this->never())->method('close');
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
         $timerCallback = null;
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timerCallback) {
             $timerCallback = $cb;
             return true;
@@ -330,7 +334,7 @@ class ClientConnectionManagerTest extends TestCase
 
     public function testConnectUsesConnectorForNewConnectionWhenIdleConnectionFromPreviousKeepAliveCallHasAlreadyFiredUnexpectedStreamEventBeforeIdleTimeoutThatClosesConnection()
     {
-        $firstConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $firstConnection = $this->createMock(ConnectionInterface::class);
         $firstConnection->expects($this->once())->method('close');
 
         $streamHandler = null;
@@ -358,14 +362,14 @@ class ClientConnectionManagerTest extends TestCase
             ]
         );
 
-        $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $secondConnection = $this->createMock(ConnectionInterface::class);
         $secondConnection->expects($this->never())->method('close');
 
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector = $this->createMock(ConnectorInterface::class);
         $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
-        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $timer = $this->createMock(TimerInterface::class);
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('addTimer')->willReturn($timer);
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 

--- a/tests/Io/ClientConnectionManagerTest.php
+++ b/tests/Io/ClientConnectionManagerTest.php
@@ -7,6 +7,7 @@ use React\Http\Message\Uri;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 use React\Tests\Http\TestCase;
+use function React\Promise\resolve;
 
 class ClientConnectionManagerTest extends TestCase
 {
@@ -100,51 +101,51 @@ class ClientConnectionManagerTest extends TestCase
 
         $streamHandler = null;
         $connectionToReuse->expects($this->exactly(3))->method('on')->withConsecutive(
-            array(
+            [
                 'close',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     $streamHandler = $cb;
                     return true;
                 })
-            ),
-            array(
+            ],
+            [
                 'data',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            ),
-            array(
+            ],
+            [
                 'error',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            )
+            ]
         );
 
         $connectionToReuse->expects($this->exactly(3))->method('removeListener')->withConsecutive(
-            array(
+            [
                 'close',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            ),
-            array(
+            ],
+            [
                 'data',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            ),
-            array(
+            ],
+            [
                 'error',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            )
+            ]
         );
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
@@ -223,7 +224,7 @@ class ClientConnectionManagerTest extends TestCase
         $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -297,7 +298,7 @@ class ClientConnectionManagerTest extends TestCase
         $secondConnection->expects($this->never())->method('close');
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
         $timerCallback = null;
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
@@ -334,34 +335,34 @@ class ClientConnectionManagerTest extends TestCase
 
         $streamHandler = null;
         $firstConnection->expects($this->exactly(3))->method('on')->withConsecutive(
-            array(
+            [
                 'close',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     $streamHandler = $cb;
                     return true;
                 })
-            ),
-            array(
+            ],
+            [
                 'data',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            ),
-            array(
+            ],
+            [
                 'error',
                 $this->callback(function ($cb) use (&$streamHandler) {
                     assert($streamHandler instanceof \Closure);
                     return $cb === $streamHandler;
                 })
-            )
+            ]
         );
 
         $secondConnection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $secondConnection->expects($this->never())->method('close');
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(\React\Promise\resolve($secondConnection));
+        $connector->expects($this->once())->method('connect')->with('tls://reactphp.org:443')->willReturn(resolve($secondConnection));
 
         $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/Io/ClientRequestStreamTest.php
+++ b/tests/Io/ClientRequestStreamTest.php
@@ -12,6 +12,8 @@ use React\Promise\Promise;
 use React\Stream\DuplexResourceStream;
 use React\Stream\ReadableStreamInterface;
 use React\Tests\Http\TestCase;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class ClientRequestStreamTest extends TestCase
 {
@@ -22,25 +24,25 @@ class ClientRequestStreamTest extends TestCase
 
         $uri = new Uri('http://www.example.com');
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->with($uri)->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->with($uri)->willReturn(resolve($connection));
 
         $requestData = new Request('GET', $uri);
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $connection->expects($this->atLeast(5))->method('on')->withConsecutive(
-            array('drain', $this->identicalTo(array($request, 'handleDrain'))),
-            array('data', $this->identicalTo(array($request, 'handleData'))),
-            array('end', $this->identicalTo(array($request, 'handleEnd'))),
-            array('error', $this->identicalTo(array($request, 'handleError'))),
-            array('close', $this->identicalTo(array($request, 'close')))
+            ['drain', $this->identicalTo([$request, 'handleDrain'])],
+            ['data', $this->identicalTo([$request, 'handleData'])],
+            ['end', $this->identicalTo([$request, 'handleEnd'])],
+            ['error', $this->identicalTo([$request, 'handleError'])],
+            ['close', $this->identicalTo([$request, 'close'])]
         );
 
         $connection->expects($this->exactly(5))->method('removeListener')->withConsecutive(
-            array('drain', $this->identicalTo(array($request, 'handleDrain'))),
-            array('data', $this->identicalTo(array($request, 'handleData'))),
-            array('end', $this->identicalTo(array($request, 'handleEnd'))),
-            array('error', $this->identicalTo(array($request, 'handleError'))),
-            array('close', $this->identicalTo(array($request, 'close')))
+            ['drain', $this->identicalTo([$request, 'handleDrain'])],
+            ['data', $this->identicalTo([$request, 'handleData'])],
+            ['end', $this->identicalTo([$request, 'handleEnd'])],
+            ['error', $this->identicalTo([$request, 'handleError'])],
+            ['close', $this->identicalTo([$request, 'close'])]
         );
 
         $request->end();
@@ -54,7 +56,7 @@ class ClientRequestStreamTest extends TestCase
     public function requestShouldEmitErrorIfConnectionFails()
     {
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\reject(new \RuntimeException()));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(reject(new \RuntimeException()));
 
         $requestData = new Request('GET', 'http://www.example.com');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -71,7 +73,7 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -89,7 +91,7 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -105,44 +107,44 @@ class ClientRequestStreamTest extends TestCase
     {
         $request = new Request('GET' , "http://localhost/");
 
-        return array(
-            array(
+        return [
+            [
                 $request->withMethod("INVA\r\nLID", '')
-            ),
-            array(
+            ],
+            [
                 $request->withRequestTarget('/inva lid')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Invalid', "Yes\r\n")
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Invalid', "Yes\n")
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Invalid', "Yes\r")
-            ),
-            array(
+            ],
+            [
                 $request->withHeader("Inva\r\nlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader("Inva\nlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader("Inva\rlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Inva Lid', 'Yes')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Inva:Lid', 'Yes')
-            ),
-            array(
+            ],
+            [
                 $request->withHeader('Invalid', "Val\0ue")
-            ),
-            array(
+            ],
+            [
                 $request->withHeader("Inva\0lid", 'Yes')
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -168,7 +170,7 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
         $request = new ClientRequestStream($connectionManager, $requestData);
@@ -187,9 +189,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.0\r\nHost: www.example.com\r\n\r\n");
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
@@ -202,9 +204,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end();
@@ -217,9 +219,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with("OPTIONS * HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('OPTIONS', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('OPTIONS', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $requestData = $requestData->withRequestTarget('*');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
@@ -233,16 +235,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -258,16 +259,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -283,16 +283,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -308,16 +307,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('HEAD', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('HEAD', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -333,16 +331,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnceWith('OK'));
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnceWith('OK'));
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -358,16 +355,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableNever());
-            $body->on('close', $that->expectCallableNever());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableNever());
+            $body->on('close', $this->expectCallableNever());
         });
         $request->on('close', $this->expectCallableNever());
 
@@ -383,16 +379,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnce('O'));
-            $body->on('end', $that->expectCallableNever());
-            $body->on('close', $that->expectCallableNever());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnce('O'));
+            $body->on('end', $this->expectCallableNever());
+            $body->on('close', $this->expectCallableNever());
         });
         $request->on('close', $this->expectCallableNever());
 
@@ -408,16 +403,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnceWith('OK'));
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnceWith('OK'));
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -433,16 +427,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableNever());
-            $body->on('end', $that->expectCallableNever());
-            $body->on('close', $that->expectCallableNever());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableNever());
+            $body->on('end', $this->expectCallableNever());
+            $body->on('close', $this->expectCallableNever());
         });
         $request->on('close', $this->expectCallableNever());
 
@@ -458,16 +451,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnceWith('O'));
-            $body->on('end', $that->expectCallableNever());
-            $body->on('close', $that->expectCallableNever());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnceWith('O'));
+            $body->on('end', $this->expectCallableNever());
+            $body->on('close', $this->expectCallableNever());
         });
         $request->on('close', $this->expectCallableNever());
 
@@ -483,16 +475,15 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnce('O'));
-            $body->on('end', $that->expectCallableNever());
-            $body->on('close', $that->expectCallableNever());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnce('O'));
+            $body->on('end', $this->expectCallableNever());
+            $body->on('close', $this->expectCallableNever());
         });
         $request->on('close', $this->expectCallableNever());
 
@@ -520,16 +511,15 @@ class ClientRequestStreamTest extends TestCase
         }));
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'close'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'close'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
-        $that = $this;
-        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) use ($that) {
-            $body->on('data', $that->expectCallableOnce('OK'));
-            $body->on('end', $that->expectCallableOnce());
-            $body->on('close', $that->expectCallableOnce());
+        $request->on('response', function (ResponseInterface $response, ReadableStreamInterface $body) {
+            $body->on('data', $this->expectCallableOnce('OK'));
+            $body->on('end', $this->expectCallableOnce());
+            $body->on('close', $this->expectCallableOnce());
         });
         $request->on('close', $this->expectCallableOnce());
 
@@ -549,10 +539,10 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
         $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -570,9 +560,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -590,9 +580,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'FOO, CLOSE, BAR'), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'FOO, CLOSE, BAR'], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -610,9 +600,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -630,10 +620,10 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
         $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'keep-alive'), '', '1.0');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'keep-alive'], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -651,10 +641,10 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
         $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
-        $requestData = new Request('GET', 'http://www.example.com', array('Connection' => 'FOO, KEEP-ALIVE, BAR'), '', '1.0');
+        $requestData = new Request('GET', 'http://www.example.com', ['Connection' => 'FOO, KEEP-ALIVE, BAR'], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -684,9 +674,9 @@ class ClientRequestStreamTest extends TestCase
         }));
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -719,9 +709,9 @@ class ClientRequestStreamTest extends TestCase
         }));
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -742,10 +732,10 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->never())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
         $connectionManager->expects($this->once())->method('keepAlive')->with(new Uri('http://www.example.com'), $connection);
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -763,9 +753,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('close');
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('GET', 'http://www.example.com', array(), '', '1.1');
+        $requestData = new Request('GET', 'http://www.example.com', [], '', '1.1');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->on('close', $this->expectCallableOnce());
@@ -782,9 +772,9 @@ class ClientRequestStreamTest extends TestCase
         $connection->expects($this->once())->method('write')->with($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome post data$#"));
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('POST', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->end('some post data');
@@ -799,15 +789,15 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->exactly(3))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")),
-            array($this->identicalTo("post")),
-            array($this->identicalTo("data"))
+            [$this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")],
+            [$this->identicalTo("post")],
+            [$this->identicalTo("data")]
         );
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('POST', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $request->write("some");
@@ -824,8 +814,8 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->exactly(2))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")),
-            array($this->identicalTo("data"))
+            [$this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")],
+            [$this->identicalTo("data")]
         )->willReturn(
             true
         );
@@ -834,7 +824,7 @@ class ClientRequestStreamTest extends TestCase
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn($deferred->promise());
 
-        $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('POST', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $this->assertFalse($request->write("some"));
@@ -858,12 +848,12 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\Connection')
             ->disableOriginalConstructor()
-            ->setMethods(array('write'))
+            ->setMethods(['write'])
             ->getMock();
 
         $connection->expects($this->exactly(2))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")),
-            array($this->identicalTo("data"))
+            [$this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsomepost$#")],
+            [$this->identicalTo("data")]
         )->willReturn(
             false
         );
@@ -872,7 +862,7 @@ class ClientRequestStreamTest extends TestCase
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
         $connectionManager->expects($this->once())->method('connect')->willReturn($deferred->promise());
 
-        $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('POST', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $this->assertFalse($request->write("some"));
@@ -897,15 +887,15 @@ class ClientRequestStreamTest extends TestCase
     {
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->exactly(3))->method('write')->withConsecutive(
-            array($this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")),
-            array($this->identicalTo("post")),
-            array($this->identicalTo("data"))
+            [$this->matchesRegularExpression("#^POST / HTTP/1\.0\r\nHost: www.example.com\r\n\r\nsome$#")],
+            [$this->identicalTo("post")],
+            [$this->identicalTo("data")]
         );
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
-        $requestData = new Request('POST', 'http://www.example.com', array(), '', '1.0');
+        $requestData = new Request('POST', 'http://www.example.com', [], '', '1.0');
         $request = new ClientRequestStream($connectionManager, $requestData);
 
         $loop = $this
@@ -916,9 +906,9 @@ class ClientRequestStreamTest extends TestCase
         $stream = new DuplexResourceStream($stream, $loop);
 
         $stream->pipe($request);
-        $stream->emit('data', array('some'));
-        $stream->emit('data', array('post'));
-        $stream->emit('data', array('data'));
+        $stream->emit('data', ['some']);
+        $stream->emit('data', ['post']);
+        $stream->emit('data', ['data']);
 
         $request->handleData("HTTP/1.0 200 OK\r\n");
         $request->handleData("Content-Type: text/plain\r\n");
@@ -1044,7 +1034,7 @@ class ClientRequestStreamTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $connectionManager = $this->getMockBuilder('React\Http\Io\ClientConnectionManager')->disableOriginalConstructor()->getMock();
-        $connectionManager->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+        $connectionManager->expects($this->once())->method('connect')->willReturn(resolve($connection));
 
         $requestData = new Request('GET', 'http://www.example.com');
         $request = new ClientRequestStream($connectionManager, $requestData);

--- a/tests/Io/ClockTest.php
+++ b/tests/Io/ClockTest.php
@@ -3,13 +3,14 @@
 namespace React\Tests\Http\Io;
 
 use PHPUnit\Framework\TestCase;
+use React\EventLoop\LoopInterface;
 use React\Http\Io\Clock;
 
 class ClockTest extends TestCase
 {
     public function testNowReturnsSameTimestampMultipleTimesInSameTick()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
 
         $clock = new Clock($loop);
 
@@ -21,7 +22,7 @@ class ClockTest extends TestCase
     public function testNowResetsMemoizedTimestampOnFutureTick()
     {
         $tick = null;
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $loop = $this->createMock(LoopInterface::class);
         $loop->expects($this->once())->method('futureTick')->with($this->callback(function ($cb) use (&$tick) {
             $tick = $cb;
             return true;

--- a/tests/Io/CloseProtectionStreamTest.php
+++ b/tests/Io/CloseProtectionStreamTest.php
@@ -27,7 +27,7 @@ class CloseProtectionStreamTest extends TestCase
         $protection->on('error', $this->expectCallableOnce());
         $protection->on('close', $this->expectCallableNever());
 
-        $input->emit('error', array(new \RuntimeException()));
+        $input->emit('error', [new \RuntimeException()]);
 
         $this->assertTrue($protection->isReadable());
         $this->assertTrue($input->isReadable());
@@ -91,7 +91,7 @@ class CloseProtectionStreamTest extends TestCase
 
         $protection->close();
 
-        $input->emit('data', array('hello'));
+        $input->emit('data', ['hello']);
 
         $this->assertFalse($protection->isReadable());
         $this->assertTrue($input->isReadable());
@@ -108,7 +108,7 @@ class CloseProtectionStreamTest extends TestCase
 
         $protection->close();
 
-        $input->emit('error', array(new \Exception()));
+        $input->emit('error', [new \Exception()]);
 
         $this->assertFalse($protection->isReadable());
         $this->assertTrue($input->isReadable());
@@ -124,7 +124,7 @@ class CloseProtectionStreamTest extends TestCase
 
         $protection->close();
 
-        $input->emit('end', array());
+        $input->emit('end', []);
 
         $this->assertFalse($protection->isReadable());
         $this->assertTrue($input->isReadable());

--- a/tests/Io/CloseProtectionStreamTest.php
+++ b/tests/Io/CloseProtectionStreamTest.php
@@ -3,14 +3,16 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\CloseProtectionStream;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class CloseProtectionStreamTest extends TestCase
 {
     public function testCloseDoesNotCloseTheInputStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->disableOriginalConstructor()->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->never())->method('pause');
         $input->expects($this->never())->method('resume');
         $input->expects($this->never())->method('close');
@@ -35,7 +37,7 @@ class CloseProtectionStreamTest extends TestCase
 
     public function testResumeStreamWillResumeInputStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
         $input->expects($this->once())->method('resume');
 
@@ -46,7 +48,7 @@ class CloseProtectionStreamTest extends TestCase
 
     public function testCloseResumesInputStreamIfItWasPreviouslyPaused()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
         $input->expects($this->once())->method('resume');
 
@@ -73,7 +75,7 @@ class CloseProtectionStreamTest extends TestCase
         $input = new ThroughStream();
 
         $protection = new CloseProtectionStream($input);
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $protection->pipe($dest);
 
@@ -132,7 +134,7 @@ class CloseProtectionStreamTest extends TestCase
 
     public function testPauseAfterCloseHasNoEffect()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->never())->method('pause');
         $input->expects($this->never())->method('resume');
 
@@ -146,7 +148,7 @@ class CloseProtectionStreamTest extends TestCase
 
     public function testResumeAfterCloseHasNoEffect()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->never())->method('pause');
         $input->expects($this->never())->method('resume');
 

--- a/tests/Io/EmptyBodyStreamTest.php
+++ b/tests/Io/EmptyBodyStreamTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\EmptyBodyStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class EmptyBodyStreamTest extends TestCase
@@ -36,7 +37,7 @@ class EmptyBodyStreamTest extends TestCase
 
     public function testPipeStreamReturnsDestinationStream()
     {
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $this->bodyStream->pipe($dest);
 
@@ -70,13 +71,13 @@ class EmptyBodyStreamTest extends TestCase
 
     public function testTell()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->tell();
     }
 
     public function testEof()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->eof();
     }
 
@@ -87,13 +88,13 @@ class EmptyBodyStreamTest extends TestCase
 
     public function testWrite()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->write('');
     }
 
     public function testRead()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->read(1);
     }
 
@@ -126,13 +127,13 @@ class EmptyBodyStreamTest extends TestCase
 
     public function testSeek()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->seek('');
     }
 
     public function testRewind()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->rewind();
     }
 

--- a/tests/Io/EmptyBodyStreamTest.php
+++ b/tests/Io/EmptyBodyStreamTest.php
@@ -65,7 +65,7 @@ class EmptyBodyStreamTest extends TestCase
         $this->bodyStream->close();
         $this->bodyStream->close();
 
-        $this->assertEquals(array(), $this->bodyStream->listeners('close'));
+        $this->assertEquals([], $this->bodyStream->listeners('close'));
     }
 
     public function testTell()
@@ -104,7 +104,7 @@ class EmptyBodyStreamTest extends TestCase
 
     public function testGetMetaDataWithoutKeyReturnsEmptyArray()
     {
-        $this->assertSame(array(), $this->bodyStream->getMetadata());
+        $this->assertSame([], $this->bodyStream->getMetadata());
     }
 
     public function testGetMetaDataWithKeyReturnsNull()

--- a/tests/Io/HttpBodyStreamTest.php
+++ b/tests/Io/HttpBodyStreamTest.php
@@ -3,7 +3,9 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\HttpBodyStream;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class HttpBodyStreamTest extends TestCase
@@ -28,7 +30,7 @@ class HttpBodyStreamTest extends TestCase
 
     public function testPauseStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $bodyStream = new HttpBodyStream($input, null);
@@ -37,7 +39,7 @@ class HttpBodyStreamTest extends TestCase
 
     public function testResumeStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('resume');
 
         $bodyStream = new HttpBodyStream($input, null);
@@ -46,7 +48,7 @@ class HttpBodyStreamTest extends TestCase
 
     public function testPipeStream()
     {
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $this->bodyStream->pipe($dest);
 
@@ -107,13 +109,13 @@ class HttpBodyStreamTest extends TestCase
 
     public function testTell()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->tell();
     }
 
     public function testEof()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->eof();
     }
 
@@ -124,13 +126,13 @@ class HttpBodyStreamTest extends TestCase
 
     public function testWrite()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->write('');
     }
 
     public function testRead()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->read('');
     }
 
@@ -151,13 +153,13 @@ class HttpBodyStreamTest extends TestCase
 
     public function testSeek()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->seek('');
     }
 
     public function testRewind()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->bodyStream->rewind();
     }
 

--- a/tests/Io/HttpBodyStreamTest.php
+++ b/tests/Io/HttpBodyStreamTest.php
@@ -22,8 +22,8 @@ class HttpBodyStreamTest extends TestCase
 
     public function testDataEmit()
     {
-        $this->bodyStream->on('data', $this->expectCallableOnce(array("hello")));
-        $this->input->emit('data', array("hello"));
+        $this->bodyStream->on('data', $this->expectCallableOnce(["hello"]));
+        $this->input->emit('data', ["hello"]);
     }
 
     public function testPauseStream()
@@ -58,7 +58,7 @@ class HttpBodyStreamTest extends TestCase
         $this->bodyStream->on('close', $this->expectCallableOnce());
 
         $this->input->close();
-        $this->input->emit('end', array());
+        $this->input->emit('end', []);
 
         $this->assertFalse($this->bodyStream->isReadable());
     }
@@ -67,11 +67,11 @@ class HttpBodyStreamTest extends TestCase
     {
         $bodyStream = new HttpBodyStream($this->input, null);
         $bodyStream->on('close', $this->expectCallableOnce());
-        $this->bodyStream->on('data', $this->expectCallableOnce(array("hello")));
+        $this->bodyStream->on('data', $this->expectCallableOnce(["hello"]));
 
-        $this->input->emit('data', array("hello"));
+        $this->input->emit('data', ["hello"]);
         $bodyStream->close();
-        $this->input->emit('data', array("world"));
+        $this->input->emit('data', ["world"]);
     }
 
     public function testHandleError()
@@ -79,7 +79,7 @@ class HttpBodyStreamTest extends TestCase
         $this->bodyStream->on('error', $this->expectCallableOnce());
         $this->bodyStream->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('error', array(new \RuntimeException()));
+        $this->input->emit('error', [new \RuntimeException()]);
 
         $this->assertFalse($this->bodyStream->isReadable());
     }

--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -7,41 +7,39 @@ use React\Tests\Http\TestCase;
 
 class IniUtilTest extends TestCase
 {
-    public function provideIniSizes()
+    public static function provideIniSizes()
     {
-        return [
-            [
-                '1',
-                1,
-            ],
-            [
-                '10',
-                10,
-            ],
-            [
-                '1024',
-                1024,
-            ],
-            [
-                '1K',
-                1024,
-            ],
-            [
-                '1.5M',
-                1572864,
-            ],
-            [
-                '64M',
-                67108864,
-            ],
-            [
-                '8G',
-                8589934592,
-            ],
-            [
-                '1T',
-                1099511627776,
-            ],
+        yield [
+            '1',
+            1,
+        ];
+        yield [
+            '10',
+            10,
+        ];
+        yield [
+            '1024',
+            1024,
+        ];
+        yield [
+            '1K',
+            1024,
+        ];
+        yield [
+            '1.5M',
+            1572864,
+        ];
+        yield [
+            '64M',
+            67108864,
+        ];
+        yield [
+            '8G',
+            8589934592,
+        ];
+        yield [
+            '1T',
+            1099511627776,
         ];
     }
 
@@ -58,16 +56,14 @@ class IniUtilTest extends TestCase
         $this->assertEquals('2', IniUtil::iniSizeToBytes('2x'));
     }
 
-    public function provideInvalidInputIniSizeToBytes()
+    public static function provideInvalidInputIniSizeToBytes()
     {
-        return [
-            ['-1G'],
-            ['0G'],
-            ['foo'],
-            ['fooK'],
-            ['1ooL'],
-            ['1ooL'],
-        ];
+        yield ['-1G'];
+        yield ['0G'];
+        yield ['foo'];
+        yield ['fooK'];
+        yield ['1ooL'];
+        yield ['1ooL'];
     }
 
     /**
@@ -75,7 +71,7 @@ class IniUtilTest extends TestCase
      */
     public function testInvalidInputIniSizeToBytes($input)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         IniUtil::iniSizeToBytes($input);
     }
 }

--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -9,40 +9,40 @@ class IniUtilTest extends TestCase
 {
     public function provideIniSizes()
     {
-        return array(
-            array(
+        return [
+            [
                 '1',
                 1,
-            ),
-            array(
+            ],
+            [
                 '10',
                 10,
-            ),
-            array(
+            ],
+            [
                 '1024',
                 1024,
-            ),
-            array(
+            ],
+            [
                 '1K',
                 1024,
-            ),
-            array(
+            ],
+            [
                 '1.5M',
                 1572864,
-            ),
-            array(
+            ],
+            [
                 '64M',
                 67108864,
-            ),
-            array(
+            ],
+            [
                 '8G',
                 8589934592,
-            ),
-            array(
+            ],
+            [
                 '1T',
                 1099511627776,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -60,14 +60,14 @@ class IniUtilTest extends TestCase
 
     public function provideInvalidInputIniSizeToBytes()
     {
-        return array(
-            array('-1G'),
-            array('0G'),
-            array('foo'),
-            array('fooK'),
-            array('1ooL'),
-            array('1ooL'),
-        );
+        return [
+            ['-1G'],
+            ['0G'],
+            ['foo'],
+            ['fooK'],
+            ['1ooL'],
+            ['1ooL'],
+        ];
     }
 
     /**

--- a/tests/Io/LengthLimitedStreamTest.php
+++ b/tests/Io/LengthLimitedStreamTest.php
@@ -3,7 +3,9 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\LengthLimitedStream;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Stream\WritableStreamInterface;
 use React\Tests\Http\TestCase;
 
 class LengthLimitedStreamTest extends TestCase
@@ -59,7 +61,7 @@ class LengthLimitedStreamTest extends TestCase
 
     public function testPauseStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $stream = new LengthLimitedStream($input, 0);
@@ -68,7 +70,7 @@ class LengthLimitedStreamTest extends TestCase
 
     public function testResumeStream()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $stream = new LengthLimitedStream($input, 0);
@@ -79,7 +81,7 @@ class LengthLimitedStreamTest extends TestCase
     public function testPipeStream()
     {
         $stream = new LengthLimitedStream($this->input, 0);
-        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $dest = $this->createMock(WritableStreamInterface::class);
 
         $ret = $stream->pipe($dest);
 

--- a/tests/Io/LengthLimitedStreamTest.php
+++ b/tests/Io/LengthLimitedStreamTest.php
@@ -24,7 +24,7 @@ class LengthLimitedStreamTest extends TestCase
         $stream = new LengthLimitedStream($this->input, 5);
         $stream->on('data', $this->expectCallableOnceWith('hello'));
         $stream->on('end', $this->expectCallableOnce());
-        $this->input->emit('data', array("hello world"));
+        $this->input->emit('data', ["hello world"]);
     }
 
     public function testInputStreamKeepsEmitting()
@@ -33,9 +33,9 @@ class LengthLimitedStreamTest extends TestCase
         $stream->on('data', $this->expectCallableOnceWith('hello'));
         $stream->on('end', $this->expectCallableOnce());
 
-        $this->input->emit('data', array("hello world"));
-        $this->input->emit('data', array("world"));
-        $this->input->emit('data', array("world"));
+        $this->input->emit('data', ["hello world"]);
+        $this->input->emit('data', ["world"]);
+        $this->input->emit('data', ["world"]);
     }
 
     public function testZeroLengthInContentLengthWillIgnoreEmittedDataEvents()
@@ -43,7 +43,7 @@ class LengthLimitedStreamTest extends TestCase
         $stream = new LengthLimitedStream($this->input, 0);
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
-        $this->input->emit('data', array("hello world"));
+        $this->input->emit('data', ["hello world"]);
     }
 
     public function testHandleError()
@@ -52,7 +52,7 @@ class LengthLimitedStreamTest extends TestCase
         $stream->on('error', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
 
-        $this->input->emit('error', array(new \RuntimeException()));
+        $this->input->emit('error', [new \RuntimeException()]);
 
         $this->assertFalse($stream->isReadable());
     }
@@ -92,7 +92,7 @@ class LengthLimitedStreamTest extends TestCase
         $stream->on('close', $this->expectCallableOnce());
 
         $this->input->close();
-        $this->input->emit('end', array());
+        $this->input->emit('end', []);
 
         $this->assertFalse($stream->isReadable());
     }

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -8,17 +8,19 @@ use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Io\MiddlewareRunner;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
-use React\Promise;
+use React\Promise\Promise;
 use React\Promise\PromiseInterface;
 use React\Tests\Http\Middleware\ProcessStack;
 use React\Tests\Http\TestCase;
+use function React\Async\await;
+use function React\Promise\reject;
 
 final class MiddlewareRunnerTest extends TestCase
 {
     public function testEmptyMiddlewareStackThrowsException()
     {
         $request = new ServerRequest('GET', 'https://example.com/');
-        $middlewares = array();
+        $middlewares = [];
         $middlewareStack = new MiddlewareRunner($middlewares);
 
         $this->setExpectedException('RuntimeException', 'No middleware to run');
@@ -28,7 +30,7 @@ final class MiddlewareRunnerTest extends TestCase
     public function testMiddlewareHandlerReceivesTwoArguments()
     {
         $args = null;
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (ServerRequestInterface $request, $next) use (&$args) {
                 $args = func_num_args();
                 return $next($request);
@@ -36,7 +38,7 @@ final class MiddlewareRunnerTest extends TestCase
             function (ServerRequestInterface $request) {
                 return null;
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -48,12 +50,12 @@ final class MiddlewareRunnerTest extends TestCase
     public function testFinalHandlerReceivesOneArgument()
     {
         $args = null;
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (ServerRequestInterface $request) use (&$args) {
                 $args = func_num_args();
                 return null;
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -64,11 +66,11 @@ final class MiddlewareRunnerTest extends TestCase
 
     public function testThrowsIfHandlerThrowsException()
     {
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (ServerRequestInterface $request) {
                 throw new \RuntimeException('hello');
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -78,11 +80,11 @@ final class MiddlewareRunnerTest extends TestCase
 
     public function testThrowsIfHandlerThrowsThrowable()
     {
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (ServerRequestInterface $request) {
                 throw new \Error('hello');
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -99,42 +101,42 @@ final class MiddlewareRunnerTest extends TestCase
         $responseMiddleware = function () {
             return new Response(200);
         };
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     $processStackA,
                     $responseMiddleware,
-                ),
+                ],
                 1,
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     $processStackB,
                     $processStackB,
                     $responseMiddleware,
-                ),
+                ],
                 2,
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     $processStackC,
                     $processStackC,
                     $processStackC,
                     $responseMiddleware,
-                ),
+                ],
                 3,
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     $processStackD,
                     $processStackD,
                     $processStackD,
                     $processStackD,
                     $responseMiddleware,
-                ),
+                ],
                 4,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -156,7 +158,7 @@ final class MiddlewareRunnerTest extends TestCase
         $response = $middlewareStack($request);
 
         $this->assertTrue($response instanceof PromiseInterface);
-        $response = \React\Async\await($response);
+        $response = await($response);
 
         $this->assertTrue($response instanceof ResponseInterface);
         $this->assertSame(200, $response->getStatusCode());
@@ -172,18 +174,18 @@ final class MiddlewareRunnerTest extends TestCase
 
     public function provideErrorHandler()
     {
-        return array(
-            array(
+        return [
+            [
                 function (\Exception $e) {
                     throw $e;
                 }
-            ),
-            array(
+            ],
+            [
                 function (\Exception $e) {
-                    return Promise\reject($e);
+                    return reject($e);
                 }
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -195,7 +197,7 @@ final class MiddlewareRunnerTest extends TestCase
         $retryCalled = 0;
         $error = null;
         $retry = function ($request, $next) use (&$error, &$retryCalled) {
-            $promise = new \React\Promise\Promise(function ($resolve) use ($request, $next) {
+            $promise = new Promise(function ($resolve) use ($request, $next) {
                 $resolve($next($request));
             });
 
@@ -209,7 +211,7 @@ final class MiddlewareRunnerTest extends TestCase
 
         $response = new Response();
         $called = 0;
-        $runner = new MiddlewareRunner(array(
+        $runner = new MiddlewareRunner([
             $retry,
             function () use ($errorHandler, &$called, $response, $exception) {
                 $called++;
@@ -219,11 +221,11 @@ final class MiddlewareRunnerTest extends TestCase
 
                 return $response;
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'https://example.com/');
 
-        $this->assertSame($response, \React\Async\await($runner($request)));
+        $this->assertSame($response, await($runner($request)));
         $this->assertSame(1, $retryCalled);
         $this->assertSame(2, $called);
         $this->assertSame($exception, $error);
@@ -231,15 +233,15 @@ final class MiddlewareRunnerTest extends TestCase
 
     public function testMultipleRunsInvokeAllMiddlewareInCorrectOrder()
     {
-        $requests = array(
+        $requests = [
             new ServerRequest('GET', 'https://example.com/1'),
             new ServerRequest('GET', 'https://example.com/2'),
             new ServerRequest('GET', 'https://example.com/3')
-        );
+        ];
 
-        $receivedRequests = array();
+        $receivedRequests = [];
 
-        $middlewareRunner = new MiddlewareRunner(array(
+        $middlewareRunner = new MiddlewareRunner([
             function (ServerRequestInterface $request, $next) use (&$receivedRequests) {
                 $receivedRequests[] = 'middleware1: ' . $request->getUri();
                 return $next($request);
@@ -250,16 +252,16 @@ final class MiddlewareRunnerTest extends TestCase
             },
             function (ServerRequestInterface $request) use (&$receivedRequests) {
                 $receivedRequests[] = 'middleware3: ' . $request->getUri();
-                return new \React\Promise\Promise(function () { });
+                return new Promise(function () { });
             }
-        ));
+        ]);
 
         foreach ($requests as $request) {
             $middlewareRunner($request);
         }
 
         $this->assertEquals(
-            array(
+            [
                 'middleware1: https://example.com/1',
                 'middleware2: https://example.com/1',
                 'middleware3: https://example.com/1',
@@ -269,20 +271,20 @@ final class MiddlewareRunnerTest extends TestCase
                 'middleware1: https://example.com/3',
                 'middleware2: https://example.com/3',
                 'middleware3: https://example.com/3'
-            ),
+            ],
             $receivedRequests
         );
     }
 
     public function provideUncommonMiddlewareArrayFormats()
     {
-        return array(
-            array(
+        return [
+            [
                 function () {
                     $sequence = '';
 
                     // Numeric index gap
-                    return array(
+                    return [
                         0 => function (ServerRequestInterface $request, $next) use (&$sequence) {
                             $sequence .= 'A';
 
@@ -294,18 +296,18 @@ final class MiddlewareRunnerTest extends TestCase
                             return $next($request);
                         },
                         3 => function () use (&$sequence) {
-                            return new Response(200, array(), $sequence . 'C');
+                            return new Response(200, [], $sequence . 'C');
                         },
-                    );
+                    ];
                 },
                 'ABC',
-            ),
-            array(
+            ],
+            [
                 function () {
                     $sequence = '';
 
                     // Reversed numeric indexes
-                    return array(
+                    return [
                         2 => function (ServerRequestInterface $request, $next) use (&$sequence) {
                             $sequence .= 'A';
 
@@ -317,18 +319,18 @@ final class MiddlewareRunnerTest extends TestCase
                             return $next($request);
                         },
                         0 => function () use (&$sequence) {
-                            return new Response(200, array(), $sequence . 'C');
+                            return new Response(200, [], $sequence . 'C');
                         },
-                    );
+                    ];
                 },
                 'ABC',
-            ),
-            array(
+            ],
+            [
                 function () {
                     $sequence = '';
 
                     // Associative array
-                    return array(
+                    return [
                         'middleware1' => function (ServerRequestInterface $request, $next) use (&$sequence) {
                             $sequence .= 'A';
 
@@ -340,18 +342,18 @@ final class MiddlewareRunnerTest extends TestCase
                             return $next($request);
                         },
                         'middleware3' => function () use (&$sequence) {
-                            return new Response(200, array(), $sequence . 'C');
+                            return new Response(200, [], $sequence . 'C');
                         },
-                    );
+                    ];
                 },
                 'ABC',
-            ),
-            array(
+            ],
+            [
                 function () {
                     $sequence = '';
 
                     // Associative array with empty or trimmable string keys
-                    return array(
+                    return [
                         '' => function (ServerRequestInterface $request, $next) use (&$sequence) {
                             $sequence .= 'A';
 
@@ -363,18 +365,18 @@ final class MiddlewareRunnerTest extends TestCase
                             return $next($request);
                         },
                         '  ' => function () use (&$sequence) {
-                            return new Response(200, array(), $sequence . 'C');
+                            return new Response(200, [], $sequence . 'C');
                         },
-                    );
+                    ];
                 },
                 'ABC',
-            ),
-            array(
+            ],
+            [
                 function () {
                     $sequence = '';
 
                     // Mixed array keys
-                    return array(
+                    return [
                         '' => function (ServerRequestInterface $request, $next) use (&$sequence) {
                             $sequence .= 'A';
 
@@ -391,13 +393,13 @@ final class MiddlewareRunnerTest extends TestCase
                             return $next($request);
                         },
                         2 => function () use (&$sequence) {
-                            return new Response(200, array(), $sequence . 'D');
+                            return new Response(200, [], $sequence . 'D');
                         },
-                    );
+                    ];
                 },
                 'ABCD',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -417,7 +419,7 @@ final class MiddlewareRunnerTest extends TestCase
     public function testPendingNextRequestHandlersCanBeCalledConcurrently()
     {
         $called = 0;
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (RequestInterface $request, $next) {
                 $first = $next($request);
                 $second = $next($request);
@@ -427,9 +429,9 @@ final class MiddlewareRunnerTest extends TestCase
             function (RequestInterface $request) use (&$called) {
                 ++$called;
 
-                return new Promise\Promise(function () { });
+                return new Promise(function () { });
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -442,7 +444,7 @@ final class MiddlewareRunnerTest extends TestCase
     public function testCancelPendingNextHandler()
     {
         $once = $this->expectCallableOnce();
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (RequestInterface $request, $next) {
                 $ret = $next($request);
                 $ret->cancel();
@@ -450,9 +452,9 @@ final class MiddlewareRunnerTest extends TestCase
                 return $ret;
             },
             function (RequestInterface $request) use ($once) {
-                return new Promise\Promise(function () { }, $once);
+                return new Promise(function () { }, $once);
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 
@@ -462,14 +464,14 @@ final class MiddlewareRunnerTest extends TestCase
     public function testCancelResultingPromiseWillCancelPendingNextHandler()
     {
         $once = $this->expectCallableOnce();
-        $middleware = new MiddlewareRunner(array(
+        $middleware = new MiddlewareRunner([
             function (RequestInterface $request, $next) {
                 return $next($request);
             },
             function (RequestInterface $request) use ($once) {
-                return new Promise\Promise(function () { }, $once);
+                return new Promise(function () { }, $once);
             }
-        ));
+        ]);
 
         $request = new ServerRequest('GET', 'http://example.com/');
 

--- a/tests/Io/MiddlewareRunnerTest.php
+++ b/tests/Io/MiddlewareRunnerTest.php
@@ -76,9 +76,6 @@ final class MiddlewareRunnerTest extends TestCase
         $middleware($request);
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testThrowsIfHandlerThrowsThrowable()
     {
         $middleware = new MiddlewareRunner(array(

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Http\Io\Middleware;
 
+use Psr\Http\Message\UploadedFileInterface;
 use React\Http\Io\MultipartParser;
 use React\Http\Message\ServerRequest;
 use React\Tests\Http\TestCase;
@@ -673,7 +674,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -708,7 +709,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -742,7 +743,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -776,7 +777,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -809,7 +810,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -842,7 +843,7 @@ final class MultipartParserTest extends TestCase
 
         $this->assertCount(1, $files);
         $this->assertTrue(isset($files['file']));
-        $this->assertInstanceOf('Psr\Http\Message\UploadedFileInterface', $files['file']);
+        $this->assertInstanceOf(UploadedFileInterface::class, $files['file']);
 
         /* @var $file \Psr\Http\Message\UploadedFileInterface */
         $file = $files['file'];
@@ -1046,7 +1047,7 @@ final class MultipartParserTest extends TestCase
 
         $parser = new MultipartParser();
 
-        $reflectecClass = new \ReflectionClass('\React\Http\Io\MultipartParser');
+        $reflectecClass = new \ReflectionClass(MultipartParser::class);
         $requestProperty = $reflectecClass->getProperty('request');
         $requestProperty->setAccessible(true);
         $cursorProperty = $reflectecClass->getProperty('cursor');

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -22,9 +22,9 @@ final class MultipartParserTest extends TestCase
         $data .= "second\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data',
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -47,21 +47,21 @@ final class MultipartParserTest extends TestCase
         $data .= "second\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     'one' => 'single',
                     'two' => 'second',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -80,21 +80,21 @@ final class MultipartParserTest extends TestCase
         $data .= "second\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary="' . $boundary . '"',
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     'one' => 'single',
                     'two' => 'second',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -113,21 +113,21 @@ final class MultipartParserTest extends TestCase
         $data .= "second\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary="' . $boundary . '"',
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     'one' => 'single',
                     'two' => 'second',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -146,18 +146,18 @@ final class MultipartParserTest extends TestCase
         $data .= "2\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
+            [
                 'users' => '2'
-            ),
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -176,20 +176,20 @@ final class MultipartParserTest extends TestCase
         $data .= "2\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     'two' => '2',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -208,20 +208,20 @@ final class MultipartParserTest extends TestCase
         $data .= "2\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     '2',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -240,25 +240,25 @@ final class MultipartParserTest extends TestCase
         $data .= "2\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'users' => array(
-                    array(
+            [
+                'users' => [
+                    [
                         '1'
-                    ),
-                    array(
+                    ],
+                    [
                         '2'
-                    )
-                ),
-            ),
+                    ]
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -273,18 +273,18 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
+            [
                 'key' => ''
-            ),
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -299,18 +299,18 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
+            [
                 '' => 'value'
-            ),
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -325,22 +325,22 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'a' => array(
-                    'b' => array(
+            [
+                'a' => [
+                    'b' => [
                         'c' => 'value'
-                    )
-                )
-            ),
+                    ]
+                ]
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -355,22 +355,22 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
-                'a' => array(
-                    array(
+            [
+                'a' => [
+                    [
                         'value'
-                    )
-                )
-            ),
+                    ]
+                ]
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -436,25 +436,25 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertSame(
-            array(
+            [
                 'MAX_FILE_SIZE' => '12000',
-                'users' => array(
+                'users' => [
                     'one' => 'single',
                     'two' => 'second',
                     0 => 'first in array',
                     1 => 'second in array',
-                ),
+                ],
                 'user' => 'single',
                 'user2' => 'second',
-            ),
+            ],
             $parsedRequest->getParsedBody()
         );
 
@@ -491,18 +491,18 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
 
         $this->assertEmpty($parsedRequest->getUploadedFiles());
         $this->assertSame(
-            array(
+            [
                 'key' => 'value'
-            ),
+            ],
             $parsedRequest->getParsedBody()
         );
     }
@@ -517,9 +517,9 @@ final class MultipartParserTest extends TestCase
         $data .= "value";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -537,9 +537,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -555,9 +555,9 @@ final class MultipartParserTest extends TestCase
         $data  = "--$boundary\r\n";
         $data .= "Content-Disposition: form-data; name=\"key\"\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -576,9 +576,9 @@ final class MultipartParserTest extends TestCase
         $data .= "hello\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -597,9 +597,9 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -618,9 +618,9 @@ final class MultipartParserTest extends TestCase
         $data .= "value\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -638,9 +638,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "value\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -662,9 +662,9 @@ final class MultipartParserTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -697,9 +697,9 @@ final class MultipartParserTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -731,9 +731,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -765,9 +765,9 @@ final class MultipartParserTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser(4);
         $parsedRequest = $parser->parse($request);
@@ -798,9 +798,9 @@ final class MultipartParserTest extends TestCase
         $data .= str_repeat('world', 1024) . "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser('1K');
         $parsedRequest = $parser->parse($request);
@@ -831,9 +831,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -869,9 +869,9 @@ final class MultipartParserTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser(100, 1);
         $parsedRequest = $parser->parse($request);
@@ -910,9 +910,9 @@ final class MultipartParserTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser(100, 1);
         $parsedRequest = $parser->parse($request);
@@ -953,9 +953,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -1008,9 +1008,9 @@ final class MultipartParserTest extends TestCase
         $data .= "\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
         $parsedRequest = $parser->parse($request);
@@ -1040,9 +1040,9 @@ final class MultipartParserTest extends TestCase
         $data .= str_repeat($chunk, $chunkCount);
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
+        $request = new ServerRequest('POST', 'http://example.com/', [
             'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        ], $data, 1.1);
 
         $parser = new MultipartParser();
 

--- a/tests/Io/PauseBufferStreamTest.php
+++ b/tests/Io/PauseBufferStreamTest.php
@@ -156,7 +156,7 @@ class PauseBufferStreamTest extends TestCase
 
         $stream->on('error', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
-        $input->emit('error', array(new \RuntimeException()));
+        $input->emit('error', [new \RuntimeException()]);
     }
 
     public function testPausedStreamWillNotPassThroughErrorEvent()
@@ -167,7 +167,7 @@ class PauseBufferStreamTest extends TestCase
         $stream->pause();
         $stream->on('error', $this->expectCallableNever());
         $stream->on('close', $this->expectCallableNever());
-        $input->emit('error', array(new \RuntimeException()));
+        $input->emit('error', [new \RuntimeException()]);
     }
 
     public function testPausedStreamWillPassThroughErrorEventOnResume()
@@ -176,7 +176,7 @@ class PauseBufferStreamTest extends TestCase
         $stream = new PauseBufferStream($input);
 
         $stream->pause();
-        $input->emit('error', array(new \RuntimeException()));
+        $input->emit('error', [new \RuntimeException()]);
 
         $stream->on('error', $this->expectCallableOnce());
         $stream->on('close', $this->expectCallableOnce());
@@ -191,7 +191,7 @@ class PauseBufferStreamTest extends TestCase
         $stream->pause();
         $stream->on('error', $this->expectCallableNever());
         $stream->on('close', $this->expectCallableOnce());
-        $input->emit('error', array(new \RuntimeException()));
+        $input->emit('error', [new \RuntimeException()]);
 
         $stream->close();
     }

--- a/tests/Io/PauseBufferStreamTest.php
+++ b/tests/Io/PauseBufferStreamTest.php
@@ -2,15 +2,16 @@
 
 namespace React\Tests\Io;
 
-use React\Tests\Http\TestCase;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
 use React\Http\Io\PauseBufferStream;
 
 class PauseBufferStreamTest extends TestCase
 {
     public function testPauseMethodWillBePassedThroughToInput()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('pause');
 
         $stream = new PauseBufferStream($input);
@@ -19,7 +20,7 @@ class PauseBufferStreamTest extends TestCase
 
     public function testCloseMethodWillBePassedThroughToInput()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->once())->method('close');
 
         $stream = new PauseBufferStream($input);
@@ -28,7 +29,7 @@ class PauseBufferStreamTest extends TestCase
 
     public function testPauseMethodWillNotBePassedThroughToInputAfterClose()
     {
-        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $input = $this->createMock(ReadableStreamInterface::class);
         $input->expects($this->never())->method('pause');
 
         $stream = new PauseBufferStream($input);

--- a/tests/Io/ReadableBodyStreamTest.php
+++ b/tests/Io/ReadableBodyStreamTest.php
@@ -3,8 +3,9 @@
 namespace React\Tests\Http\Io;
 
 use React\Http\Io\ReadableBodyStream;
-use React\Tests\Http\TestCase;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
+use React\Tests\Http\TestCase;
 
 class ReadableBodyStreamTest extends TestCase
 {
@@ -16,7 +17,7 @@ class ReadableBodyStreamTest extends TestCase
      */
     public function setUpStream()
     {
-        $this->input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $this->input = $this->createMock(ReadableStreamInterface::class);
         $this->stream = new ReadableBodyStream($this->input);
     }
 
@@ -102,7 +103,7 @@ class ReadableBodyStreamTest extends TestCase
         $this->input->write('hi');
         $this->input->end();
 
-        $this->assertInstanceOf('UnderflowException', $called);
+        $this->assertInstanceOf(\UnderflowException::class, $called);
         $this->assertSame('Unexpected end of response body after 2/5 bytes', $called->getMessage());
     }
 
@@ -188,7 +189,7 @@ class ReadableBodyStreamTest extends TestCase
 
     public function testPointlessDetachThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->detach();
     }
 
@@ -199,7 +200,7 @@ class ReadableBodyStreamTest extends TestCase
 
     public function testPointlessTellThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->tell();
     }
 
@@ -210,13 +211,13 @@ class ReadableBodyStreamTest extends TestCase
 
     public function testPointlessSeekThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->seek(0);
     }
 
     public function testPointlessRewindThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->rewind();
     }
 
@@ -227,19 +228,19 @@ class ReadableBodyStreamTest extends TestCase
 
     public function testPointlessWriteThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->write('');
     }
 
     public function testPointlessReadThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->read(8192);
     }
 
     public function testPointlessGetContentsThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
         $this->stream->getContents();
     }
 

--- a/tests/Io/ReadableBodyStreamTest.php
+++ b/tests/Io/ReadableBodyStreamTest.php
@@ -250,6 +250,6 @@ class ReadableBodyStreamTest extends TestCase
 
     public function testPointlessGetMetadataReturnsEmptyArrayWhenNoKeyIsGiven()
     {
-        $this->assertEquals(array(), $this->stream->getMetadata());
+        $this->assertEquals([], $this->stream->getMetadata());
     }
 }

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -19,14 +19,14 @@ class RequestHeaderParserTest extends TestCase
 
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\n"));
-        $connection->emit('data', array("Host: example.com:80\r\n"));
-        $connection->emit('data', array("Connection: close\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\n"]);
+        $connection->emit('data', ["Host: example.com:80\r\n"]);
+        $connection->emit('data', ["Connection: close\r\n"]);
 
         $parser->removeAllListeners();
         $parser->on('headers', $this->expectCallableOnce());
 
-        $connection->emit('data', array("\r\n"));
+        $connection->emit('data', ["\r\n"]);
     }
 
     public function testFeedInOneGo()
@@ -40,7 +40,7 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection);
 
         $data = $this->createGetRequest();
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
     }
 
     public function testFeedTwoRequestsOnSeparateConnections()
@@ -60,8 +60,8 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection2);
 
         $data = $this->createGetRequest();
-        $connection1->emit('data', array($data));
-        $connection2->emit('data', array($data));
+        $connection1->emit('data', [$data]);
+        $connection2->emit('data', [$data]);
 
         $this->assertEquals(2, $called);
     }
@@ -83,13 +83,13 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection);
 
         $data = $this->createGetRequest();
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
         $this->assertSame('GET', $request->getMethod());
         $this->assertEquals('http://example.com/', $request->getUri());
         $this->assertSame('1.1', $request->getProtocolVersion());
-        $this->assertSame(array('Host' => array('example.com'), 'Connection' => array('close')), $request->getHeaders());
+        $this->assertSame(['Host' => ['example.com'], 'Connection' => ['close']], $request->getHeaders());
 
         $this->assertSame($connection, $conn);
     }
@@ -101,10 +101,9 @@ class RequestHeaderParserTest extends TestCase
         $parser = new RequestHeaderParser($clock);
 
         $ended = false;
-        $that = $this;
-        $parser->on('headers', function (ServerRequestInterface $request) use (&$ended, $that) {
+        $parser->on('headers', function (ServerRequestInterface $request) use (&$ended) {
             $body = $request->getBody();
-            $that->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+            $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
             $body->on('end', function () use (&$ended) {
                 $ended = true;
@@ -115,7 +114,7 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection);
 
         $data = "GET / HTTP/1.0\r\n\r\n";
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertTrue($ended);
     }
@@ -127,10 +126,9 @@ class RequestHeaderParserTest extends TestCase
         $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
-        $that = $this;
-        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer, $that) {
+        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer) {
             $body = $request->getBody();
-            $that->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+            $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
             $body->on('data', function ($chunk) use (&$buffer) {
                 $buffer .= $chunk;
@@ -145,7 +143,7 @@ class RequestHeaderParserTest extends TestCase
 
         $data = "POST / HTTP/1.0\r\nContent-Length: 11\r\n\r\n";
         $data .= 'RANDOM DATA';
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertSame('RANDOM DATA.', $buffer);
     }
@@ -157,10 +155,9 @@ class RequestHeaderParserTest extends TestCase
         $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
-        $that = $this;
-        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer, $that) {
+        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer) {
             $body = $request->getBody();
-            $that->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+            $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
             $body->on('data', function ($chunk) use (&$buffer) {
                 $buffer .= $chunk;
@@ -173,7 +170,7 @@ class RequestHeaderParserTest extends TestCase
         $size = 10000;
         $data = "POST / HTTP/1.0\r\nContent-Length: $size\r\n\r\n";
         $data .= str_repeat('x', $size);
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertSame($size, strlen($buffer));
     }
@@ -185,10 +182,9 @@ class RequestHeaderParserTest extends TestCase
         $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
-        $that = $this;
-        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer, $that) {
+        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer) {
             $body = $request->getBody();
-            $that->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+            $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
             $body->on('data', function ($chunk) use (&$buffer) {
                 $buffer .= $chunk;
@@ -200,7 +196,7 @@ class RequestHeaderParserTest extends TestCase
 
         $data = "POST / HTTP/1.0\r\n\r\n";
         $data .= 'RANDOM DATA';
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertSame('', $buffer);
     }
@@ -212,10 +208,9 @@ class RequestHeaderParserTest extends TestCase
         $parser = new RequestHeaderParser($clock);
 
         $buffer = '';
-        $that = $this;
-        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer, $that) {
+        $parser->on('headers', function (ServerRequestInterface $request) use (&$buffer) {
             $body = $request->getBody();
-            $that->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+            $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
             $body->on('data', function ($chunk) use (&$buffer) {
                 $buffer .= $chunk;
@@ -227,7 +222,7 @@ class RequestHeaderParserTest extends TestCase
 
         $data = "POST / HTTP/1.0\r\nContent-Length: 6\r\n\r\n";
         $data .= 'RANDOM DATA';
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertSame('RANDOM', $buffer);
     }
@@ -247,17 +242,17 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection);
 
         $data = $this->createAdvancedPostRequest();
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
         $this->assertSame('POST', $request->getMethod());
         $this->assertEquals('http://example.com/foo?bar=baz', $request->getUri());
         $this->assertSame('1.1', $request->getProtocolVersion());
-        $headers = array(
-            'Host' => array('example.com'),
-            'User-Agent' => array('react/alpha'),
-            'Connection' => array('close'),
-        );
+        $headers = [
+            'Host' => ['example.com'],
+            'User-Agent' => ['react/alpha'],
+            'Connection' => ['close']
+        ];
         $this->assertSame($headers, $request->getHeaders());
     }
 
@@ -272,11 +267,11 @@ class RequestHeaderParserTest extends TestCase
             $request = $parsedRequest;
         });
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('tcp://127.1.1.1:8000');
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\n\r\n"]);
 
         $this->assertEquals('http://127.1.1.1:8000/foo', $request->getUri());
         $this->assertFalse($request->hasHeader('Host'));
@@ -293,11 +288,11 @@ class RequestHeaderParserTest extends TestCase
             $request = $parsedRequest;
         });
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('tls://127.1.1.1:8000');
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $this->assertEquals('https://example.com/foo', $request->getUri());
         $this->assertEquals('example.com', $request->getHeaderLine('Host'));
@@ -321,7 +316,7 @@ class RequestHeaderParserTest extends TestCase
         $parser->handle($connection);
 
         $data = str_repeat('A', 8193);
-        $connection->emit('data', array($data));
+        $connection->emit('data', [$data]);
 
         $this->assertInstanceOf('OverflowException', $error);
         $this->assertSame('Maximum header size of 8192 exceeded.', $error->getMessage());
@@ -343,7 +338,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("\r\n\r\n"));
+        $connection->emit('data', ["\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Unable to parse invalid request-line', $error->getMessage());
@@ -364,7 +359,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /\r\n\r\n"));
+        $connection->emit('data', ["GET /\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Unable to parse invalid request-line', $error->getMessage());
@@ -385,7 +380,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost : yes\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost : yes\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Unable to parse invalid request header fields', $error->getMessage());
@@ -406,7 +401,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: yes\rFoo: bar\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: yes\rFoo: bar\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Unable to parse invalid request header fields', $error->getMessage());
@@ -427,7 +422,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET tcp://example.com:80/ HTTP/1.0\r\n\r\n"));
+        $connection->emit('data', ["GET tcp://example.com:80/ HTTP/1.0\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid absolute-form request-target', $error->getMessage());
@@ -448,15 +443,15 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /somepath?param=http://example.com HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+        $connection->emit('data', ["GET /somepath?param=http://example.com HTTP/1.1\r\nHost: localhost\r\n\r\n"]);
 
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
         $this->assertSame('GET', $request->getMethod());
         $this->assertEquals('http://localhost/somepath?param=http://example.com', $request->getUri());
         $this->assertSame('1.1', $request->getProtocolVersion());
-        $headers = array(
-            'Host' => array('localhost')
-        );
+        $headers = [
+            'Host' => ['localhost']
+        ];
         $this->assertSame($headers, $request->getHeaders());
     }
 
@@ -475,7 +470,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET ://example.com:80/ HTTP/1.0\r\n\r\n"));
+        $connection->emit('data', ["GET ://example.com:80/ HTTP/1.0\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid absolute-form request-target', $error->getMessage());
@@ -496,7 +491,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET http://example.com:80/#home HTTP/1.0\r\n\r\n"));
+        $connection->emit('data', ["GET http://example.com:80/#home HTTP/1.0\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid absolute-form request-target', $error->getMessage());
@@ -517,7 +512,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: http://user:pass@host/\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: http://user:pass@host/\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid Host header value', $error->getMessage());
@@ -538,7 +533,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET http://example.com/ HTTP/1.1\r\nHost: \r\n\r\n"));
+        $connection->emit('data', ["GET http://example.com/ HTTP/1.1\r\nHost: \r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('Invalid Host header value', $error->getMessage());
@@ -559,7 +554,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("CONNECT http://example.com:8080/ HTTP/1.1\r\nHost: example.com:8080\r\n\r\n"));
+        $connection->emit('data', ["CONNECT http://example.com:8080/ HTTP/1.1\r\nHost: example.com:8080\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame('CONNECT method MUST use authority-form request target', $error->getMessage());
@@ -580,7 +575,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.2\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.2\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(505, $error->getCode());
@@ -602,7 +597,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: foo\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: foo\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -624,7 +619,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -646,7 +641,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: foo\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: foo\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(501, $error->getCode());
@@ -668,7 +663,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n"));
+        $connection->emit('data', ["GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n"]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
         $this->assertSame(400, $error->getCode());
@@ -688,12 +683,12 @@ class RequestHeaderParserTest extends TestCase
             $request = $parsedRequest;
         });
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress', 'getRemoteAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress', 'getRemoteAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('tls://127.1.1.1:8000');
         $connection->expects($this->once())->method('getRemoteAddress')->willReturn('tls://192.168.1.1:8001');
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $serverParams = $request->getServerParams();
 
@@ -721,12 +716,12 @@ class RequestHeaderParserTest extends TestCase
             $request = $parsedRequest;
         });
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress', 'getRemoteAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress', 'getRemoteAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('tcp://127.1.1.1:8000');
         $connection->expects($this->once())->method('getRemoteAddress')->willReturn('tcp://192.168.1.1:8001');
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $serverParams = $request->getServerParams();
 
@@ -754,12 +749,12 @@ class RequestHeaderParserTest extends TestCase
             $request = $parsedRequest;
         });
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress', 'getRemoteAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress', 'getRemoteAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('unix://./server.sock');
         $connection->expects($this->once())->method('getRemoteAddress')->willReturn(null);
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $serverParams = $request->getServerParams();
 
@@ -790,7 +785,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $serverParams = $request->getServerParams();
 
@@ -811,12 +806,12 @@ class RequestHeaderParserTest extends TestCase
 
         $parser = new RequestHeaderParser($clock);
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress', 'getRemoteAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress', 'getRemoteAddress'])->getMock();
         $connection->expects($this->once())->method('getLocalAddress')->willReturn('tcp://127.1.1.1:8000');
         $connection->expects($this->once())->method('getRemoteAddress')->willReturn('tcp://192.168.1.1:8001');
 
         $parser->handle($connection);
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $request = null;
         $parser->on('headers', function ($parsedRequest) use (&$request) {
@@ -824,7 +819,7 @@ class RequestHeaderParserTest extends TestCase
         });
 
         $parser->handle($connection);
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         assert($request instanceof ServerRequestInterface);
         $serverParams = $request->getServerParams();
@@ -846,10 +841,10 @@ class RequestHeaderParserTest extends TestCase
 
         $parser = new RequestHeaderParser($clock);
 
-        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('getLocalAddress', 'getRemoteAddress'))->getMock();
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(['getLocalAddress', 'getRemoteAddress'])->getMock();
 
         $parser->handle($connection);
-        $connection->emit('data', array("GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $ref = new \ReflectionProperty($parser, 'connectionParams');
         $ref->setAccessible(true);
@@ -857,7 +852,7 @@ class RequestHeaderParserTest extends TestCase
         $this->assertCount(1, $ref->getValue($parser));
 
         $connection->emit('close');
-        $this->assertEquals(array(), $ref->getValue($parser));
+        $this->assertEquals([], $ref->getValue($parser));
     }
 
     public function testQueryParmetersWillBeSet()
@@ -875,7 +870,7 @@ class RequestHeaderParserTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(null)->getMock();
         $parser->handle($connection);
 
-        $connection->emit('data', array("GET /foo.php?hello=world&test=this HTTP/1.0\r\nHost: example.com\r\n\r\n"));
+        $connection->emit('data', ["GET /foo.php?hello=world&test=this HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $queryParams = $request->getQueryParams();
 

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -776,10 +776,6 @@ class RequestHeaderParserTest extends TestCase
 
     public function testServerParamsWontBeSetOnMissingUrls()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM');
-        }
-
         $request = null;
 
         $clock = $this->getMockBuilder('React\Http\Io\Clock')->disableOriginalConstructor()->getMock();

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -82,9 +82,6 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', array($data));
     }
 
-    /**
-     * @requires PHP 5.4
-     */
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
@@ -2845,9 +2842,6 @@ class StreamingServerTest extends TestCase
         $this->assertEquals('hello', $exception->getPrevious()->getMessage());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testResponseThrowableThrowInCallBackFunctionWillResultInErrorMessage()
     {
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -12,6 +12,7 @@ use React\Promise\Promise;
 use React\Stream\ThroughStream;
 use React\Tests\Http\SocketServerStub;
 use React\Tests\Http\TestCase;
+use function React\Promise\resolve;
 
 class StreamingServerTest extends TestCase
 {
@@ -37,7 +38,7 @@ class StreamingServerTest extends TestCase
         $connection = $this->getMockBuilder('React\Socket\Connection')
             ->disableOriginalConstructor()
             ->setMethods(array_merge(
-                array(
+                [
                     'write',
                     'end',
                     'close',
@@ -48,8 +49,8 @@ class StreamingServerTest extends TestCase
                     'getRemoteAddress',
                     'getLocalAddress',
                     'pipe'
-                ),
-                (is_array($additionalMethods) ? $additionalMethods : array())
+                ],
+                (is_array($additionalMethods) ? $additionalMethods : [])
             ))
             ->getMock();
 
@@ -64,11 +65,11 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = '';
         $data .= "GET / HTTP/1.1\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestEventIsEmitted()
@@ -76,22 +77,22 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestEventIsEmittedForArrayCallable()
     {
         $this->called = null;
-        $server = new StreamingServer(Loop::get(), array($this, 'helperCallableOnce'));
+        $server = new StreamingServer(Loop::get(), [$this, 'helperCallableOnce']);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals(1, $this->called);
     }
@@ -116,10 +117,10 @@ class StreamingServerTest extends TestCase
             ->willReturn('127.0.0.1:8080');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $serverParams = $requestAssertion->getServerParams();
 
@@ -128,7 +129,7 @@ class StreamingServerTest extends TestCase
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
-        $this->assertSame(array(), $requestAssertion->getQueryParams());
+        $this->assertSame([], $requestAssertion->getQueryParams());
         $this->assertSame('http://example.com/', (string)$requestAssertion->getUri());
         $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
         $this->assertSame('127.0.0.1', $serverParams['REMOTE_ADDR']);
@@ -149,10 +150,10 @@ class StreamingServerTest extends TestCase
             ->willReturn('127.0.0.1:8080');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $serverParams = $requestAssertion->getServerParams();
 
@@ -161,7 +162,7 @@ class StreamingServerTest extends TestCase
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
-        $this->assertSame(array(), $requestAssertion->getQueryParams());
+        $this->assertSame([], $requestAssertion->getQueryParams());
         $this->assertSame('http://example.com/', (string)$requestAssertion->getUri());
         $this->assertSame('example.com', $requestAssertion->getHeaderLine('Host'));
         $this->assertSame('127.0.0.1', $serverParams['REMOTE_ADDR']);
@@ -175,10 +176,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -197,10 +198,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -219,10 +220,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -241,10 +242,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.0\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -262,10 +263,10 @@ class StreamingServerTest extends TestCase
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestOptionsAsterisk()
@@ -276,10 +277,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
@@ -295,10 +296,10 @@ class StreamingServerTest extends TestCase
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET * HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestConnectAuthorityForm()
@@ -309,10 +310,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
@@ -331,10 +332,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT example.com:443 HTTP/1.1\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
@@ -353,10 +354,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
@@ -375,10 +376,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
@@ -395,10 +396,10 @@ class StreamingServerTest extends TestCase
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestNonConnectWithAuthorityRequestTargetWillReject()
@@ -407,10 +408,10 @@ class StreamingServerTest extends TestCase
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET example.com:80 HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestWithoutHostEventUsesSocketAddress()
@@ -427,10 +428,10 @@ class StreamingServerTest extends TestCase
             ->willReturn('127.0.0.1:80');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET /test HTTP/1.0\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -448,10 +449,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -470,10 +471,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
@@ -489,10 +490,10 @@ class StreamingServerTest extends TestCase
         $server->on('error', $this->expectCallableOnce());
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET http://example.com:8080/test HTTP/1.1\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestOptionsAsteriskEvent()
@@ -504,10 +505,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
@@ -526,10 +527,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "OPTIONS http://example.com HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
@@ -548,7 +549,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->once())->method('pause');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -556,7 +557,7 @@ class StreamingServerTest extends TestCase
         $data .= "Content-Length: 5\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestResumeWillBeForwardedToConnection()
@@ -568,7 +569,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->once())->method('resume');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -576,7 +577,7 @@ class StreamingServerTest extends TestCase
         $data .= "Content-Length: 5\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestCloseWillNotCloseConnection()
@@ -588,10 +589,10 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestPauseAfterCloseWillNotBeForwarded()
@@ -605,10 +606,10 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('pause');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestResumeAfterCloseWillNotBeForwarded()
@@ -622,10 +623,10 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('resume');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestEventWithoutBodyWillNotEmitData()
@@ -637,10 +638,10 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestEventWithSecondDataEventWillEmitBodyData()
@@ -652,7 +653,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = '';
         $data .= "POST / HTTP/1.1\r\n";
@@ -660,7 +661,7 @@ class StreamingServerTest extends TestCase
         $data .= "Content-Length: 100\r\n";
         $data .= "\r\n";
         $data .= "incomplete";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestEventWithPartialBodyWillEmitData()
@@ -672,18 +673,18 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = '';
         $data .= "POST / HTTP/1.1\r\n";
         $data .= "Host: localhost\r\n";
         $data .= "Content-Length: 100\r\n";
         $data .= "\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $data = '';
         $data .= "incomplete";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testResponseContainsServerHeader()
@@ -706,10 +707,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("\r\nServer: ReactPHP/1\r\n", $buffer);
     }
@@ -736,10 +737,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals('', $buffer);
     }
@@ -766,10 +767,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->connection->emit('close');
 
         $this->assertEquals('', $buffer);
@@ -783,7 +784,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -802,10 +803,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertStringEndsWith("\r\n\r\n0\r\n\r\n", $buffer);
@@ -818,7 +819,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -837,10 +838,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $stream->end();
 
@@ -856,7 +857,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -875,10 +876,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertStringStartsWith("HTTP/1.0 200 OK\r\n", $buffer);
         $this->assertStringEndsWith("\r\n\r\n", $buffer);
@@ -892,7 +893,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -913,7 +914,7 @@ class StreamingServerTest extends TestCase
         $this->connection = $this->getMockBuilder('React\Socket\Connection')
             ->disableOriginalConstructor()
             ->setMethods(
-                array(
+                [
                     'write',
                     'end',
                     'close',
@@ -924,7 +925,7 @@ class StreamingServerTest extends TestCase
                     'getRemoteAddress',
                     'getLocalAddress',
                     'pipe'
-                )
+                ]
             )
             ->getMock();
 
@@ -933,10 +934,10 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('write');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testResponseBodyStreamWillBeClosedIfConnectionEmitsCloseEvent()
@@ -947,16 +948,16 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->connection->emit('close');
     }
 
@@ -965,11 +966,11 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(
+                [
                     'date' => '',
                     'server' => '',
                     'Upgrade' => 'demo'
-                ),
+                ],
                 'foo'
             );
         });
@@ -988,10 +989,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nUpgrade: demo\r\nContent-Length: 3\r\n\r\nfoo", $buffer);
     }
@@ -1001,10 +1002,10 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(
+                [
                     'date' => '',
                     'server' => ''
-                ),
+                ],
                 'foo'
             );
         });
@@ -1023,10 +1024,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: demo\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo", $buffer);
     }
@@ -1036,11 +1037,11 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 101,
-                array(
+                [
                     'date' => '',
                     'server' => '',
                     'Upgrade' => 'demo'
-                ),
+                ],
                 'foo'
             );
         });
@@ -1061,10 +1062,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: demo\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals("HTTP/1.1 101 Switching Protocols\r\nUpgrade: demo\r\nConnection: upgrade\r\n\r\nfoo", $buffer);
     }
@@ -1076,11 +1077,11 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 101,
-                array(
+                [
                     'date' => '',
                     'server' => '',
                     'Upgrade' => 'demo'
-                ),
+                ],
                 $stream
             );
         });
@@ -1099,10 +1100,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: demo\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $stream->write('hello');
         $stream->write('world');
@@ -1117,7 +1118,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -1136,10 +1137,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $stream->write('hello');
         $stream->write('world');
@@ -1155,18 +1156,18 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('pipe')->with($stream);
 
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testResponseContainsSameRequestProtocolVersionAndChunkedBodyForHttp11()
@@ -1174,7 +1175,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(),
+                [],
                 'bye'
             );
         });
@@ -1193,10 +1194,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("bye", $buffer);
@@ -1207,7 +1208,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(),
+                [],
                 'bye'
             );
         });
@@ -1226,10 +1227,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.0\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.0 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\n\r\n", $buffer);
@@ -1241,7 +1242,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(),
+                [],
                 'bye'
             );
         });
@@ -1259,10 +1260,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1277,7 +1278,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array('Content-Length' => '3'),
+                ['Content-Length' => '3'],
                 $stream
             );
         });
@@ -1295,10 +1296,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1309,7 +1310,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 204,
-                array(),
+                [],
                 'bye'
             );
         });
@@ -1327,10 +1328,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1345,7 +1346,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 204,
-                array('Content-Length' => '3'),
+                ['Content-Length' => '3'],
                 $stream
             );
         });
@@ -1363,10 +1364,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1377,7 +1378,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
-                array(),
+                [],
                 ''
             );
         });
@@ -1395,10 +1396,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertNotContainsString("\r\nContent-Length: 0\r\n", $buffer);
@@ -1409,7 +1410,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
-                array('Content-Length' => 3),
+                ['Content-Length' => 3],
                 ''
             );
         });
@@ -1427,10 +1428,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1441,7 +1442,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array('Content-Length' => 3),
+                ['Content-Length' => 3],
                 ''
             );
         });
@@ -1459,10 +1460,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1473,7 +1474,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 304,
-                array(),
+                [],
                 'bye'
             );
         });
@@ -1491,10 +1492,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1509,7 +1510,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 304,
-                array('Content-Length' => '3'),
+                ['Content-Length' => '3'],
                 $stream
             );
         });
@@ -1527,10 +1528,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
         $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
@@ -1558,10 +1559,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.2\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
 
@@ -1592,11 +1593,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
         $data .= str_repeat('A', 8193 - strlen($data)) . "\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('OverflowException', $error);
 
@@ -1626,10 +1627,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "bad request\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('InvalidArgumentException', $error);
 
@@ -1652,7 +1653,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1661,7 +1662,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "hello";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestChunkedTransferEncodingRequestWillEmitDecodedDataEventOnRequestStream()
@@ -1681,7 +1682,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1691,7 +1692,7 @@ class StreamingServerTest extends TestCase
         $data .= "5\r\nhello\r\n";
         $data .= "0\r\n\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals('chunked', $requestValidation->getHeaderLine('Transfer-Encoding'));
     }
@@ -1711,7 +1712,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1722,7 +1723,7 @@ class StreamingServerTest extends TestCase
         $data .= "0\r\n\r\n";
         $data .= "2\r\nhi\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestChunkedTransferEncodingEmpty()
@@ -1740,7 +1741,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1749,7 +1750,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "0\r\n\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestChunkedTransferEncodingHeaderCanBeUpperCase()
@@ -1769,7 +1770,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1779,7 +1780,7 @@ class StreamingServerTest extends TestCase
         $data .= "5\r\nhello\r\n";
         $data .= "0\r\n\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->assertEquals('CHUNKED', $requestValidation->getHeaderLine('Transfer-Encoding'));
     }
 
@@ -1798,7 +1799,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1807,7 +1808,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "5\r\nhello\r\n";
         $data .= "0\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestContentLengthWillEmitDataEventAndEndEventAndAdditionalDataWillBeIgnored()
@@ -1823,11 +1824,11 @@ class StreamingServerTest extends TestCase
             $request->getBody()->on('close', $closeEvent);
             $request->getBody()->on('error', $errorEvent);
 
-            return \React\Promise\resolve(new Response());
+            return resolve(new Response());
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1837,7 +1838,7 @@ class StreamingServerTest extends TestCase
         $data .= "hello";
         $data .= "world";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestContentLengthWillEmitDataEventAndEndEventAndAdditionalDataWillBeIgnoredSplitted()
@@ -1856,7 +1857,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1865,11 +1866,11 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "hello";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $data = "world";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestZeroContentLengthWillEmitEndEvent()
@@ -1888,7 +1889,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1896,7 +1897,7 @@ class StreamingServerTest extends TestCase
         $data .= "Content-Length: 0\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestZeroContentLengthWillEmitEndAndAdditionalDataWillBeIgnored()
@@ -1914,7 +1915,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1923,7 +1924,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "hello";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestZeroContentLengthWillEmitEndAndAdditionalDataWillBeIgnoredSplitted()
@@ -1941,7 +1942,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1949,11 +1950,11 @@ class StreamingServerTest extends TestCase
         $data .= "Content-Length: 0\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $data = "hello";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
@@ -1961,13 +1962,13 @@ class StreamingServerTest extends TestCase
         $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
-            return \React\Promise\resolve(new Response());
+            return resolve(new Response());
         });
 
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -1978,7 +1979,7 @@ class StreamingServerTest extends TestCase
             $data .= 'a';
         }
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
@@ -1991,7 +1992,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -2000,7 +2001,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "5\r\nhello world\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
@@ -2013,7 +2014,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -2022,7 +2023,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "5\r\nhello\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->connection->emit('end');
     }
 
@@ -2036,7 +2037,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -2045,7 +2046,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "hello\r\nhello\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
@@ -2058,7 +2059,7 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -2067,7 +2068,7 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
         $data .= "incomplete";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->connection->emit('end');
     }
 
@@ -2088,11 +2089,11 @@ class StreamingServerTest extends TestCase
         $this->connection->expects($this->never())->method('close');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testRequestWithoutDefinedLengthWillIgnoreDataEvent()
@@ -2110,12 +2111,12 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
         $data .= "hello world";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
     }
 
     public function testResponseWithBodyStreamWillUseChunkedTransferEncodingByDefault()
@@ -2124,7 +2125,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(),
+                [],
                 $stream
             );
         });
@@ -2142,12 +2143,12 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
-        $stream->emit('data', array('hello'));
+        $this->connection->emit('data', [$data]);
+        $stream->emit('data', ['hello']);
 
         $this->assertContainsString("Transfer-Encoding: chunked", $buffer);
         $this->assertContainsString("hello", $buffer);
@@ -2158,10 +2159,10 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(
+                [
                     'Content-Length' => 1000,
                     'Transfer-Encoding' => 'chunked'
-                ),
+                ],
                 'hello'
             );
         });
@@ -2179,11 +2180,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertNotContainsString("Transfer-Encoding: chunked", $buffer);
         $this->assertContainsString("Content-Length: 5", $buffer);
@@ -2199,7 +2200,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
-                array(),
+                [],
                 $body
             );
         });
@@ -2217,10 +2218,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("Transfer-Encoding: chunked", $buffer);
         $this->assertNotContainsString("Content-Length:", $buffer);
@@ -2236,7 +2237,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($body) {
             return new Response(
                 200,
-                array(),
+                [],
                 $body
             );
         });
@@ -2254,10 +2255,10 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n";
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertNotContainsString("Transfer-Encoding: chunked", $buffer);
         $this->assertNotContainsString("Content-Length:", $buffer);
@@ -2270,9 +2271,9 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($stream) {
             return new Response(
                 200,
-                array(
+                [
                     'Transfer-Encoding' => 'custom'
-                ),
+                ],
                 $stream
             );
         });
@@ -2290,12 +2291,12 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
-        $stream->emit('data', array('hello'));
+        $this->connection->emit('data', [$data]);
+        $stream->emit('data', ['hello']);
 
         $this->assertContainsString('Transfer-Encoding: chunked', $buffer);
         $this->assertNotContainsString('Transfer-Encoding: custom', $buffer);
@@ -2329,11 +2330,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("Date: Thu, 19 May 2022 14:54:51 GMT\r\n", $buffer);
@@ -2345,7 +2346,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array("Date" => "Tue, 15 Nov 1994 08:12:31 GMT")
+                ["Date" => "Tue, 15 Nov 1994 08:12:31 GMT"]
             );
         });
 
@@ -2362,11 +2363,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n", $buffer);
@@ -2378,7 +2379,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array('Date' => '')
+                ['Date' => '']
             );
         });
 
@@ -2395,11 +2396,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertNotContainsString("Date:", $buffer);
@@ -2411,14 +2412,14 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array(
-                    'Set-Cookie' => array(
+                [
+                    'Set-Cookie' => [
                         'name=test',
                         'session=abc'
-                    ),
+                    ],
                     'Date' => '',
                     'Server' => ''
-                )
+                ]
             );
         });
 
@@ -2435,11 +2436,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertEquals("HTTP/1.1 200 OK\r\nSet-Cookie: name=test\r\nSet-Cookie: session=abc\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", $buffer);
     }
@@ -2463,7 +2464,7 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -2471,7 +2472,7 @@ class StreamingServerTest extends TestCase
         $data .= "Expect: 100-continue\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->assertContainsString("HTTP/1.1 100 Continue\r\n", $buffer);
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
     }
@@ -2495,13 +2496,13 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.0\r\n";
         $data .= "Expect: 100-continue\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->assertContainsString("HTTP/1.0 200 OK\r\n", $buffer);
         $this->assertNotContainsString("HTTP/1.1 100 Continue\r\n\r\n", $buffer);
     }
@@ -2519,7 +2520,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
-                array(),
+                [],
                 $input
             );
         });
@@ -2537,13 +2538,13 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
-        $input->emit('data', array('1'));
-        $input->emit('data', array('23'));
+        $this->connection->emit('data', [$data]);
+        $input->emit('data', ['1']);
+        $input->emit('data', ['23']);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\n\r\n", $buffer);
@@ -2558,7 +2559,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) use ($input) {
             return new Response(
                 200,
-                array('Content-Length' => 5),
+                ['Content-Length' => 5],
                 $input
             );
         });
@@ -2576,13 +2577,13 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
-        $input->emit('data', array('hel'));
-        $input->emit('data', array('lo'));
+        $this->connection->emit('data', [$data]);
+        $input->emit('data', ['hel']);
+        $input->emit('data', ['lo']);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("Content-Length: 5\r\n", $buffer);
@@ -2594,7 +2595,7 @@ class StreamingServerTest extends TestCase
     public function testResponseWithResponsePromise()
     {
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
-            return \React\Promise\resolve(new Response());
+            return resolve(new Response());
         });
 
         $buffer = '';
@@ -2610,11 +2611,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("\r\n\r\n", $buffer);
     }
@@ -2643,11 +2644,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
         $this->assertInstanceOf('RuntimeException', $exception);
@@ -2656,7 +2657,7 @@ class StreamingServerTest extends TestCase
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
     {
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
-            return \React\Promise\resolve("invalid");
+            return resolve("invalid");
         });
 
         $buffer = '';
@@ -2672,11 +2673,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
@@ -2703,11 +2704,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
@@ -2734,11 +2735,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
@@ -2748,7 +2749,7 @@ class StreamingServerTest extends TestCase
         $server = new StreamingServer(Loop::get(), function (ServerRequestInterface $request) {
             return new Response(
                 200,
-                array('Transfer-Encoding' => 'chunked'),
+                ['Transfer-Encoding' => 'chunked'],
                 'hello'
             );
         });
@@ -2766,11 +2767,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
         $this->assertContainsString("Content-Length: 5\r\n", $buffer);
@@ -2798,11 +2799,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
     }
@@ -2831,11 +2832,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertInstanceOf('RuntimeException', $exception);
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
@@ -2866,12 +2867,12 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
         try {
-            $this->connection->emit('data', array($data));
+            $this->connection->emit('data', [$data]);
         } catch (\Error $e) {
             $this->markTestSkipped(
                 'A \Throwable bubbled out of the request callback. ' .
@@ -2911,11 +2912,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
         $this->assertInstanceOf('RuntimeException', $exception);
@@ -2923,49 +2924,49 @@ class StreamingServerTest extends TestCase
 
     public static function provideInvalidResponse()
     {
-        $response = new Response(200, array(), '', '1.1', 'OK');
+        $response = new Response(200, [], '', '1.1', 'OK');
 
-        return array(
-            array(
+        return [
+            [
                 $response->withStatus(99, 'OK')
-            ),
-            array(
+            ],
+            [
                 $response->withStatus(1000, 'OK')
-            ),
-            array(
+            ],
+            [
                 $response->withStatus(200, "Invald\r\nReason: Yes")
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Invalid', "Yes\r\n")
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Invalid', "Yes\n")
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Invalid', "Yes\r")
-            ),
-            array(
+            ],
+            [
                 $response->withHeader("Inva\r\nlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $response->withHeader("Inva\nlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $response->withHeader("Inva\rlid", 'Yes')
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Inva Lid', 'Yes')
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Inva:Lid', 'Yes')
-            ),
-            array(
+            ],
+            [
                 $response->withHeader('Invalid', "Val\0ue")
-            ),
-            array(
+            ],
+            [
                 $response->withHeader("Inva\0lid", 'Yes')
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -2996,11 +2997,11 @@ class StreamingServerTest extends TestCase
             );
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
         $this->assertInstanceOf('InvalidArgumentException', $exception);
@@ -3024,11 +3025,11 @@ class StreamingServerTest extends TestCase
             ->willReturn('127.0.0.1:8080');
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = $this->createGetRequest();
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $serverParams = $requestValidation->getServerParams();
 
@@ -3048,11 +3049,11 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET /foo.php?hello=world&test=bar HTTP/1.0\r\n\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
         $queryParams = $requestValidation->getQueryParams();
 
@@ -3068,7 +3069,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -3076,9 +3077,9 @@ class StreamingServerTest extends TestCase
         $data .= "Cookie: hello=world\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
+        $this->connection->emit('data', [$data]);
 
-        $this->assertEquals(array('hello' => 'world'), $requestValidation->getCookieParams());
+        $this->assertEquals(['hello' => 'world'], $requestValidation->getCookieParams());
     }
 
     public function testRequestInvalidMultipleCookiesWontBeAddedToServerRequest()
@@ -3089,7 +3090,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -3098,8 +3099,8 @@ class StreamingServerTest extends TestCase
         $data .= "Cookie: test=failed\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
-        $this->assertEquals(array(), $requestValidation->getCookieParams());
+        $this->connection->emit('data', [$data]);
+        $this->assertEquals([], $requestValidation->getCookieParams());
     }
 
     public function testRequestCookieWithSeparatorWillBeAddedToServerRequest()
@@ -3110,7 +3111,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -3118,8 +3119,8 @@ class StreamingServerTest extends TestCase
         $data .= "Cookie: hello=world; test=abc\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
-        $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $requestValidation->getCookieParams());
+        $this->connection->emit('data', [$data]);
+        $this->assertEquals(['hello' => 'world', 'test' => 'abc'], $requestValidation->getCookieParams());
     }
 
     public function testRequestCookieWithCommaValueWillBeAddedToServerRequest()
@@ -3130,7 +3131,7 @@ class StreamingServerTest extends TestCase
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $data = "GET / HTTP/1.1\r\n";
         $data .= "Host: example.com\r\n";
@@ -3138,8 +3139,8 @@ class StreamingServerTest extends TestCase
         $data .= "Cookie: test=abc,def; hello=world\r\n";
         $data .= "\r\n";
 
-        $this->connection->emit('data', array($data));
-        $this->assertEquals(array('test' => 'abc,def', 'hello' => 'world'), $requestValidation->getCookieParams());
+        $this->connection->emit('data', [$data]);
+        $this->assertEquals(['test' => 'abc,def', 'hello' => 'world'], $requestValidation->getCookieParams());
     }
 
     public function testNewConnectionWillInvokeParserOnce()
@@ -3154,12 +3155,12 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
     }
 
     public function testNewConnectionWillInvokeParserOnceAndInvokeRequestHandlerWhenParserIsDoneForHttp10()
     {
-        $request = new ServerRequest('GET', 'http://localhost/', array(), '', '1.0');
+        $request = new ServerRequest('GET', 'http://localhost/', [], '', '1.0');
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
@@ -3171,7 +3172,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->once())->method('end');
@@ -3182,7 +3183,7 @@ class StreamingServerTest extends TestCase
 
     public function testNewConnectionWillInvokeParserOnceAndInvokeRequestHandlerWhenParserIsDoneForHttp11ConnectionClose()
     {
-        $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'close'));
+        $request = new ServerRequest('GET', 'http://localhost/', ['Connection' => 'close']);
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
@@ -3194,7 +3195,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->once())->method('end');
@@ -3208,7 +3209,7 @@ class StreamingServerTest extends TestCase
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $server = new StreamingServer(Loop::get(), function () {
-            return new Response(200, array('Connection' => 'close'));
+            return new Response(200, ['Connection' => 'close']);
         });
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
@@ -3219,7 +3220,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->once())->method('end');
@@ -3244,7 +3245,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->never())->method('end');
@@ -3255,7 +3256,7 @@ class StreamingServerTest extends TestCase
 
     public function testNewConnectionWillInvokeParserTwiceAfterInvokingRequestHandlerWhenConnectionCanBeKeptAliveForHttp10ConnectionKeepAlive()
     {
-        $request = new ServerRequest('GET', 'http://localhost/', array('Connection' => 'keep-alive'), '', '1.0');
+        $request = new ServerRequest('GET', 'http://localhost/', ['Connection' => 'keep-alive'], '', '1.0');
 
         $server = new StreamingServer(Loop::get(), function () {
             return new Response();
@@ -3269,7 +3270,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->never())->method('end');
@@ -3284,7 +3285,7 @@ class StreamingServerTest extends TestCase
 
         $body = new ThroughStream();
         $server = new StreamingServer(Loop::get(), function () use ($body) {
-            return new Response(200, array(), $body);
+            return new Response(200, [], $body);
         });
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
@@ -3295,7 +3296,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->once())->method('write');
         $this->connection->expects($this->never())->method('end');
@@ -3310,7 +3311,7 @@ class StreamingServerTest extends TestCase
 
         $body = new ThroughStream();
         $server = new StreamingServer(Loop::get(), function () use ($body) {
-            return new Response(200, array(), $body);
+            return new Response(200, [], $body);
         });
 
         $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
@@ -3321,7 +3322,7 @@ class StreamingServerTest extends TestCase
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($this->connection));
+        $this->socket->emit('connection', [$this->connection]);
 
         $this->connection->expects($this->exactly(2))->method('write');
         $this->connection->expects($this->never())->method('end');
@@ -3336,16 +3337,16 @@ class StreamingServerTest extends TestCase
 
     public function testCompletingARequestWillRemoveConnectionOnCloseListener()
     {
-        $connection = $this->mockConnection(array('removeListener'));
+        $connection = $this->mockConnection(['removeListener']);
 
         $request = new ServerRequest('GET', 'http://localhost/');
 
         $server = new StreamingServer(Loop::get(), function () {
-            return \React\Promise\resolve(new Response());
+            return resolve(new Response());
         });
 
         $server->listen($this->socket);
-        $this->socket->emit('connection', array($connection));
+        $this->socket->emit('connection', [$connection]);
 
         $connection->expects($this->once())->method('removeListener');
 

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -4,11 +4,14 @@ namespace React\Tests\Http\Io;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use React\EventLoop\Loop;
+use React\Http\Io\RequestHeaderParser;
 use React\Http\Io\StreamingServer;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
 use React\Promise\Promise;
+use React\Socket\Connection;
 use React\Stream\ThroughStream;
 use React\Tests\Http\SocketServerStub;
 use React\Tests\Http\TestCase;
@@ -35,7 +38,7 @@ class StreamingServerTest extends TestCase
 
     private function mockConnection(array $additionalMethods = null)
     {
-        $connection = $this->getMockBuilder('React\Socket\Connection')
+        $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods(array_merge(
                 [
@@ -125,7 +128,7 @@ class StreamingServerTest extends TestCase
         $serverParams = $requestAssertion->getServerParams();
 
         $this->assertSame(1, $i);
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -158,7 +161,7 @@ class StreamingServerTest extends TestCase
         $serverParams = $requestAssertion->getServerParams();
 
         $this->assertSame(1, $i);
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -181,7 +184,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -203,7 +206,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -225,7 +228,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -247,7 +250,7 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/', $requestAssertion->getRequestTarget());
         $this->assertSame('/', $requestAssertion->getUri()->getPath());
@@ -282,7 +285,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('*', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -315,7 +318,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:443', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -337,7 +340,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:443 HTTP/1.1\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:443', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -359,7 +362,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:80', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -381,7 +384,7 @@ class StreamingServerTest extends TestCase
         $data = "CONNECT example.com:80 HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('CONNECT', $requestAssertion->getMethod());
         $this->assertSame('example.com:80', $requestAssertion->getRequestTarget());
         $this->assertSame('', $requestAssertion->getUri()->getPath());
@@ -433,7 +436,7 @@ class StreamingServerTest extends TestCase
         $data = "GET /test HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://127.0.0.1/test', $requestAssertion->getUri());
@@ -454,7 +457,7 @@ class StreamingServerTest extends TestCase
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('http://example.com/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com/test', $requestAssertion->getUri());
@@ -476,7 +479,7 @@ class StreamingServerTest extends TestCase
         $data = "GET http://example.com/test HTTP/1.1\r\nHost: other.example.org\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('GET', $requestAssertion->getMethod());
         $this->assertSame('http://example.com/test', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com/test', $requestAssertion->getUri());
@@ -510,7 +513,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('*', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com', $requestAssertion->getUri());
@@ -532,7 +535,7 @@ class StreamingServerTest extends TestCase
         $data = "OPTIONS http://example.com HTTP/1.1\r\nHost: example.com\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $requestAssertion);
+        $this->assertInstanceOf(ServerRequestInterface::class, $requestAssertion);
         $this->assertSame('OPTIONS', $requestAssertion->getMethod());
         $this->assertSame('http://example.com', $requestAssertion->getRequestTarget());
         $this->assertEquals('http://example.com', $requestAssertion->getUri());
@@ -698,12 +701,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -712,7 +713,7 @@ class StreamingServerTest extends TestCase
         $data = $this->createGetRequest();
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("\r\nServer: ReactPHP/1\r\n", $buffer);
+        $this->assertStringContainsString("\r\nServer: ReactPHP/1\r\n", $buffer);
     }
 
     public function testResponsePendingPromiseWillNotSendAnything()
@@ -728,12 +729,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -758,12 +757,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -794,12 +791,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -829,12 +824,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -867,12 +860,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -903,15 +894,13 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
-        $this->connection = $this->getMockBuilder('React\Socket\Connection')
+        $this->connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods(
                 [
@@ -980,12 +969,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1015,12 +1002,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1053,12 +1038,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1091,12 +1074,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1128,12 +1109,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1185,12 +1164,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1199,8 +1176,8 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("bye", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("bye", $buffer);
     }
 
     public function testResponseContainsSameRequestProtocolVersionAndRawBodyForHttp10()
@@ -1218,12 +1195,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1232,9 +1207,9 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.0\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.0 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
-        $this->assertContainsString("bye", $buffer);
+        $this->assertStringContainsString("HTTP/1.0 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("bye", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyForHeadRequest()
@@ -1251,12 +1226,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1265,9 +1238,9 @@ class StreamingServerTest extends TestCase
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
-        $this->assertNotContainsString("bye", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringNotContainsString("bye", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyForHeadRequestWithStreamingResponse()
@@ -1287,12 +1260,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1301,8 +1272,8 @@ class StreamingServerTest extends TestCase
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatus()
@@ -1319,12 +1290,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1333,9 +1302,9 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
-        $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
-        $this->assertNotContainsString("bye", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
+        $this->assertStringNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringNotContainsString("bye", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyAndNoContentLengthForNoContentStatusResponseWithStreamingBody()
@@ -1355,12 +1324,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1369,8 +1336,8 @@ class StreamingServerTest extends TestCase
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
-        $this->assertNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 204 No Content\r\n", $buffer);
+        $this->assertStringNotContainsString("\r\nContent-Length: 3\r\n", $buffer);
     }
 
     public function testResponseContainsNoContentLengthHeaderForNotModifiedStatus()
@@ -1387,12 +1354,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1401,8 +1366,8 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
-        $this->assertNotContainsString("\r\nContent-Length: 0\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
+        $this->assertStringNotContainsString("\r\nContent-Length: 0\r\n", $buffer);
     }
 
     public function testResponseContainsExplicitContentLengthHeaderForNotModifiedStatus()
@@ -1419,12 +1384,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1433,8 +1396,8 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
     }
 
     public function testResponseContainsExplicitContentLengthHeaderForHeadRequests()
@@ -1451,12 +1414,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1465,8 +1426,8 @@ class StreamingServerTest extends TestCase
         $data = "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatus()
@@ -1483,12 +1444,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1497,9 +1456,9 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
-        $this->assertNotContainsString("bye", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringNotContainsString("bye", $buffer);
     }
 
     public function testResponseContainsNoResponseBodyForNotModifiedStatusWithStreamingBody()
@@ -1519,12 +1478,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1533,8 +1490,8 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
-        $this->assertContainsString("\r\nContent-Length: 3\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 304 Not Modified\r\n", $buffer);
+        $this->assertStringContainsString("\r\nContent-Length: 3\r\n", $buffer);
     }
 
     public function testRequestInvalidHttpProtocolVersionWillEmitErrorAndSendErrorResponse()
@@ -1550,12 +1507,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1564,11 +1519,11 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.2\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $error);
 
-        $this->assertContainsString("HTTP/1.1 505 HTTP Version Not Supported\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
-        $this->assertContainsString("Error 505: HTTP Version Not Supported", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 505 HTTP Version Not Supported\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("Error 505: HTTP Version Not Supported", $buffer);
     }
 
     public function testRequestOverflowWillEmitErrorAndSendErrorResponse()
@@ -1584,12 +1539,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1599,10 +1552,10 @@ class StreamingServerTest extends TestCase
         $data .= str_repeat('A', 8193 - strlen($data)) . "\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('OverflowException', $error);
+        $this->assertInstanceOf(\OverflowException::class, $error);
 
-        $this->assertContainsString("HTTP/1.1 431 Request Header Fields Too Large\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\nError 431: Request Header Fields Too Large", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 431 Request Header Fields Too Large\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\nError 431: Request Header Fields Too Large", $buffer);
     }
 
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
@@ -1618,12 +1571,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -1632,10 +1583,10 @@ class StreamingServerTest extends TestCase
         $data = "bad request\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('InvalidArgumentException', $error);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $error);
 
-        $this->assertContainsString("HTTP/1.1 400 Bad Request\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\nError 400: Bad Request", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 400 Bad Request\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\nError 400: Bad Request", $buffer);
     }
 
     public function testRequestContentLengthBodyDataWillEmitDataEventOnRequestStream()
@@ -1959,7 +1910,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestInvalidChunkHeaderTooLongWillEmitErrorOnRequestStream()
     {
-        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
+        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf(\Exception::class));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
             return resolve(new Response());
@@ -1984,7 +1935,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestInvalidChunkBodyTooLongWillEmitErrorOnRequestStream()
     {
-        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
+        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf(\Exception::class));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
@@ -2006,7 +1957,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestUnexpectedEndOfRequestWithChunkedTransferConnectionWillEmitErrorOnRequestStream()
     {
-        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
+        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf(\Exception::class));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
@@ -2029,7 +1980,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestInvalidChunkHeaderWillEmitErrorOnRequestStream()
     {
-        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
+        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf(\Exception::class));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
@@ -2051,7 +2002,7 @@ class StreamingServerTest extends TestCase
 
     public function testRequestUnexpectedEndOfRequestWithContentLengthWillEmitErrorOnRequestStream()
     {
-        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf('Exception'));
+        $errorEvent = $this->expectCallableOnceWith($this->isInstanceOf(\Exception::class));
         $server = new StreamingServer(Loop::get(), function ($request) use ($errorEvent){
             $request->getBody()->on('error', $errorEvent);
         });
@@ -2134,12 +2085,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2150,8 +2099,8 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', [$data]);
         $stream->emit('data', ['hello']);
 
-        $this->assertContainsString("Transfer-Encoding: chunked", $buffer);
-        $this->assertContainsString("hello", $buffer);
+        $this->assertStringContainsString("Transfer-Encoding: chunked", $buffer);
+        $this->assertStringContainsString("hello", $buffer);
     }
 
     public function testResponseWithBodyStringWillOverwriteExplicitContentLengthAndTransferEncoding()
@@ -2171,12 +2120,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2186,14 +2133,14 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertNotContainsString("Transfer-Encoding: chunked", $buffer);
-        $this->assertContainsString("Content-Length: 5", $buffer);
-        $this->assertContainsString("hello", $buffer);
+        $this->assertStringNotContainsString("Transfer-Encoding: chunked", $buffer);
+        $this->assertStringContainsString("Content-Length: 5", $buffer);
+        $this->assertStringContainsString("hello", $buffer);
     }
 
     public function testResponseContainsResponseBodyWithTransferEncodingChunkedForBodyWithUnknownSize()
     {
-        $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
+        $body = $this->createMock(StreamInterface::class);
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
@@ -2209,12 +2156,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2223,14 +2168,14 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("Transfer-Encoding: chunked", $buffer);
-        $this->assertNotContainsString("Content-Length:", $buffer);
-        $this->assertContainsString("body", $buffer);
+        $this->assertStringContainsString("Transfer-Encoding: chunked", $buffer);
+        $this->assertStringNotContainsString("Content-Length:", $buffer);
+        $this->assertStringContainsString("body", $buffer);
     }
 
     public function testResponseContainsResponseBodyWithPlainBodyWithUnknownSizeForLegacyHttp10()
     {
-        $body = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
+        $body = $this->createMock(StreamInterface::class);
         $body->expects($this->once())->method('getSize')->willReturn(null);
         $body->expects($this->once())->method('__toString')->willReturn('body');
 
@@ -2246,12 +2191,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2260,9 +2203,9 @@ class StreamingServerTest extends TestCase
         $data = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n";
         $this->connection->emit('data', [$data]);
 
-        $this->assertNotContainsString("Transfer-Encoding: chunked", $buffer);
-        $this->assertNotContainsString("Content-Length:", $buffer);
-        $this->assertContainsString("body", $buffer);
+        $this->assertStringNotContainsString("Transfer-Encoding: chunked", $buffer);
+        $this->assertStringNotContainsString("Content-Length:", $buffer);
+        $this->assertStringContainsString("body", $buffer);
     }
 
     public function testResponseWithCustomTransferEncodingWillBeIgnoredAndUseChunkedTransferEncodingInstead()
@@ -2282,12 +2225,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2298,9 +2239,9 @@ class StreamingServerTest extends TestCase
         $this->connection->emit('data', [$data]);
         $stream->emit('data', ['hello']);
 
-        $this->assertContainsString('Transfer-Encoding: chunked', $buffer);
-        $this->assertNotContainsString('Transfer-Encoding: custom', $buffer);
-        $this->assertContainsString("5\r\nhello\r\n", $buffer);
+        $this->assertStringContainsString('Transfer-Encoding: chunked', $buffer);
+        $this->assertStringNotContainsString('Transfer-Encoding: custom', $buffer);
+        $this->assertStringContainsString("5\r\nhello\r\n", $buffer);
     }
 
     public function testResponseWithoutExplicitDateHeaderWillAddCurrentDateFromClock()
@@ -2321,12 +2262,10 @@ class StreamingServerTest extends TestCase
             $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2336,9 +2275,9 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("Date: Thu, 19 May 2022 14:54:51 GMT\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("Date: Thu, 19 May 2022 14:54:51 GMT\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
     }
 
     public function testResponseWithCustomDateHeaderOverwritesDefault()
@@ -2354,12 +2293,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2369,9 +2306,9 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
     }
 
     public function testResponseWithEmptyDateHeaderRemovesDateHeader()
@@ -2387,12 +2324,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2402,9 +2337,9 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertNotContainsString("Date:", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringNotContainsString("Date:", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
     }
 
     public function testResponseCanContainMultipleCookieHeaders()
@@ -2427,12 +2362,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2455,12 +2388,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2473,8 +2404,8 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
 
         $this->connection->emit('data', [$data]);
-        $this->assertContainsString("HTTP/1.1 100 Continue\r\n", $buffer);
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 100 Continue\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
     }
 
     public function testResponseWithExpectContinueRequestWontSendContinueForHttp10()
@@ -2487,12 +2418,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2503,13 +2432,13 @@ class StreamingServerTest extends TestCase
         $data .= "\r\n";
 
         $this->connection->emit('data', [$data]);
-        $this->assertContainsString("HTTP/1.0 200 OK\r\n", $buffer);
-        $this->assertNotContainsString("HTTP/1.1 100 Continue\r\n\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.0 200 OK\r\n", $buffer);
+        $this->assertStringNotContainsString("HTTP/1.1 100 Continue\r\n\r\n", $buffer);
     }
 
     public function testInvalidCallbackFunctionLeadsToException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new StreamingServer(Loop::get(), 'invalid');
     }
 
@@ -2529,12 +2458,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2546,10 +2473,10 @@ class StreamingServerTest extends TestCase
         $input->emit('data', ['1']);
         $input->emit('data', ['23']);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
-        $this->assertContainsString("1\r\n1\r\n", $buffer);
-        $this->assertContainsString("2\r\n23\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("1\r\n1\r\n", $buffer);
+        $this->assertStringContainsString("2\r\n23\r\n", $buffer);
     }
 
     public function testResponseBodyStreamWithContentLengthWillStreamTillLengthWithoutTransferEncoding()
@@ -2568,12 +2495,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2585,11 +2510,11 @@ class StreamingServerTest extends TestCase
         $input->emit('data', ['hel']);
         $input->emit('data', ['lo']);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("Content-Length: 5\r\n", $buffer);
-        $this->assertNotContainsString("Transfer-Encoding", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
-        $this->assertContainsString("hello", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("Content-Length: 5\r\n", $buffer);
+        $this->assertStringNotContainsString("Transfer-Encoding", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("hello", $buffer);
     }
 
     public function testResponseWithResponsePromise()
@@ -2602,12 +2527,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2616,8 +2539,8 @@ class StreamingServerTest extends TestCase
         $data = $this->createGetRequest();
 
         $this->connection->emit('data', [$data]);
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("\r\n\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("\r\n\r\n", $buffer);
     }
 
     public function testResponseReturnInvalidTypeWillResultInError()
@@ -2635,12 +2558,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2650,8 +2571,8 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
     }
 
     public function testResponseResolveWrongTypeInPromiseWillResultInError()
@@ -2664,12 +2585,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2679,7 +2598,7 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
 
     public function testResponseRejectedPromiseWillResultInErrorMessage()
@@ -2695,12 +2614,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2710,7 +2627,7 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
 
     public function testResponseExceptionInCallbackWillResultInErrorMessage()
@@ -2726,12 +2643,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2741,7 +2656,7 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
     }
 
     public function testResponseWithContentLengthHeaderForStringBodyOverwritesTransferEncoding()
@@ -2758,12 +2673,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2773,11 +2686,11 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
-        $this->assertContainsString("Content-Length: 5\r\n", $buffer);
-        $this->assertContainsString("hello", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("Content-Length: 5\r\n", $buffer);
+        $this->assertStringContainsString("hello", $buffer);
 
-        $this->assertNotContainsString("Transfer-Encoding", $buffer);
+        $this->assertStringNotContainsString("Transfer-Encoding", $buffer);
     }
 
     public function testResponseWillBeHandled()
@@ -2790,12 +2703,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2805,7 +2716,7 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 200 OK\r\n", $buffer);
+        $this->assertStringContainsString("HTTP/1.1 200 OK\r\n", $buffer);
     }
 
     public function testResponseExceptionThrowInCallBackFunctionWillResultInErrorMessage()
@@ -2823,12 +2734,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2838,8 +2747,8 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertInstanceOf('RuntimeException', $exception);
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
         $this->assertEquals('hello', $exception->getPrevious()->getMessage());
     }
 
@@ -2858,12 +2767,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2881,8 +2788,8 @@ class StreamingServerTest extends TestCase
             );
         }
 
-        $this->assertInstanceOf('RuntimeException', $exception);
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
         $this->assertEquals('hello', $exception->getPrevious()->getMessage());
     }
 
@@ -2903,12 +2810,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -2918,54 +2823,52 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
     }
 
     public static function provideInvalidResponse()
     {
         $response = new Response(200, [], '', '1.1', 'OK');
 
-        return [
-            [
-                $response->withStatus(99, 'OK')
-            ],
-            [
-                $response->withStatus(1000, 'OK')
-            ],
-            [
-                $response->withStatus(200, "Invald\r\nReason: Yes")
-            ],
-            [
-                $response->withHeader('Invalid', "Yes\r\n")
-            ],
-            [
-                $response->withHeader('Invalid', "Yes\n")
-            ],
-            [
-                $response->withHeader('Invalid', "Yes\r")
-            ],
-            [
-                $response->withHeader("Inva\r\nlid", 'Yes')
-            ],
-            [
-                $response->withHeader("Inva\nlid", 'Yes')
-            ],
-            [
-                $response->withHeader("Inva\rlid", 'Yes')
-            ],
-            [
-                $response->withHeader('Inva Lid', 'Yes')
-            ],
-            [
-                $response->withHeader('Inva:Lid', 'Yes')
-            ],
-            [
-                $response->withHeader('Invalid', "Val\0ue")
-            ],
-            [
-                $response->withHeader("Inva\0lid", 'Yes')
-            ]
+        yield [
+            $response->withStatus(99, 'OK')
+        ];
+        yield [
+            $response->withStatus(1000, 'OK')
+        ];
+        yield [
+            $response->withStatus(200, "Invald\r\nReason: Yes")
+        ];
+        yield [
+            $response->withHeader('Invalid', "Yes\r\n")
+        ];
+        yield [
+            $response->withHeader('Invalid', "Yes\n")
+        ];
+        yield [
+            $response->withHeader('Invalid', "Yes\r")
+        ];
+        yield [
+            $response->withHeader("Inva\r\nlid", 'Yes')
+        ];
+        yield [
+            $response->withHeader("Inva\nlid", 'Yes')
+        ];
+        yield [
+            $response->withHeader("Inva\rlid", 'Yes')
+        ];
+        yield [
+            $response->withHeader('Inva Lid', 'Yes')
+        ];
+        yield [
+            $response->withHeader('Inva:Lid', 'Yes')
+        ];
+        yield [
+            $response->withHeader('Invalid', "Val\0ue")
+        ];
+        yield [
+            $response->withHeader("Inva\0lid", 'Yes')
         ];
     }
 
@@ -2988,12 +2891,10 @@ class StreamingServerTest extends TestCase
         $this->connection
             ->expects($this->any())
             ->method('write')
-            ->will(
-                $this->returnCallback(
-                    function ($data) use (&$buffer) {
-                        $buffer .= $data;
-                    }
-                )
+            ->willReturnCallback(
+                function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                }
             );
 
         $server->listen($this->socket);
@@ -3003,8 +2904,8 @@ class StreamingServerTest extends TestCase
 
         $this->connection->emit('data', [$data]);
 
-        $this->assertContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
-        $this->assertInstanceOf('InvalidArgumentException', $exception);
+        $this->assertStringContainsString("HTTP/1.1 500 Internal Server Error\r\n", $buffer);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
     }
 
     public function testRequestServerRequestParams()
@@ -3147,7 +3048,7 @@ class StreamingServerTest extends TestCase
     {
         $server = new StreamingServer(Loop::get(), $this->expectCallableNever());
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3164,7 +3065,7 @@ class StreamingServerTest extends TestCase
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3187,7 +3088,7 @@ class StreamingServerTest extends TestCase
 
         $server = new StreamingServer(Loop::get(), $this->expectCallableOnceWith($request));
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3212,7 +3113,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, ['Connection' => 'close']);
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3237,7 +3138,7 @@ class StreamingServerTest extends TestCase
             return new Response();
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3262,7 +3163,7 @@ class StreamingServerTest extends TestCase
             return new Response();
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3288,7 +3189,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, [], $body);
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
@@ -3314,7 +3215,7 @@ class StreamingServerTest extends TestCase
             return new Response(200, [], $body);
         });
 
-        $parser = $this->getMockBuilder('React\Http\Io\RequestHeaderParser')->disableOriginalConstructor()->getMock();
+        $parser = $this->createMock(RequestHeaderParser::class);
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -11,10 +11,13 @@ use React\Http\Message\Request;
 use React\Http\Message\Response;
 use React\Http\Message\ResponseException;
 use React\EventLoop\Loop;
-use React\Promise;
 use React\Promise\Deferred;
+use React\Promise\Promise;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
+use function React\Async\await;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class TransactionTest extends TestCase
 {
@@ -24,7 +27,7 @@ class TransactionTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $transaction = new Transaction($sender, $loop);
 
-        $new = $transaction->withOptions(array('followRedirects' => false));
+        $new = $transaction->withOptions(['followRedirects' => false]);
 
         $this->assertInstanceOf('React\Http\Io\Transaction', $new);
         $this->assertNotSame($transaction, $new);
@@ -41,7 +44,7 @@ class TransactionTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $transaction = new Transaction($sender, $loop);
 
-        $transaction->withOptions(array('followRedirects' => false));
+        $transaction->withOptions(['followRedirects' => false]);
 
         $ref = new \ReflectionProperty($transaction, 'followRedirects');
         $ref->setAccessible(true);
@@ -55,8 +58,8 @@ class TransactionTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $transaction = new Transaction($sender, $loop);
 
-        $transaction = $transaction->withOptions(array('followRedirects' => false));
-        $transaction = $transaction->withOptions(array('followRedirects' => null));
+        $transaction = $transaction->withOptions(['followRedirects' => false]);
+        $transaction = $transaction->withOptions(['followRedirects' => null]);
 
         $ref = new \ReflectionProperty($transaction, 'followRedirects');
         $ref->setAccessible(true);
@@ -74,10 +77,10 @@ class TransactionTest extends TestCase
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -93,7 +96,7 @@ class TransactionTest extends TestCase
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
 
@@ -119,10 +122,10 @@ class TransactionTest extends TestCase
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $this->assertNotNull($timeout);
@@ -143,13 +146,13 @@ class TransactionTest extends TestCase
         $loop->expects($this->never())->method('addTimer');
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), '');
+        $response = new Response(200, [], '');
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 0.001));
+        $transaction = $transaction->withOptions(['timeout' => 0.001]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -164,14 +167,14 @@ class TransactionTest extends TestCase
         $loop->expects($this->once())->method('cancelTimer')->with($timer);
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), '');
+        $response = new Response(200, [], '');
 
         $deferred = new Deferred();
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn($deferred->promise());
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 0.001));
+        $transaction = $transaction->withOptions(['timeout' => 0.001]);
         $promise = $transaction->send($request);
 
         $deferred->resolve($response);
@@ -189,10 +192,10 @@ class TransactionTest extends TestCase
         $exception = new \RuntimeException();
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\reject($exception));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(reject($exception));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 0.001));
+        $transaction = $transaction->withOptions(['timeout' => 0.001]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -213,7 +216,7 @@ class TransactionTest extends TestCase
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn($deferred->promise());
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 0.001));
+        $transaction = $transaction->withOptions(['timeout' => 0.001]);
         $promise = $transaction->send($request);
 
         $exception = new \RuntimeException();
@@ -231,10 +234,10 @@ class TransactionTest extends TestCase
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => -1));
+        $transaction = $transaction->withOptions(['timeout' => -1]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -246,13 +249,13 @@ class TransactionTest extends TestCase
         $loop->expects($this->never())->method('addTimer');
 
         $stream = new ThroughStream();
-        $request = new Request('POST', 'http://example.com', array(), new ReadableBodyStream($stream));
+        $request = new Request('POST', 'http://example.com', [], new ReadableBodyStream($stream));
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -267,13 +270,13 @@ class TransactionTest extends TestCase
 
         $stream = new ThroughStream();
         $stream->close();
-        $request = new Request('POST', 'http://example.com', array(), new ReadableBodyStream($stream));
+        $request = new Request('POST', 'http://example.com', [], new ReadableBodyStream($stream));
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
@@ -287,13 +290,13 @@ class TransactionTest extends TestCase
         $loop->expects($this->never())->method('cancelTimer');
 
         $stream = new ThroughStream();
-        $request = new Request('POST', 'http://example.com', array(), new ReadableBodyStream($stream));
+        $request = new Request('POST', 'http://example.com', [], new ReadableBodyStream($stream));
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $stream->close();
@@ -307,14 +310,14 @@ class TransactionTest extends TestCase
         $loop->expects($this->never())->method('addTimer');
 
         $stream = new ThroughStream();
-        $request = new Request('POST', 'http://example.com', array(), new ReadableBodyStream($stream));
+        $request = new Request('POST', 'http://example.com', [], new ReadableBodyStream($stream));
 
         $deferred = new Deferred();
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
         $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn($deferred->promise());
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $deferred->reject(new \RuntimeException('Request failed'));
@@ -337,13 +340,13 @@ class TransactionTest extends TestCase
         $loop->expects($this->never())->method('cancelTimer');
 
         $stream = new ThroughStream();
-        $request = new Request('POST', 'http://example.com', array(), new ReadableBodyStream($stream));
+        $request = new Request('POST', 'http://example.com', [], new ReadableBodyStream($stream));
 
         $sender = $this->getMockBuilder('React\Http\Io\Sender')->disableOriginalConstructor()->getMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new \React\Promise\Promise(function () { }));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(new Promise(function () { }));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $stream->close();
@@ -368,10 +371,10 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => -1));
+        $transaction = $transaction->withOptions(['timeout' => -1]);
         $promise = $transaction->send($request);
 
         $exception = null;
@@ -388,21 +391,21 @@ class TransactionTest extends TestCase
     {
         $stream = new ThroughStream();
         Loop::addTimer(0.001, function () use ($stream) {
-            $stream->emit('data', array('hello world'));
+            $stream->emit('data', ['hello world']);
             $stream->close();
         });
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), new ReadableBodyStream($stream));
+        $response = new Response(200, [], new ReadableBodyStream($stream));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, Loop::get());
         $promise = $transaction->send($request);
 
-        $response = \React\Async\await($promise);
+        $response = await($promise);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('hello world', (string)$response->getBody());
@@ -415,11 +418,11 @@ class TransactionTest extends TestCase
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
-        $response = new Response(200, array('Content-Length' => '100000000'), new ReadableBodyStream($stream, 100000000));
+        $response = new Response(200, ['Content-Length' => '100000000'], new ReadableBodyStream($stream, 100000000));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, Loop::get());
 
@@ -446,14 +449,14 @@ class TransactionTest extends TestCase
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
 
-        $response = new Response(200, array(), new ReadableBodyStream($stream));
+        $response = new Response(200, [], new ReadableBodyStream($stream));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, Loop::get());
-        $transaction = $transaction->withOptions(array('maximumSize' => 10));
+        $transaction = $transaction->withOptions(['maximumSize' => 10]);
         $promise = $transaction->send($request);
 
         $exception = null;
@@ -479,11 +482,11 @@ class TransactionTest extends TestCase
         });
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), new ReadableBodyStream($stream));
+        $response = new Response(200, [], new ReadableBodyStream($stream));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, Loop::get());
         $promise = $transaction->send($request);
@@ -511,7 +514,7 @@ class TransactionTest extends TestCase
         $stream->expects($this->once())->method('close');
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), new ReadableBodyStream($stream));
+        $response = new Response(200, [], new ReadableBodyStream($stream));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $deferred = new Deferred();
@@ -541,14 +544,14 @@ class TransactionTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $response = new Response(200, array(), new ReadableBodyStream($this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock()));
+        $response = new Response(200, [], new ReadableBodyStream($this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock()));
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($this->equalTo($request))->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('streaming' => true, 'timeout' => -1));
+        $transaction = $transaction->withOptions(['streaming' => true, 'timeout' => -1]);
         $promise = $transaction->send($request);
 
         $response = null;
@@ -566,13 +569,13 @@ class TransactionTest extends TestCase
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
         // conditional GET request will respond with 304 (Not Modified
-        $request = new Request('GET', 'http://example.com', array('If-None-Match' => '"abc"'));
-        $response = new Response(304, array('ETag' => '"abc"'));
+        $request = new Request('GET', 'http://example.com', ['If-None-Match' => '"abc"']);
+        $response = new Response(304, ['ETag' => '"abc"']);
         $sender = $this->makeSenderMock();
-        $sender->expects($this->once())->method('send')->with($request)->willReturn(Promise\resolve($response));
+        $sender->expects($this->once())->method('send')->with($request)->willReturn(resolve($response));
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => -1));
+        $transaction = $transaction->withOptions(['timeout' => -1]);
         $promise = $transaction->send($request);
 
         $promise->then($this->expectCallableOnceWith($response));
@@ -584,16 +587,16 @@ class TransactionTest extends TestCase
 
         // original GET request will respond with custom 333 redirect status code and follow location header
         $requestOriginal = new Request('GET', 'http://example.com');
-        $response = new Response(333, array('Location' => 'foo'));
+        $response = new Response(333, ['Location' => 'foo']);
         $sender = $this->makeSenderMock();
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($requestOriginal),
-            array($this->callback(function (RequestInterface $request) {
+            [$requestOriginal],
+            [$this->callback(function (RequestInterface $request) {
                 return $request->getMethod() === 'GET' && (string)$request->getUri() === 'http://example.com/foo';
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($response),
-            new \React\Promise\Promise(function () { })
+            resolve($response),
+            new Promise(function () { })
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -604,27 +607,26 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array('User-Agent' => 'Chrome');
+        $customHeaders = ['User-Agent' => 'Chrome'];
         $requestWithUserAgent = new Request('GET', 'http://example.com', $customHeaders);
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithUserAgent
-        $redirectResponse = new Response(301, array('Location' => 'http://redirect.com'));
+        $redirectResponse = new Response(301, ['Location' => 'http://redirect.com']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithUserAgent
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertEquals(array('Chrome'), $request->getHeader('User-Agent'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertEquals(['Chrome'], $request->getHeader('User-Agent'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -635,27 +637,26 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array('Authorization' => 'secret');
+        $customHeaders = ['Authorization' => 'secret'];
         $requestWithAuthorization = new Request('GET', 'http://example.com', $customHeaders);
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
-        $redirectResponse = new Response(301, array('Location' => 'http://redirect.com'));
+        $redirectResponse = new Response(301, ['Location' => 'http://redirect.com']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertFalse($request->hasHeader('Authorization'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertFalse($request->hasHeader('Authorization'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -666,27 +667,26 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array('Authorization' => 'secret');
+        $customHeaders = ['Authorization' => 'secret'];
         $requestWithAuthorization = new Request('GET', 'http://example.com', $customHeaders);
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
-        $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(301, ['Location' => 'http://example.com/new']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertEquals(array('secret'), $request->getHeader('Authorization'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertEquals(['secret'], $request->getHeader('Authorization'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -702,22 +702,21 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithAuthorization
-        $redirectResponse = new Response(301, array('Location' => 'http://user:pass@example.com/new'));
+        $redirectResponse = new Response(301, ['Location' => 'http://user:pass@example.com/new']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithAuthorization
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertEquals('user:pass', $request->getUri()->getUserInfo());
-                $that->assertFalse($request->hasHeader('Authorization'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertEquals('user:pass', $request->getUri()->getUserInfo());
+                $this->assertFalse($request->hasHeader('Authorization'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -728,32 +727,31 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array(
+        $customHeaders = [
             'Content-Type' => 'text/html; charset=utf-8',
-            'Content-Length' => '111',
-        );
+            'Content-Length' => '111'
+        ];
 
         $requestWithCustomHeaders = new Request('GET', 'http://example.com', $customHeaders);
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $requestWithCustomHeaders
-        $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(301, ['Location' => 'http://example.com/new']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $requestWithCustomHeaders
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertFalse($request->hasHeader('Content-Type'));
-                $that->assertFalse($request->hasHeader('Content-Length'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertFalse($request->hasHeader('Content-Type'));
+                $this->assertFalse($request->hasHeader('Content-Length'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -764,33 +762,32 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array(
+        $customHeaders = [
             'Content-Type' => 'text/html; charset=utf-8',
-            'Content-Length' => '111',
-        );
+            'Content-Length' => '111'
+        ];
 
         $request = new Request('POST', 'http://example.com', $customHeaders);
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $request
-        $redirectResponse = new Response(303, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(303, ['Location' => 'http://example.com/new']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $request
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertEquals('GET', $request->getMethod());
-                $that->assertFalse($request->hasHeader('Content-Type'));
-                $that->assertFalse($request->hasHeader('Content-Length'));
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertEquals('GET', $request->getMethod());
+                $this->assertFalse($request->hasHeader('Content-Type'));
+                $this->assertFalse($request->hasHeader('Content-Length'));
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -801,40 +798,39 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array(
+        $customHeaders = [
             'Content-Type' => 'text/html; charset=utf-8',
-            'Content-Length' => '111',
-        );
+            'Content-Length' => '111'
+        ];
 
         $request = new Request('POST', 'http://example.com', $customHeaders, '{"key":"value"}');
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $request
-        $redirectResponse = new Response(307, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(307, ['Location' => 'http://example.com/new']);
 
         // mock sender to resolve promise with the given $okResponse in
         // response to the given $request
         $okResponse = new Response(200);
-        $that = $this;
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->callback(function (RequestInterface $request) use ($that) {
-                $that->assertEquals('POST', $request->getMethod());
-                $that->assertEquals('{"key":"value"}', (string)$request->getBody());
-                $that->assertEquals(
-                    array(
-                        'Content-Type' => array('text/html; charset=utf-8'),
-                        'Content-Length' => array('111'),
-                        'Host' => array('example.com')
-                    ),
+            [$this->anything()],
+            [$this->callback(function (RequestInterface $request) {
+                $this->assertEquals('POST', $request->getMethod());
+                $this->assertEquals('{"key":"value"}', (string)$request->getBody());
+                $this->assertEquals(
+                    [
+                        'Content-Type' => ['text/html; charset=utf-8'],
+                        'Content-Length' => ['111'],
+                        'Host' => ['example.com']
+                    ],
                     $request->getHeaders()
                 );
                 return true;
-            }))
+            })]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
-            Promise\resolve($okResponse)
+            resolve($redirectResponse),
+            resolve($okResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -845,10 +841,10 @@ class TransactionTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $customHeaders = array(
+        $customHeaders = [
             'Content-Type' => 'text/html; charset=utf-8',
-            'Content-Length' => '111',
-        );
+            'Content-Length' => '111'
+        ];
 
         $stream = new ThroughStream();
         $request = new Request('POST', 'http://example.com', $customHeaders, new ReadableBodyStream($stream));
@@ -856,12 +852,12 @@ class TransactionTest extends TestCase
 
         // mock sender to resolve promise with the given $redirectResponse in
         // response to the given $request
-        $redirectResponse = new Response(307, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(307, ['Location' => 'http://example.com/new']);
 
         $sender->expects($this->once())->method('send')->withConsecutive(
-            array($this->anything())
+            [$this->anything()]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse)
+            resolve($redirectResponse)
         );
 
         $transaction = new Transaction($sender, $loop);
@@ -883,7 +879,7 @@ class TransactionTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $sender = $this->makeSenderMock();
 
-        $pending = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
         $sender->expects($this->once())->method('send')->willReturn($pending);
@@ -904,13 +900,13 @@ class TransactionTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $sender = $this->makeSenderMock();
 
-        $pending = new \React\Promise\Promise(function () { }, function () { throw new \RuntimeException(); });
+        $pending = new Promise(function () { }, function () { throw new \RuntimeException(); });
 
         // mock sender to return pending promise which should be cancelled when cancelling result
         $sender->expects($this->once())->method('send')->willReturn($pending);
 
         $transaction = new Transaction($sender, $loop);
-        $transaction = $transaction->withOptions(array('timeout' => 2));
+        $transaction = $transaction->withOptions(['timeout' => 2]);
         $promise = $transaction->send($request);
 
         $promise->cancel();
@@ -924,16 +920,16 @@ class TransactionTest extends TestCase
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
-        $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(301, ['Location' => 'http://example.com/new']);
 
-        $pending = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->anything())
+            [$this->anything()],
+            [$this->anything()]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
+            resolve($redirectResponse),
             $pending
         );
 
@@ -953,12 +949,12 @@ class TransactionTest extends TestCase
         // mock sender to resolve promise with the given $redirectResponse in
         $first = new Deferred();
 
-        $second = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
+        $second = new Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->anything())
+            [$this->anything()],
+            [$this->anything()]
         )->willReturnOnConsecutiveCalls(
             $first->promise(),
             $second
@@ -968,7 +964,7 @@ class TransactionTest extends TestCase
         $promise = $transaction->send($request);
 
         // mock sender to resolve promise with the given $redirectResponse in
-        $first->resolve(new Response(301, array('Location' => 'http://example.com/new')));
+        $first->resolve(new Response(301, ['Location' => 'http://example.com/new']));
 
         $promise->cancel();
     }
@@ -990,7 +986,7 @@ class TransactionTest extends TestCase
         $transaction = new Transaction($sender, $loop);
         $promise = $transaction->send($request);
 
-        $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'), new ReadableBodyStream($body));
+        $redirectResponse = new Response(301, ['Location' => 'http://example.com/new'], new ReadableBodyStream($body));
         $deferred->resolve($redirectResponse);
 
         $promise->cancel();
@@ -1013,7 +1009,7 @@ class TransactionTest extends TestCase
         $body->on('close', $this->expectCallableOnce());
 
         // mock sender to resolve promise with the given $redirectResponse in
-        $first->resolve(new Response(301, array('Location' => 'http://example.com/new'), new ReadableBodyStream($body)));
+        $first->resolve(new Response(301, ['Location' => 'http://example.com/new'], new ReadableBodyStream($body)));
         $promise->cancel();
     }
 
@@ -1025,16 +1021,16 @@ class TransactionTest extends TestCase
         $sender = $this->makeSenderMock();
 
         // mock sender to resolve promise with the given $redirectResponse in
-        $redirectResponse = new Response(301, array('Location' => 'http://example.com/new'));
+        $redirectResponse = new Response(301, ['Location' => 'http://example.com/new']);
 
-        $pending = new \React\Promise\Promise(function () { }, $this->expectCallableOnce());
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
 
         // mock sender to return pending promise which should be cancelled when cancelling result
         $sender->expects($this->exactly(2))->method('send')->withConsecutive(
-            array($this->anything()),
-            array($this->anything())
+            [$this->anything()],
+            [$this->anything()]
         )->willReturnOnConsecutiveCalls(
-            Promise\resolve($redirectResponse),
+            resolve($redirectResponse),
             $pending
         );
 

--- a/tests/Io/UploadedFileTest.php
+++ b/tests/Io/UploadedFileTest.php
@@ -8,14 +8,12 @@ Use React\Tests\Http\TestCase;
 
 class UploadedFileTest extends TestCase
 {
-    public function failtyErrorProvider()
+    public static function failtyErrorProvider()
     {
-        return [
-            ['a'],
-            [null],
-            [-1],
-            [9]
-        ];
+        yield ['a'];
+        yield [null];
+        yield [-1];
+        yield [9];
     }
 
     /**
@@ -25,7 +23,8 @@ class UploadedFileTest extends TestCase
     {
         $stream = new BufferedBody('');
 
-        $this->setExpectedException('InvalidArgumentException', 'Invalid error code, must be an UPLOAD_ERR_* constant');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid error code, must be an UPLOAD_ERR_* constant');
         new UploadedFile($stream, 0, $error, 'foo.bar', 'foo/bar');
     }
 
@@ -34,7 +33,8 @@ class UploadedFileTest extends TestCase
         $stream = new BufferedBody('');
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_OK, 'foo.bar', 'foo/bar');
 
-        $this->setExpectedException('RuntimeException', 'Not implemented');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not implemented');
         $uploadedFile->moveTo('bar.foo');
     }
 
@@ -54,7 +54,8 @@ class UploadedFileTest extends TestCase
         $stream = new BufferedBody('');
         $uploadedFile = new UploadedFile($stream, 0, UPLOAD_ERR_NO_FILE, 'foo.bar', 'foo/bar');
 
-        $this->setExpectedException('RuntimeException', 'Cannot retrieve stream due to upload error');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot retrieve stream due to upload error');
         $uploadedFile->getStream();
     }
 }

--- a/tests/Io/UploadedFileTest.php
+++ b/tests/Io/UploadedFileTest.php
@@ -10,12 +10,12 @@ class UploadedFileTest extends TestCase
 {
     public function failtyErrorProvider()
     {
-        return array(
-            array('a'),
-            array(null),
-            array(-1),
-            array(9),
-        );
+        return [
+            ['a'],
+            [null],
+            [-1],
+            [9]
+        ];
     }
 
     /**

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -14,7 +14,7 @@ class RequestTest extends TestCase
         $request = new Request(
             'GET',
             'http://localhost',
-            array(),
+            [],
             'foo'
         );
 
@@ -28,7 +28,7 @@ class RequestTest extends TestCase
         $request = new Request(
             'GET',
             'http://localhost',
-            array(),
+            [],
             new ThroughStream()
         );
 
@@ -43,7 +43,7 @@ class RequestTest extends TestCase
         $request = new Request(
             'GET',
             'http://localhost',
-            array(),
+            [],
             $body = new HttpBodyStream(new ThroughStream(), 100)
         );
 
@@ -56,7 +56,7 @@ class RequestTest extends TestCase
         new Request(
             'GET',
             'http://localhost',
-            array(),
+            [],
             null
         );
     }

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -2,8 +2,10 @@
 
 namespace React\Tests\Http\Message;
 
+use Psr\Http\Message\StreamInterface;
 use React\Http\Io\HttpBodyStream;
 use React\Http\Message\Request;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
@@ -33,8 +35,8 @@ class RequestTest extends TestCase
         );
 
         $body = $request->getBody();
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
         $this->assertNull($body->getSize());
     }
 
@@ -52,7 +54,8 @@ class RequestTest extends TestCase
 
     public function testConstructWithNullBodyThrows()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid request body given');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid request body given');
         new Request(
             'GET',
             'http://localhost',

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -11,7 +11,7 @@ class ResponseTest extends TestCase
 {
     public function testConstructWithStringBodyWillReturnStreamInstance()
     {
-        $response = new Response(200, array(), 'hello');
+        $response = new Response(200, [], 'hello');
         $body = $response->getBody();
 
         /** @var \Psr\Http\Message\StreamInterface $body */
@@ -21,7 +21,7 @@ class ResponseTest extends TestCase
 
     public function testConstructWithStreamingBodyWillReturnReadableBodyStream()
     {
-        $response = new Response(200, array(), new ThroughStream());
+        $response = new Response(200, [], new ThroughStream());
         $body = $response->getBody();
 
         /** @var \Psr\Http\Message\StreamInterface $body */
@@ -35,7 +35,7 @@ class ResponseTest extends TestCase
     {
         $response = new Response(
             200,
-            array(),
+            [],
             $body = new HttpBodyStream(new ThroughStream(), 100)
         );
 
@@ -45,13 +45,13 @@ class ResponseTest extends TestCase
     public function testFloatBodyWillThrow()
     {
         $this->setExpectedException('InvalidArgumentException');
-        new Response(200, array(), 1.0);
+        new Response(200, [], 1.0);
     }
 
     public function testResourceBodyWillThrow()
     {
         $this->setExpectedException('InvalidArgumentException');
-        new Response(200, array(), tmpfile());
+        new Response(200, [], tmpfile());
     }
 
     public function testWithStatusReturnsNewInstanceWhenStatusIsChanged()
@@ -99,7 +99,7 @@ class ResponseTest extends TestCase
 
     public function testJsonMethodReturnsPrettyPrintedJsonResponse()
     {
-        $response = Response::json(array('text' => 'Hello wörld!'));
+        $response = Response::json(['text' => 'Hello wörld!']);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
@@ -155,7 +155,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array(), $response->getHeaders());
+        $this->assertEquals([], $response->getHeaders());
     }
 
     public function testParseMessageWithSimpleOkResponse()
@@ -165,7 +165,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithSimpleOkResponseWithCustomReasonPhrase()
@@ -175,7 +175,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Mostly Okay', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithSimpleOkResponseWithEmptyReasonPhraseAppliesDefault()
@@ -185,7 +185,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithSimpleOkResponseWithoutReasonPhraseAndWhitespaceSeparatorAppliesDefault()
@@ -195,7 +195,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithHttp10SimpleOkResponse()
@@ -205,7 +205,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.0', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithHttp10SimpleOkResponseWithLegacyNewlines()
@@ -215,7 +215,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('1.0', $response->getProtocolVersion());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals(array('Server' => array('demo')), $response->getHeaders());
+        $this->assertEquals(['Server' => ['demo']], $response->getHeaders());
     }
 
     public function testParseMessageWithInvalidHttpProtocolVersion12Throws()

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -2,8 +2,10 @@
 
 namespace React\Tests\Http\Message;
 
+use Psr\Http\Message\StreamInterface;
 use React\Http\Io\HttpBodyStream;
 use React\Http\Message\Response;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
@@ -15,7 +17,7 @@ class ResponseTest extends TestCase
         $body = $response->getBody();
 
         /** @var \Psr\Http\Message\StreamInterface $body */
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
         $this->assertEquals('hello', (string) $body);
     }
 
@@ -25,9 +27,9 @@ class ResponseTest extends TestCase
         $body = $response->getBody();
 
         /** @var \Psr\Http\Message\StreamInterface $body */
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
-        $this->assertInstanceof('React\Stream\ReadableStreamInterface', $body);
-        $this->assertInstanceOf('React\Http\Io\HttpBodyStream', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertInstanceof(ReadableStreamInterface::class, $body);
+        $this->assertInstanceOf(HttpBodyStream::class, $body);
         $this->assertNull($body->getSize());
     }
 
@@ -44,13 +46,13 @@ class ResponseTest extends TestCase
 
     public function testFloatBodyWillThrow()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Response(200, [], 1.0);
     }
 
     public function testResourceBodyWillThrow()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Response(200, [], tmpfile());
     }
 
@@ -126,7 +128,8 @@ class ResponseTest extends TestCase
 
     public function testJsonMethodThrowsForInvalidString()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON: Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to encode given data as JSON: Malformed UTF-8 characters, possibly incorrectly encoded');
         Response::json("Hello w\xF6rld!");
     }
 
@@ -220,25 +223,25 @@ class ResponseTest extends TestCase
 
     public function testParseMessageWithInvalidHttpProtocolVersion12Throws()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         Response::parseMessage("HTTP/1.2 200 OK\r\n");
     }
 
     public function testParseMessageWithInvalidHttpProtocolVersion2Throws()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         Response::parseMessage("HTTP/2 200 OK\r\n");
     }
 
     public function testParseMessageWithInvalidStatusCodeUnderflowThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         Response::parseMessage("HTTP/1.1 99 OK\r\n");
     }
 
     public function testParseMessageWithInvalidResponseHeaderFieldThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         Response::parseMessage("HTTP/1.1 200 OK\r\nServer\r\n");
     }
 }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -97,9 +97,6 @@ class ResponseTest extends TestCase
         $this->assertEquals('<!doctype html><body>Hello wörld!</body>', (string) $response->getBody());
     }
 
-    /**
-     * @requires PHP 5.4
-     */
     public function testJsonMethodReturnsPrettyPrintedJsonResponse()
     {
         $response = Response::json(array('text' => 'Hello wörld!'));
@@ -109,9 +106,6 @@ class ResponseTest extends TestCase
         $this->assertEquals("{\n    \"text\": \"Hello wörld!\"\n}\n", (string) $response->getBody());
     }
 
-    /**
-     * @requires PHP 5.6.6
-     */
     public function testJsonMethodReturnsZeroFractionsInJsonResponse()
     {
         $response = Response::json(1.0);
@@ -132,11 +126,7 @@ class ResponseTest extends TestCase
 
     public function testJsonMethodThrowsForInvalidString()
     {
-        if (PHP_VERSION_ID < 50500) {
-            $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON');
-        } else {
-            $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON: Malformed UTF-8 characters, possibly incorrectly encoded');
-        }
+        $this->setExpectedException('InvalidArgumentException', 'Unable to encode given data as JSON: Malformed UTF-8 characters, possibly incorrectly encoded');
         Response::json("Hello w\xF6rld!");
     }
 

--- a/tests/Message/ServerRequestTest.php
+++ b/tests/Message/ServerRequestTest.php
@@ -21,7 +21,7 @@ class ServerRequestTest extends TestCase
 
     public function testGetNoAttributes()
     {
-        $this->assertEquals(array(), $this->request->getAttributes());
+        $this->assertEquals([], $this->request->getAttributes());
     }
 
     public function testWithAttribute()
@@ -29,7 +29,7 @@ class ServerRequestTest extends TestCase
         $request = $this->request->withAttribute('hello', 'world');
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('hello' => 'world'), $request->getAttributes());
+        $this->assertEquals(['hello' => 'world'], $request->getAttributes());
     }
 
     public function testGetAttribute()
@@ -56,61 +56,61 @@ class ServerRequestTest extends TestCase
         $request = $request->withoutAttribute('hello');
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'nice'), $request->getAttributes());
+        $this->assertEquals(['test' => 'nice'], $request->getAttributes());
     }
 
     public function testGetQueryParamsFromConstructorUri()
     {
         $this->request = new ServerRequest('GET', 'http://localhost/?test=world');
 
-        $this->assertEquals(array('test' => 'world'), $this->request->getQueryParams());
+        $this->assertEquals(['test' => 'world'], $this->request->getQueryParams());
     }
 
     public function testWithCookieParams()
     {
-        $request = $this->request->withCookieParams(array('test' => 'world'));
+        $request = $this->request->withCookieParams(['test' => 'world']);
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'world'), $request->getCookieParams());
+        $this->assertEquals(['test' => 'world'], $request->getCookieParams());
     }
 
     public function testGetQueryParamsFromConstructorUriUrlencoded()
     {
         $this->request = new ServerRequest('GET', 'http://localhost/?test=hello+world%21');
 
-        $this->assertEquals(array('test' => 'hello world!'), $this->request->getQueryParams());
+        $this->assertEquals(['test' => 'hello world!'], $this->request->getQueryParams());
     }
 
     public function testWithQueryParams()
     {
-        $request = $this->request->withQueryParams(array('test' => 'world'));
+        $request = $this->request->withQueryParams(['test' => 'world']);
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'world'), $request->getQueryParams());
+        $this->assertEquals(['test' => 'world'], $request->getQueryParams());
     }
 
     public function testWithQueryParamsWithoutSpecialEncoding()
     {
-        $request = $this->request->withQueryParams(array('test' => 'hello world!'));
+        $request = $this->request->withQueryParams(['test' => 'hello world!']);
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'hello world!'), $request->getQueryParams());
+        $this->assertEquals(['test' => 'hello world!'], $request->getQueryParams());
     }
 
     public function testWithUploadedFiles()
     {
-        $request = $this->request->withUploadedFiles(array('test' => 'world'));
+        $request = $this->request->withUploadedFiles(['test' => 'world']);
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'world'), $request->getUploadedFiles());
+        $this->assertEquals(['test' => 'world'], $request->getUploadedFiles());
     }
 
     public function testWithParsedBody()
     {
-        $request = $this->request->withParsedBody(array('test' => 'world'));
+        $request = $this->request->withParsedBody(['test' => 'world']);
 
         $this->assertNotSame($request, $this->request);
-        $this->assertEquals(array('test' => 'world'), $request->getParsedBody());
+        $this->assertEquals(['test' => 'world'], $request->getParsedBody());
     }
 
     public function testServerRequestParameter()
@@ -119,10 +119,10 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://127.0.0.1',
-            array('Content-Length' => strlen($body)),
+            ['Content-Length' => strlen($body)],
             $body,
             '1.0',
-            array('SERVER_ADDR' => '127.0.0.1')
+            ['SERVER_ADDR' => '127.0.0.1']
         );
 
         $serverParams = $request->getServerParams();
@@ -139,11 +139,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world')
+            ['Cookie' => 'hello=world']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world'), $cookies);
+        $this->assertEquals(['hello' => 'world'], $cookies);
     }
 
     public function testParseMultipleCookieNameValuePairWillReturnValidArray()
@@ -151,11 +151,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world; test=abc')
+            ['Cookie' => 'hello=world; test=abc']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world', 'test' => 'abc'), $cookies);
+        $this->assertEquals(['hello' => 'world', 'test' => 'abc'], $cookies);
     }
 
     public function testParseMultipleCookieHeadersAreNotAllowedAndWillReturnEmptyArray()
@@ -163,11 +163,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => array('hello=world', 'test=abc'))
+            ['Cookie' => ['hello=world', 'test=abc']]
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array(), $cookies);
+        $this->assertEquals([], $cookies);
     }
 
     public function testMultipleCookiesWithSameNameWillReturnLastValue()
@@ -175,11 +175,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world; hello=abc')
+            ['Cookie' => 'hello=world; hello=abc']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'abc'), $cookies);
+        $this->assertEquals(['hello' => 'abc'], $cookies);
     }
 
     public function testOtherEqualSignsWillBeAddedToValueAndWillReturnValidArray()
@@ -187,11 +187,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world=test=php')
+            ['Cookie' => 'hello=world=test=php']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world=test=php'), $cookies);
+        $this->assertEquals(['hello' => 'world=test=php'], $cookies);
     }
 
     public function testSingleCookieValueInCookiesReturnsEmptyArray()
@@ -199,11 +199,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'world')
+            ['Cookie' => 'world']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array(), $cookies);
+        $this->assertEquals([], $cookies);
     }
 
     public function testSingleMutlipleCookieValuesReturnsEmptyArray()
@@ -211,11 +211,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'world; test')
+            ['Cookie' => 'world; test']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array(), $cookies);
+        $this->assertEquals([], $cookies);
     }
 
     public function testSingleValueIsValidInMultipleValueCookieWillReturnValidArray()
@@ -223,11 +223,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'world; test=php')
+            ['Cookie' => 'world; test=php']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('test' => 'php'), $cookies);
+        $this->assertEquals(['test' => 'php'], $cookies);
     }
 
     public function testUrlEncodingForValueWillReturnValidArray()
@@ -235,11 +235,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world%21; test=100%25%20coverage')
+            ['Cookie' => 'hello=world%21; test=100%25%20coverage']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world!', 'test' => '100% coverage'), $cookies);
+        $this->assertEquals(['hello' => 'world!', 'test' => '100% coverage'], $cookies);
     }
 
     public function testUrlEncodingForKeyWillReturnValidArray()
@@ -247,11 +247,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'react%3Bphp=is%20great')
+            ['Cookie' => 'react%3Bphp=is%20great']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('react%3Bphp' => 'is great'), $cookies);
+        $this->assertEquals(['react%3Bphp' => 'is great'], $cookies);
     }
 
     public function testCookieWithoutSpaceAfterSeparatorWillBeAccepted()
@@ -259,11 +259,11 @@ class ServerRequestTest extends TestCase
         $this->request = new ServerRequest(
             'GET',
             'http://localhost',
-            array('Cookie' => 'hello=world;react=php')
+            ['Cookie' => 'hello=world;react=php']
         );
 
         $cookies = $this->request->getCookieParams();
-        $this->assertEquals(array('hello' => 'world', 'react' => 'php'), $cookies);
+        $this->assertEquals(['hello' => 'world', 'react' => 'php'], $cookies);
     }
 
     public function testConstructWithStringRequestBodyReturnsStringBodyWithAutomaticSize()
@@ -271,7 +271,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'GET',
             'http://localhost',
-            array(),
+            [],
             'foo'
         );
 
@@ -285,7 +285,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'GET',
             'http://localhost',
-            array(),
+            [],
             $body = new HttpBodyStream(new ThroughStream(), 100)
         );
 
@@ -297,7 +297,7 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'GET',
             'http://localhost',
-            array(),
+            [],
             new ThroughStream()
         );
 
@@ -312,9 +312,9 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'GET',
             'http://localhost',
-            array(
+            [
                 'Content-Length' => 100
-            ),
+            ],
             new ThroughStream()
         );
 
@@ -329,9 +329,9 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest(
             'GET',
             'http://localhost',
-            array(
+            [
                 'Transfer-Encoding' => 'Chunked'
-            ),
+            ],
             new ThroughStream()
         );
 
@@ -347,7 +347,7 @@ class ServerRequestTest extends TestCase
         new ServerRequest(
             'GET',
             'http://localhost',
-            array(),
+            [],
             1.0
         );
     }
@@ -358,14 +358,14 @@ class ServerRequestTest extends TestCase
         new ServerRequest(
             'GET',
             'http://localhost',
-            array(),
+            [],
             tmpfile()
         );
     }
 
     public function testParseMessageWithSimpleGetRequest()
     {
-        $request = ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: example.com\r\n", array());
+        $request = ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: example.com\r\n", []);
 
         $this->assertEquals('GET', $request->getMethod());
         $this->assertEquals('http://example.com/', (string) $request->getUri());
@@ -374,7 +374,7 @@ class ServerRequestTest extends TestCase
 
     public function testParseMessageWithHttp10RequestWithoutHost()
     {
-        $request = ServerRequest::parseMessage("GET / HTTP/1.0\r\n", array());
+        $request = ServerRequest::parseMessage("GET / HTTP/1.0\r\n", []);
 
         $this->assertEquals('GET', $request->getMethod());
         $this->assertEquals('http://127.0.0.1/', (string) $request->getUri());
@@ -383,7 +383,7 @@ class ServerRequestTest extends TestCase
 
     public function testParseMessageWithOptionsMethodWithAsteriskFormRequestTarget()
     {
-        $request = ServerRequest::parseMessage("OPTIONS * HTTP/1.1\r\nHost: example.com\r\n", array());
+        $request = ServerRequest::parseMessage("OPTIONS * HTTP/1.1\r\nHost: example.com\r\n", []);
 
         $this->assertEquals('OPTIONS', $request->getMethod());
         $this->assertEquals('*', $request->getRequestTarget());
@@ -393,7 +393,7 @@ class ServerRequestTest extends TestCase
 
     public function testParseMessageWithConnectMethodWithAuthorityFormRequestTarget()
     {
-        $request = ServerRequest::parseMessage("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n", array());
+        $request = ServerRequest::parseMessage("CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n", []);
 
         $this->assertEquals('CONNECT', $request->getMethod());
         $this->assertEquals('example.com:80', $request->getRequestTarget());
@@ -404,84 +404,84 @@ class ServerRequestTest extends TestCase
     public function testParseMessageWithInvalidHttp11RequestWithoutHostThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\n", []);
     }
 
     public function testParseMessageWithInvalidHttpProtocolVersionThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.2\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.2\r\n", []);
     }
 
     public function testParseMessageWithInvalidProtocolThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / CUSTOM/1.1\r\n", array());
+        ServerRequest::parseMessage("GET / CUSTOM/1.1\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithoutValueThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderSyntaxThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: ///\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: ///\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithSchemeThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: http://localhost\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: http://localhost\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithQueryThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost?foo\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost?foo\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithFragmentThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost#foo\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost#foo\r\n", []);
     }
 
     public function testParseMessageWithInvalidContentLengthHeaderThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length:\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length:\r\n", []);
     }
 
     public function testParseMessageWithInvalidTransferEncodingHeaderThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding:\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding:\r\n", []);
     }
 
     public function testParseMessageWithInvalidBothContentLengthHeaderAndTransferEncodingHeaderThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n", array());
+        ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n", []);
     }
 
     public function testParseMessageWithInvalidEmptyHostHeaderWithAbsoluteFormRequestTargetThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET http://example.com/ HTTP/1.1\r\nHost: \r\n", array());
+        ServerRequest::parseMessage("GET http://example.com/ HTTP/1.1\r\nHost: \r\n", []);
     }
 
     public function testParseMessageWithInvalidConnectMethodNotUsingAuthorityFormThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("CONNECT / HTTP/1.1\r\nHost: localhost\r\n", array());
+        ServerRequest::parseMessage("CONNECT / HTTP/1.1\r\nHost: localhost\r\n", []);
     }
 
     public function testParseMessageWithInvalidRequestTargetAsteriskFormThrows()
     {
         $this->setExpectedException('InvalidArgumentException');
-        ServerRequest::parseMessage("GET * HTTP/1.1\r\nHost: localhost\r\n", array());
+        ServerRequest::parseMessage("GET * HTTP/1.1\r\nHost: localhost\r\n", []);
     }
 }

--- a/tests/Message/ServerRequestTest.php
+++ b/tests/Message/ServerRequestTest.php
@@ -2,8 +2,10 @@
 
 namespace React\Tests\Http\Message;
 
+use Psr\Http\Message\StreamInterface;
 use React\Http\Io\HttpBodyStream;
 use React\Http\Message\ServerRequest;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
@@ -302,8 +304,8 @@ class ServerRequestTest extends TestCase
         );
 
         $body = $request->getBody();
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
         $this->assertSame(0, $body->getSize());
     }
 
@@ -319,8 +321,8 @@ class ServerRequestTest extends TestCase
         );
 
         $body = $request->getBody();
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
         $this->assertSame(100, $body->getSize());
     }
 
@@ -336,14 +338,14 @@ class ServerRequestTest extends TestCase
         );
 
         $body = $request->getBody();
-        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
         $this->assertNull($body->getSize());
     }
 
     public function testConstructWithFloatRequestBodyThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new ServerRequest(
             'GET',
             'http://localhost',
@@ -354,7 +356,7 @@ class ServerRequestTest extends TestCase
 
     public function testConstructWithResourceRequestBodyThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new ServerRequest(
             'GET',
             'http://localhost',
@@ -403,85 +405,85 @@ class ServerRequestTest extends TestCase
 
     public function testParseMessageWithInvalidHttp11RequestWithoutHostThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\n", []);
     }
 
     public function testParseMessageWithInvalidHttpProtocolVersionThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.2\r\n", []);
     }
 
     public function testParseMessageWithInvalidProtocolThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / CUSTOM/1.1\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithoutValueThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderSyntaxThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: ///\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithSchemeThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: http://localhost\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithQueryThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost?foo\r\n", []);
     }
 
     public function testParseMessageWithInvalidHostHeaderWithFragmentThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost#foo\r\n", []);
     }
 
     public function testParseMessageWithInvalidContentLengthHeaderThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length:\r\n", []);
     }
 
     public function testParseMessageWithInvalidTransferEncodingHeaderThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding:\r\n", []);
     }
 
     public function testParseMessageWithInvalidBothContentLengthHeaderAndTransferEncodingHeaderThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n", []);
     }
 
     public function testParseMessageWithInvalidEmptyHostHeaderWithAbsoluteFormRequestTargetThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET http://example.com/ HTTP/1.1\r\nHost: \r\n", []);
     }
 
     public function testParseMessageWithInvalidConnectMethodNotUsingAuthorityFormThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("CONNECT / HTTP/1.1\r\nHost: localhost\r\n", []);
     }
 
     public function testParseMessageWithInvalidRequestTargetAsteriskFormThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         ServerRequest::parseMessage("GET * HTTP/1.1\r\nHost: localhost\r\n", []);
     }
 }

--- a/tests/Message/UriTest.php
+++ b/tests/Message/UriTest.php
@@ -33,95 +33,95 @@ class UriTest extends TestCase
 
     public static function provideValidUris()
     {
-        return array(
-            array(
+        return [
+            [
                 'http://localhost'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://127.0.0.1/'
-            ),
-            array(
+            ],
+            [
                 'http://[::1]:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/sub/path'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/with%20space'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/with%2fslash'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name=Alice'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name=John+Doe'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name=John%20Doe'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name=Alice&age=42'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name=Alice&'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?choice=A%26B'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?safe=Yes!?'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?alias=@home'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?assign:=true'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name='
-            ),
-            array(
+            ],
+            [
                 'http://localhost/?name'
-            ),
-            array(
+            ],
+            [
                 ''
-            ),
-            array(
+            ],
+            [
                 '/'
-            ),
-            array(
+            ],
+            [
                 '/path'
-            ),
-            array(
+            ],
+            [
                 'path'
-            ),
-            array(
+            ],
+            [
                 'http://user@localhost/'
-            ),
-            array(
+            ],
+            [
                 'http://user:@localhost/'
-            ),
-            array(
+            ],
+            [
                 'http://:pass@localhost/'
-            ),
-            array(
+            ],
+            [
                 'http://user:pass@localhost/path?query#fragment'
-            ),
-            array(
+            ],
+            [
                 'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -137,36 +137,36 @@ class UriTest extends TestCase
 
     public static function provideValidUrisThatWillBeTransformed()
     {
-        return array(
-            array(
+        return [
+            [
                 'http://localhost:8080/?',
                 'http://localhost:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost:8080/#',
                 'http://localhost:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost:8080/?#',
                 'http://localhost:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://@localhost:8080/',
                 'http://localhost:8080/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost:8080/?percent=50%',
                 'http://localhost:8080/?percent=50%25'
-            ),
-            array(
+            ],
+            [
                 'http://user name:pass word@localhost/path name?query name#frag ment',
                 'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
-            ),
-            array(
+            ],
+            [
                 'HTTP://USER:PASS@LOCALHOST:8080/PATH?QUERY#FRAGMENT',
                 'http://USER:PASS@localhost:8080/PATH?QUERY#FRAGMENT'
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -576,113 +576,113 @@ class UriTest extends TestCase
 
     public static function provideResolveUris()
     {
-        return array(
-            array(
+        return [
+            [
                 'http://localhost/',
                 '',
                 'http://localhost/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/',
                 'http://example.com/',
                 'http://example.com/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/',
                 'path',
                 'http://localhost/path'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/',
                 'path/',
                 'http://localhost/path/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/',
                 'path//',
                 'http://localhost/path/'
-            ),
-            array(
+            ],
+            [
                 'http://localhost',
                 'path',
                 'http://localhost/path'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/a/b',
                 '/path',
                 'http://localhost/path'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/',
                 '/a/b/c',
                 'http://localhost/a/b/c'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/a/path',
                 'b/c',
                 'http://localhost/a/b/c'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/a/path',
                 '/b/c',
                 'http://localhost/b/c'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/a/path/',
                 'b/c',
                 'http://localhost/a/path/b/c'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/a/path/',
                 '../b/c',
                 'http://localhost/a/b/c'
-            ),
-            array(
+            ],
+            [
                 'http://localhost',
                 '../../../a/b',
                 'http://localhost/a/b'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 '?query',
                 'http://localhost/path?query'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 '#fragment',
                 'http://localhost/path#fragment'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 'http://localhost',
                 'http://localhost'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 'http://localhost/?query#fragment',
                 'http://localhost/?query#fragment'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path/?a#fragment',
                 '?b',
                 'http://localhost/path/?b'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 '//localhost',
                 'http://localhost'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 '//localhost/a?query',
                 'http://localhost/a?query'
-            ),
-            array(
+            ],
+            [
                 'http://localhost/path',
                 '//LOCALHOST',
                 'http://localhost'
-            )
-        );
+            ]
+        ];
     }
 
     /**

--- a/tests/Message/UriTest.php
+++ b/tests/Message/UriTest.php
@@ -130,11 +130,6 @@ class UriTest extends TestCase
      */
     public function testToStringReturnsOriginalUriGivenToCtor($string)
     {
-        if (PHP_VERSION_ID < 50519 || (PHP_VERSION_ID < 50603 && PHP_VERSION_ID >= 50606)) {
-            // @link https://3v4l.org/HdoPG
-            $this->markTestSkipped('Empty password not supported on legacy PHP');
-        }
-
         $uri = new Uri($string);
 
         $this->assertEquals($string, (string) $uri);

--- a/tests/Message/UriTest.php
+++ b/tests/Message/UriTest.php
@@ -9,118 +9,116 @@ class UriTest extends TestCase
 {
     public function testCtorWithInvalidSyntaxThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Uri('///');
     }
 
     public function testCtorWithInvalidSchemeThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Uri('not+a+scheme://localhost');
     }
 
     public function testCtorWithInvalidHostThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Uri('http://not a host/');
     }
 
     public function testCtorWithInvalidPortThrows()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new Uri('http://localhost:80000/');
     }
 
     public static function provideValidUris()
     {
-        return [
-            [
-                'http://localhost'
-            ],
-            [
-                'http://localhost/'
-            ],
-            [
-                'http://localhost:8080/'
-            ],
-            [
-                'http://127.0.0.1/'
-            ],
-            [
-                'http://[::1]:8080/'
-            ],
-            [
-                'http://localhost/path'
-            ],
-            [
-                'http://localhost/sub/path'
-            ],
-            [
-                'http://localhost/with%20space'
-            ],
-            [
-                'http://localhost/with%2fslash'
-            ],
-            [
-                'http://localhost/?name=Alice'
-            ],
-            [
-                'http://localhost/?name=John+Doe'
-            ],
-            [
-                'http://localhost/?name=John%20Doe'
-            ],
-            [
-                'http://localhost/?name=Alice&age=42'
-            ],
-            [
-                'http://localhost/?name=Alice&'
-            ],
-            [
-                'http://localhost/?choice=A%26B'
-            ],
-            [
-                'http://localhost/?safe=Yes!?'
-            ],
-            [
-                'http://localhost/?alias=@home'
-            ],
-            [
-                'http://localhost/?assign:=true'
-            ],
-            [
-                'http://localhost/?name='
-            ],
-            [
-                'http://localhost/?name'
-            ],
-            [
-                ''
-            ],
-            [
-                '/'
-            ],
-            [
-                '/path'
-            ],
-            [
-                'path'
-            ],
-            [
-                'http://user@localhost/'
-            ],
-            [
-                'http://user:@localhost/'
-            ],
-            [
-                'http://:pass@localhost/'
-            ],
-            [
-                'http://user:pass@localhost/path?query#fragment'
-            ],
-            [
-                'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
-            ]
+        yield [
+            'http://localhost'
+        ];
+        yield [
+            'http://localhost/'
+        ];
+        yield [
+            'http://localhost:8080/'
+        ];
+        yield [
+            'http://127.0.0.1/'
+        ];
+        yield [
+            'http://[::1]:8080/'
+        ];
+        yield [
+            'http://localhost/path'
+        ];
+        yield [
+            'http://localhost/sub/path'
+        ];
+        yield [
+            'http://localhost/with%20space'
+        ];
+        yield [
+            'http://localhost/with%2fslash'
+        ];
+        yield [
+            'http://localhost/?name=Alice'
+        ];
+        yield [
+            'http://localhost/?name=John+Doe'
+        ];
+        yield [
+            'http://localhost/?name=John%20Doe'
+        ];
+        yield [
+            'http://localhost/?name=Alice&age=42'
+        ];
+        yield [
+            'http://localhost/?name=Alice&'
+        ];
+        yield [
+            'http://localhost/?choice=A%26B'
+        ];
+        yield [
+            'http://localhost/?safe=Yes!?'
+        ];
+        yield [
+            'http://localhost/?alias=@home'
+        ];
+        yield [
+            'http://localhost/?assign:=true'
+        ];
+        yield [
+            'http://localhost/?name='
+        ];
+        yield [
+            'http://localhost/?name'
+        ];
+        yield [
+            ''
+        ];
+        yield [
+            '/'
+        ];
+        yield [
+            '/path'
+        ];
+        yield [
+            'path'
+        ];
+        yield [
+            'http://user@localhost/'
+        ];
+        yield [
+            'http://user:@localhost/'
+        ];
+        yield [
+            'http://:pass@localhost/'
+        ];
+        yield [
+            'http://user:pass@localhost/path?query#fragment'
+        ];
+        yield [
+            'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
         ];
     }
 
@@ -137,35 +135,33 @@ class UriTest extends TestCase
 
     public static function provideValidUrisThatWillBeTransformed()
     {
-        return [
-            [
-                'http://localhost:8080/?',
-                'http://localhost:8080/'
-            ],
-            [
-                'http://localhost:8080/#',
-                'http://localhost:8080/'
-            ],
-            [
-                'http://localhost:8080/?#',
-                'http://localhost:8080/'
-            ],
-            [
-                'http://@localhost:8080/',
-                'http://localhost:8080/'
-            ],
-            [
-                'http://localhost:8080/?percent=50%',
-                'http://localhost:8080/?percent=50%25'
-            ],
-            [
-                'http://user name:pass word@localhost/path name?query name#frag ment',
-                'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
-            ],
-            [
-                'HTTP://USER:PASS@LOCALHOST:8080/PATH?QUERY#FRAGMENT',
-                'http://USER:PASS@localhost:8080/PATH?QUERY#FRAGMENT'
-            ]
+        yield [
+            'http://localhost:8080/?',
+            'http://localhost:8080/'
+        ];
+        yield [
+            'http://localhost:8080/#',
+            'http://localhost:8080/'
+        ];
+        yield [
+            'http://localhost:8080/?#',
+            'http://localhost:8080/'
+        ];
+        yield [
+            'http://@localhost:8080/',
+            'http://localhost:8080/'
+        ];
+        yield [
+            'http://localhost:8080/?percent=50%',
+            'http://localhost:8080/?percent=50%25'
+        ];
+        yield [
+            'http://user name:pass word@localhost/path name?query name#frag ment',
+            'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
+        ];
+        yield [
+            'HTTP://USER:PASS@LOCALHOST:8080/PATH?QUERY#FRAGMENT',
+            'http://USER:PASS@localhost:8080/PATH?QUERY#FRAGMENT'
         ];
     }
 
@@ -251,7 +247,7 @@ class UriTest extends TestCase
     {
         $uri = new Uri('http://localhost');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $uri->withScheme('invalid+scheme');
     }
 
@@ -375,7 +371,7 @@ class UriTest extends TestCase
     {
         $uri = new Uri('http://localhost');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $uri->withHost('invalid+host');
     }
 
@@ -383,7 +379,7 @@ class UriTest extends TestCase
     {
         $uri = new Uri('http://localhost');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $uri->withHost('invalid host');
     }
 
@@ -448,7 +444,7 @@ class UriTest extends TestCase
     {
         $uri = new Uri('http://localhost');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $uri->withPort(0);
     }
 
@@ -456,7 +452,7 @@ class UriTest extends TestCase
     {
         $uri = new Uri('http://localhost');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $uri->withPort(65536);
     }
 
@@ -576,112 +572,110 @@ class UriTest extends TestCase
 
     public static function provideResolveUris()
     {
-        return [
-            [
-                'http://localhost/',
-                '',
-                'http://localhost/'
-            ],
-            [
-                'http://localhost/',
-                'http://example.com/',
-                'http://example.com/'
-            ],
-            [
-                'http://localhost/',
-                'path',
-                'http://localhost/path'
-            ],
-            [
-                'http://localhost/',
-                'path/',
-                'http://localhost/path/'
-            ],
-            [
-                'http://localhost/',
-                'path//',
-                'http://localhost/path/'
-            ],
-            [
-                'http://localhost',
-                'path',
-                'http://localhost/path'
-            ],
-            [
-                'http://localhost/a/b',
-                '/path',
-                'http://localhost/path'
-            ],
-            [
-                'http://localhost/',
-                '/a/b/c',
-                'http://localhost/a/b/c'
-            ],
-            [
-                'http://localhost/a/path',
-                'b/c',
-                'http://localhost/a/b/c'
-            ],
-            [
-                'http://localhost/a/path',
-                '/b/c',
-                'http://localhost/b/c'
-            ],
-            [
-                'http://localhost/a/path/',
-                'b/c',
-                'http://localhost/a/path/b/c'
-            ],
-            [
-                'http://localhost/a/path/',
-                '../b/c',
-                'http://localhost/a/b/c'
-            ],
-            [
-                'http://localhost',
-                '../../../a/b',
-                'http://localhost/a/b'
-            ],
-            [
-                'http://localhost/path',
-                '?query',
-                'http://localhost/path?query'
-            ],
-            [
-                'http://localhost/path',
-                '#fragment',
-                'http://localhost/path#fragment'
-            ],
-            [
-                'http://localhost/path',
-                'http://localhost',
-                'http://localhost'
-            ],
-            [
-                'http://localhost/path',
-                'http://localhost/?query#fragment',
-                'http://localhost/?query#fragment'
-            ],
-            [
-                'http://localhost/path/?a#fragment',
-                '?b',
-                'http://localhost/path/?b'
-            ],
-            [
-                'http://localhost/path',
-                '//localhost',
-                'http://localhost'
-            ],
-            [
-                'http://localhost/path',
-                '//localhost/a?query',
-                'http://localhost/a?query'
-            ],
-            [
-                'http://localhost/path',
-                '//LOCALHOST',
-                'http://localhost'
-            ]
+        yield [
+            'http://localhost/',
+            '',
+            'http://localhost/'
+        ];
+        yield [
+            'http://localhost/',
+            'http://example.com/',
+            'http://example.com/'
+        ];
+        yield [
+            'http://localhost/',
+            'path',
+            'http://localhost/path'
+        ];
+        yield [
+            'http://localhost/',
+            'path/',
+            'http://localhost/path/'
+        ];
+        yield [
+            'http://localhost/',
+            'path//',
+            'http://localhost/path/'
+        ];
+        yield [
+            'http://localhost',
+            'path',
+            'http://localhost/path'
+        ];
+        yield [
+            'http://localhost/a/b',
+            '/path',
+            'http://localhost/path'
+        ];
+        yield [
+            'http://localhost/',
+            '/a/b/c',
+            'http://localhost/a/b/c'
+        ];
+        yield [
+            'http://localhost/a/path',
+            'b/c',
+            'http://localhost/a/b/c'
+        ];
+        yield [
+            'http://localhost/a/path',
+            '/b/c',
+            'http://localhost/b/c'
+        ];
+        yield [
+            'http://localhost/a/path/',
+            'b/c',
+            'http://localhost/a/path/b/c'
+        ];
+        yield [
+            'http://localhost/a/path/',
+            '../b/c',
+            'http://localhost/a/b/c'
+        ];
+        yield [
+            'http://localhost',
+            '../../../a/b',
+            'http://localhost/a/b'
+        ];
+        yield [
+            'http://localhost/path',
+            '?query',
+            'http://localhost/path?query'
+        ];
+        yield [
+            'http://localhost/path',
+            '#fragment',
+            'http://localhost/path#fragment'
+        ];
+        yield [
+            'http://localhost/path',
+            'http://localhost',
+            'http://localhost'
+        ];
+        yield [
+            'http://localhost/path',
+            'http://localhost/?query#fragment',
+            'http://localhost/?query#fragment'
+        ];
+        yield [
+            'http://localhost/path/?a#fragment',
+            '?b',
+            'http://localhost/path/?b'
+        ];
+        yield [
+            'http://localhost/path',
+            '//localhost',
+            'http://localhost'
+        ];
+        yield [
+            'http://localhost/path',
+            '//localhost/a?query',
+            'http://localhost/a?query'
+        ];
+        yield [
+            'http://localhost/path',
+            '//LOCALHOST',
+            'http://localhost'
         ];
     }
 

--- a/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+++ b/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
@@ -163,7 +163,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $body->expects($this->never())->method('pause');
         $body->expects($this->never())->method('resume');
         $limitHandlers = new LimitConcurrentRequestsMiddleware(1);
-        $limitHandlers(new ServerRequest('GET', 'https://example.com/', array(), $body), function () {});
+        $limitHandlers(new ServerRequest('GET', 'https://example.com/', [], $body), function () {});
     }
 
     public function testStreamDoesPauseWhenAboveLimit()
@@ -177,7 +177,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
             return new Promise(function () { });
         });
 
-        $limitHandlers(new ServerRequest('GET', 'https://example.com/', array(), $body), function () {});
+        $limitHandlers(new ServerRequest('GET', 'https://example.com/', [], $body), function () {});
     }
 
     public function testStreamDoesPauseAndThenResumeWhenDequeued()
@@ -195,7 +195,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         assert($promise instanceof PromiseInterface);
         $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
 
-        $limitHandlers(new ServerRequest('GET', 'https://example.com/', array(), $body), function () {});
+        $limitHandlers(new ServerRequest('GET', 'https://example.com/', [], $body), function () {});
 
         $deferred->reject(new \RuntimeException());
     }
@@ -205,7 +205,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -224,7 +224,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 5)
         );
 
@@ -246,7 +246,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -261,7 +261,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -280,7 +280,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -303,7 +303,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -331,7 +331,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -354,7 +354,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -376,7 +376,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -400,7 +400,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -422,7 +422,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             'hello'
             );
 
@@ -445,7 +445,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 5)
         );
 
@@ -494,7 +494,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 10)
         );
 
@@ -524,7 +524,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 10)
         );
 
@@ -555,7 +555,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 10)
         );
 
@@ -586,7 +586,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'http://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 10)
         );
 

--- a/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+++ b/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
@@ -120,9 +120,6 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         });
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testThrowsErrorDirectlyFromMiddlewareWhenBelowLimit()
     {
         $middleware = new LimitConcurrentRequestsMiddleware(1);

--- a/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
+++ b/tests/Middleware/LimitConcurrentRequestsMiddlewareTest.php
@@ -10,6 +10,7 @@ use React\Http\Middleware\LimitConcurrentRequestsMiddleware;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
 
@@ -114,7 +115,8 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
     {
         $middleware = new LimitConcurrentRequestsMiddleware(1);
 
-        $this->setExpectedException('RuntimeException', 'demo');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('demo');
         $middleware(new ServerRequest('GET', 'https://example.com/'), function () {
             throw new \RuntimeException('demo');
         });
@@ -124,7 +126,8 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
     {
         $middleware = new LimitConcurrentRequestsMiddleware(1);
 
-        $this->setExpectedException('Error', 'demo');
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('demo');
         $middleware(new ServerRequest('GET', 'https://example.com/'), function () {
             throw new \Error('demo');
         });
@@ -159,7 +162,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
 
     public function testStreamDoesNotPauseOrResumeWhenBelowLimit()
     {
-        $body = $this->getMockBuilder('React\Http\Io\HttpBodyStream')->disableOriginalConstructor()->getMock();
+        $body = $this->createMock(HttpBodyStream::class);
         $body->expects($this->never())->method('pause');
         $body->expects($this->never())->method('resume');
         $limitHandlers = new LimitConcurrentRequestsMiddleware(1);
@@ -168,7 +171,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
 
     public function testStreamDoesPauseWhenAboveLimit()
     {
-        $body = $this->getMockBuilder('React\Http\Io\HttpBodyStream')->disableOriginalConstructor()->getMock();
+        $body = $this->createMock(HttpBodyStream::class);
         $body->expects($this->once())->method('pause');
         $body->expects($this->never())->method('resume');
         $limitHandlers = new LimitConcurrentRequestsMiddleware(1);
@@ -182,7 +185,7 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
 
     public function testStreamDoesPauseAndThenResumeWhenDequeued()
     {
-        $body = $this->getMockBuilder('React\Http\Io\HttpBodyStream')->disableOriginalConstructor()->getMock();
+        $body = $this->createMock(HttpBodyStream::class);
         $body->expects($this->once())->method('pause');
         $body->expects($this->once())->method('resume');
         $limitHandlers = new LimitConcurrentRequestsMiddleware(1);
@@ -467,11 +470,11 @@ final class LimitConcurrentRequestsMiddlewareTest extends TestCase
         $deferred->reject(new \RuntimeException());
 
         $this->assertNotSame($request, $req);
-        $this->assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $req);
+        $this->assertInstanceOf(ServerRequestInterface::class, $req);
 
         $body = $req->getBody();
-        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
-        /* @var $body \React\Stream\ReadableStreamInterface */
+        $this->assertInstanceOf(ReadableStreamInterface::class, $body);
+        /* @var $body ReadableStreamInterface */
 
         $this->assertEquals(5, $body->getSize());
 

--- a/tests/Middleware/ProcessStack.php
+++ b/tests/Middleware/ProcessStack.php
@@ -3,7 +3,7 @@
 namespace React\Tests\Http\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
-use React\Promise;
+use function React\Promise\resolve;
 
 final class ProcessStack
 {
@@ -15,7 +15,7 @@ final class ProcessStack
     public function __invoke(ServerRequestInterface $request, $stack)
     {
         $this->callCount++;
-        return Promise\resolve($stack($request));
+        return resolve($stack($request));
     }
 
     /**

--- a/tests/Middleware/RequestBodyBufferMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyBufferMiddlewareTest.php
@@ -272,7 +272,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $this->assertFalse($stream->isWritable());
 
         assert($exception instanceof \RuntimeException);
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('Buffered 3', $exception->getMessage());
         $this->assertEquals(42, $exception->getCode());
         $this->assertNull($exception->getPrevious());
@@ -307,7 +307,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $this->assertFalse($stream->isWritable());
 
         assert($exception instanceof \Error);
-        $this->assertInstanceOf('Error', $exception);
+        $this->assertInstanceOf(\Error::class, $exception);
         $this->assertEquals('Buffered 3', $exception->getMessage());
         $this->assertEquals(42, $exception->getCode());
         $this->assertNull($exception->getPrevious());
@@ -342,10 +342,10 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $this->assertFalse($stream->isWritable());
 
         assert($exception instanceof \RuntimeException);
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('Error while buffering request body: Unexpected Foo', $exception->getMessage());
         $this->assertEquals(42, $exception->getCode());
-        $this->assertInstanceOf('UnexpectedValueException', $exception->getPrevious());
+        $this->assertInstanceOf(\UnexpectedValueException::class, $exception->getPrevious());
     }
 
     public function testFullBodyStreamedBeforeCallingNextMiddleware()
@@ -399,7 +399,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         });
 
         assert($exception instanceof \RuntimeException);
-        $this->assertInstanceOf('RuntimeException', $exception);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
         $this->assertEquals('Cancelled buffering request body', $exception->getMessage());
         $this->assertEquals(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());

--- a/tests/Middleware/RequestBodyBufferMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyBufferMiddlewareTest.php
@@ -11,6 +11,7 @@ use React\Http\Message\ServerRequest;
 use React\Http\Middleware\RequestBodyBufferMiddleware;
 use React\Stream\ThroughStream;
 use React\Tests\Http\TestCase;
+use function React\Async\await;
 
 final class RequestBodyBufferMiddlewareTest extends TestCase
 {
@@ -20,7 +21,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 11)
         );
 
@@ -49,7 +50,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             $stream
         );
 
@@ -72,7 +73,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             $body = new HttpBodyStream($stream, 0)
         );
 
@@ -95,7 +96,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             ''
         );
         $body = $serverRequest->getBody();
@@ -122,7 +123,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 2)
         );
 
@@ -145,7 +146,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 2)
         );
 
@@ -154,13 +155,13 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $promise = $buffer(
             $serverRequest,
             function (ServerRequestInterface $request) {
-                return new Response(200, array(), $request->getBody()->getContents());
+                return new Response(200, [], $request->getBody()->getContents());
             }
         );
 
         $stream->end('aa');
 
-        $response = \React\Async\await($promise);
+        $response = await($promise);
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('', $response->getBody()->getContents());
@@ -175,15 +176,15 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 2048)
         );
 
         $buffer = new RequestBodyBufferMiddleware('1K');
-        $response = \React\Async\await($buffer(
+        $response = await($buffer(
             $serverRequest,
             function (ServerRequestInterface $request) {
-                return new Response(200, array(), $request->getBody()->getContents());
+                return new Response(200, [], $request->getBody()->getContents());
             }
         ));
 
@@ -196,7 +197,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             'hello'
         );
 
@@ -219,7 +220,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, null)
         );
 
@@ -227,13 +228,13 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $promise = $buffer(
             $serverRequest,
             function (ServerRequestInterface $request) {
-                return new Response(200, array(), $request->getBody()->getContents());
+                return new Response(200, [], $request->getBody()->getContents());
             }
         );
 
         $stream->end('aa');
 
-        $exposedResponse = \React\Async\await($promise->then(
+        $exposedResponse = await($promise->then(
             null,
             $this->expectCallableNever()
         ));
@@ -249,7 +250,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, null)
         );
 
@@ -284,7 +285,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, null)
         );
 
@@ -321,7 +322,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, null)
         );
 
@@ -355,7 +356,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, null)
         );
 
@@ -381,7 +382,7 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $serverRequest = new ServerRequest(
             'GET',
             'https://example.com/',
-            array(),
+            [],
             new HttpBodyStream($stream, 2)
         );
 

--- a/tests/Middleware/RequestBodyBufferMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyBufferMiddlewareTest.php
@@ -277,9 +277,6 @@ final class RequestBodyBufferMiddlewareTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testBufferingRejectsWhenNextHandlerThrowsErrorWhenStreamEnds()
     {
         $stream = new ThroughStream();

--- a/tests/Middleware/RequestBodyParserMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyParserMiddlewareTest.php
@@ -15,9 +15,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ),
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded'
+            ],
             'hello=world'
         );
 
@@ -30,7 +30,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
 
         $this->assertSame(
-            array('hello' => 'world'),
+            ['hello' => 'world'],
             $parsedRequest->getParsedBody()
         );
         $this->assertSame('hello=world', (string)$parsedRequest->getBody());
@@ -42,9 +42,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'CONTENT-TYPE' => 'APPLICATION/X-WWW-Form-URLEncoded',
-            ),
+            [
+                'CONTENT-TYPE' => 'APPLICATION/X-WWW-Form-URLEncoded'
+            ],
             'Hello=World'
         );
 
@@ -57,7 +57,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
 
         $this->assertSame(
-            array('Hello' => 'World'),
+            ['Hello' => 'World'],
             $parsedRequest->getParsedBody()
         );
         $this->assertSame('Hello=World', (string)$parsedRequest->getBody());
@@ -69,9 +69,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ),
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded'
+            ],
             'foo=bar&baz[]=cheese&bar[]=beer&bar[]=wine&market[fish]=salmon&market[meat][]=beef&market[meat][]=chicken&market[]=bazaar'
         );
 
@@ -84,24 +84,24 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
 
         $this->assertSame(
-            array(
+            [
                 'foo' => 'bar',
-                'baz' => array(
+                'baz' => [
                     'cheese',
-                ),
-                'bar' => array(
+                ],
+                'bar' => [
                     'beer',
                     'wine',
-                ),
-                'market' => array(
+                ],
+                'market' => [
                     'fish' => 'salmon',
-                    'meat' => array(
+                    'meat' => [
                         'beef',
                         'chicken',
-                    ),
+                    ],
                     0 => 'bazaar',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
         $this->assertSame('foo=bar&baz[]=cheese&bar[]=beer&bar[]=wine&market[fish]=salmon&market[meat][]=beef&market[meat][]=chicken&market[]=bazaar', (string)$parsedRequest->getBody());
@@ -115,9 +115,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ),
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded'
+            ],
             'hello' . str_repeat('[]', $allowed + 1) . '=world'
         );
 
@@ -130,7 +130,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
 
         $this->assertSame(
-            array(),
+            [],
             $parsedRequest->getParsedBody()
         );
     }
@@ -143,9 +143,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ),
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded'
+            ],
             str_repeat('a[]=b&', $allowed + 1)
         );
 
@@ -170,9 +170,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $request = new ServerRequest(
             'POST',
             'https://example.com/',
-            array(
-                'Content-Type' => 'application/json',
-            ),
+            [
+                'Content-Type' => 'application/json'
+            ],
             '{"hello":"world"}'
         );
 
@@ -204,9 +204,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $data .= "second\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        $request = new ServerRequest('POST', 'http://example.com/', [
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary
+        ], $data, 1.1);
 
         /** @var ServerRequestInterface $parsedRequest */
         $parsedRequest = $middleware(
@@ -217,12 +217,12 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         );
 
         $this->assertSame(
-            array(
-                'users' => array(
+            [
+                'users' => [
                     'one' => 'single',
                     'two' => 'second',
-                ),
-            ),
+                ],
+            ],
             $parsedRequest->getParsedBody()
         );
         $this->assertSame($data, (string)$parsedRequest->getBody());
@@ -242,9 +242,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         $data .= "world\r\n";
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        $request = new ServerRequest('POST', 'http://example.com/', [
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary
+        ], $data, 1.1);
 
         /** @var ServerRequestInterface $parsedRequest */
         $parsedRequest = $middleware(
@@ -274,9 +274,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         }
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        $request = new ServerRequest('POST', 'http://example.com/', [
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary
+        ], $data, 1.1);
 
         /** @var ServerRequestInterface $parsedRequest */
         $parsedRequest = $middleware(
@@ -310,9 +310,9 @@ final class RequestBodyParserMiddlewareTest extends TestCase
         }
         $data .= "--$boundary--\r\n";
 
-        $request = new ServerRequest('POST', 'http://example.com/', array(
-            'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
-        ), $data, 1.1);
+        $request = new ServerRequest('POST', 'http://example.com/', [
+            'Content-Type' => 'multipart/form-data; boundary=' . $boundary
+        ], $data, 1.1);
 
         /** @var ServerRequestInterface $parsedRequest */
         $parsedRequest = $middleware(

--- a/tests/Middleware/RequestBodyParserMiddlewareTest.php
+++ b/tests/Middleware/RequestBodyParserMiddlewareTest.php
@@ -109,13 +109,6 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
     public function testFormUrlencodedIgnoresBodyWithExcessiveNesting()
     {
-        // supported in all Zend PHP versions and HHVM
-        // ini setting does exist everywhere but HHVM: https://3v4l.org/hXLiK
-        // HHVM limits to 64 and returns an empty array structure: https://3v4l.org/j3DK2
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Not supported on HHVM (limited to depth 64, but keeps empty array structure)');
-        }
-
         $allowed = (int)ini_get('max_input_nesting_level');
 
         $middleware = new RequestBodyParserMiddleware();
@@ -144,12 +137,6 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
     public function testFormUrlencodedTruncatesBodyWithExcessiveLength()
     {
-        // supported as of PHP 5.3.11, no HHVM support: https://3v4l.org/PiqnQ
-        // ini setting already exists in PHP 5.3.9: https://3v4l.org/VF6oV
-        if (defined('HHVM_VERSION') || PHP_VERSION_ID < 50311) {
-            $this->markTestSkipped('Not supported on HHVM and PHP < 5.3.11 (unlimited length)');
-        }
-
         $allowed = (int)ini_get('max_input_vars');
 
         $middleware = new RequestBodyParserMiddleware();
@@ -243,13 +230,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
     public function testMultipartFormDataIgnoresFieldWithExcessiveNesting()
     {
-        // supported in all Zend PHP versions and HHVM
-        // ini setting does exist everywhere but HHVM: https://3v4l.org/hXLiK
-        // HHVM limits to 64 and otherwise returns an empty array structure
-        $allowed = (int)ini_get('max_input_nesting_level');
-        if ($allowed === 0) {
-            $allowed = 64;
-        }
+        $allowed = (int) ini_get('max_input_nesting_level');
 
         $middleware = new RequestBodyParserMiddleware();
 
@@ -278,12 +259,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
     public function testMultipartFormDataTruncatesBodyWithExcessiveLength()
     {
-        // ini setting exists in PHP 5.3.9, not in HHVM: https://3v4l.org/VF6oV
-        // otherwise default to 1000 as implemented within
-        $allowed = (int)ini_get('max_input_vars');
-        if ($allowed === 0) {
-            $allowed = 1000;
-        }
+        $allowed = (int) ini_get('max_input_vars');
 
         $middleware = new RequestBodyParserMiddleware();
 
@@ -319,12 +295,7 @@ final class RequestBodyParserMiddlewareTest extends TestCase
 
     public function testMultipartFormDataTruncatesExcessiveNumberOfEmptyFileUploads()
     {
-        // ini setting exists in PHP 5.3.9, not in HHVM: https://3v4l.org/VF6oV
-        // otherwise default to 1000 as implemented within
-        $allowed = (int)ini_get('max_input_vars');
-        if ($allowed === 0) {
-            $allowed = 1000;
-        }
+        $allowed = (int) ini_get('max_input_vars');
 
         $middleware = new RequestBodyParserMiddleware();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -72,18 +72,12 @@ class TestCase extends BaseTestCase
 
     public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
     {
-        if (method_exists($this, 'expectException')) {
-            // PHPUnit 5+
-            $this->expectException($exception);
-            if ($exceptionMessage !== '') {
-                $this->expectExceptionMessage($exceptionMessage);
-            }
-            if ($exceptionCode !== null) {
-                $this->expectExceptionCode($exceptionCode);
-            }
-        } else {
-            // legacy PHPUnit 4
-            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        $this->expectException($exception);
+        if ($exceptionMessage !== '') {
+            $this->expectExceptionMessage($exceptionMessage);
+        }
+        if ($exceptionCode !== null) {
+            $this->expectExceptionCode($exceptionCode);
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Http;
 
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -39,46 +40,12 @@ class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+        if (method_exists(MockBuilder::class, 'addMethods')) {
             // PHPUnit 9+
-            return $this->getMockBuilder('stdClass')->addMethods(['__invoke'])->getMock();
+            return $this->getMockBuilder(\stdClass::class)->addMethods(['__invoke'])->getMock();
         } else {
-            // legacy PHPUnit 4 - PHPUnit 8
-            return $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
+            // legacy PHPUnit
+            return $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
         }
     }
-
-    public function assertContainsString($needle, $haystack)
-    {
-        if (method_exists($this, 'assertStringContainsString')) {
-            // PHPUnit 7.5+
-            $this->assertStringContainsString($needle, $haystack);
-        } else {
-            // legacy PHPUnit 4 - PHPUnit 7.5
-            $this->assertContains($needle, $haystack);
-        }
-    }
-
-    public function assertNotContainsString($needle, $haystack)
-    {
-        if (method_exists($this, 'assertStringNotContainsString')) {
-            // PHPUnit 7.5+
-            $this->assertStringNotContainsString($needle, $haystack);
-        } else {
-            // legacy PHPUnit 4 - PHPUnit 7.5
-            $this->assertNotContains($needle, $haystack);
-        }
-    }
-
-    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
-    {
-        $this->expectException($exception);
-        if ($exceptionMessage !== '') {
-            $this->expectExceptionMessage($exceptionMessage);
-        }
-        if ($exceptionCode !== null) {
-            $this->expectExceptionCode($exceptionCode);
-        }
-    }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    public function expectCallableOnce() // protected (PHP 5.4+)
+    protected function expectCallableOnce()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -16,7 +16,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    public function expectCallableOnceWith($value) // protected (PHP 5.4+)
+    protected function expectCallableOnceWith($value)
     {
         $mock = $this->createCallableMock();
         $mock
@@ -27,7 +27,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    public function expectCallableNever() // protected (PHP 5.4+)
+    protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();
         $mock
@@ -41,10 +41,10 @@ class TestCase extends BaseTestCase
     {
         if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
             // PHPUnit 9+
-            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+            return $this->getMockBuilder('stdClass')->addMethods(['__invoke'])->getMock();
         } else {
             // legacy PHPUnit 4 - PHPUnit 8
-            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+            return $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         }
     }
 

--- a/tests/benchmark-middleware-runner.php
+++ b/tests/benchmark-middleware-runner.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $middleware = function (ServerRequestInterface $request, $next) {
     return $next($request);
 };
-$middlewareList = array();
+$middlewareList = [];
 for ($i = 0; $i < MIDDLEWARE_COUNT; $i++) {
     $middlewareList[] = $middleware;
 }


### PR DESCRIPTION
This changeset updates the project to require PHP 7.1+ and drop legacy PHP < 7.1 and HHVM as discussed in #517. I'm marking this as a BC break for anybody still stuck on very old PHP versions, but there's little chance this will affect any current projects otherwise.

This PR aims to contain the minimal changeset to update the PHP version requirement only. Follow-up PRs will update our APIs to leverage newer language features.

Builds on top of #508 and others
Refs https://github.com/reactphp/cache/pull/58