### PR TITLE
Fix expected error code in tests when ext-sockets is not enabled

### DIFF
--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -373,7 +373,7 @@ class FunctionalBrowserTest extends TestCase
 
         $this->expectException(\OverflowException::class);
         $this->expectExceptionMessage('Response body size of 5 bytes exceeds maximum of 4 bytes');
-        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0);
+        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90);
         await($promise);
     }
 
@@ -383,7 +383,7 @@ class FunctionalBrowserTest extends TestCase
 
         $this->expectException(\OverflowException::class);
         $this->expectExceptionMessage('Response body size exceeds maximum of 4 bytes');
-        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 0);
+        $this->expectExceptionCode(defined('SOCKET_EMSGSIZE') ? SOCKET_EMSGSIZE : 90);
         await($promise);
     }
 


### PR DESCRIPTION
The expected error code when ext-sockets is not enabled (SOCKET_EMSGSIZE is not defined) is 90 per the two places that OverFlowException is created in class Transaction

https://github.com/reactphp/http/blob/212382c3559fa1a40fb1598b4cb92f3c97f7232e/src/Io/Transaction.php#L173-L176
https://github.com/reactphp/http/blob/212382c3559fa1a40fb1598b4cb92f3c97f7232e/src/Io/Transaction.php#L205-L208