### PR TITLE
Pass PHPStan Analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "phpunit/phpunit": "^9.6 || ^7.5",
         "react/async": "^4 || ^3",
         "react/promise-stream": "^1.4",
-        "react/promise-timer": "^1.9"
+        "react/promise-timer": "^1.9",
+        "phpstan/phpstan": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,9 @@
         "psr-4": {
             "React\\Tests\\Http\\": "tests/"
         }
+    },
+    "scripts": {
+        "phpstan": "vendor/bin/phpstan analyse src",
+        "phpstan tests": "vendor/bin/phpstan analyse tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "react/async": "^4 || ^3",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.9",
-        "phpstan/phpstan": "^1.11"
+        "phpstan/phpstan": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Io/AbstractMessageTest.php
+++ b/tests/Io/AbstractMessageTest.php
@@ -15,7 +15,7 @@ class MessageMock extends AbstractMessage
      */
     public function __construct($protocolVersion, array $headers, StreamInterface $body)
     {
-        return parent::__construct($protocolVersion, $headers, $body);
+        parent::__construct($protocolVersion, $headers, $body);
     }
 }
 


### PR DESCRIPTION
For the [Roadmap to v3.x](https://github.com/reactphp/http/issues/517), there was a request to fully type the API for the library. For this PR, I have installed PHPStan and added it to the composer.json (as well as some run scripts), and fixed all the issues that appeared.

As an aside, Interesting enough, PHPStan would fail if I run `src` and `tests` together at the same time. But one at a time the analysis runs fine.