### PR TITLE
[1.x] Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,18 +31,18 @@
         "fig/http-message-util": "^1.1",
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^3 || ^2.3 || ^1.2.1",
-        "react/socket": "^1.12",
-        "react/stream": "^1.2"
+        "react/promise": "^3.2 || ^2.3 || ^1.2.1",
+        "react/socket": "^1.16",
+        "react/stream": "^1.4"
     },
     "require-dev": {
         "clue/http-proxy-react": "^1.8",
         "clue/reactphp-ssh-proxy": "^1.4",
         "clue/socks-react": "^1.4",
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2",
+        "react/async": "^4.2 || ^3 || ^2",
         "react/promise-stream": "^1.4",
-        "react/promise-timer": "^1.9"
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -10,6 +10,7 @@ use React\Http\Io\Transaction;
 use React\Http\Message\Request;
 use React\Http\Message\Uri;
 use React\Promise\PromiseInterface;
+use React\Socket\Connector;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
 use InvalidArgumentException;
@@ -88,7 +89,7 @@ class Browser
 
         $loop = $loop ?: Loop::get();
         $this->transaction = new Transaction(
-            Sender::createFromLoop($loop, $connector),
+            Sender::createFromLoop($loop, $connector ?: new Connector(array(), $loop)),
             $loop
         );
     }

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -8,7 +8,6 @@ use React\EventLoop\LoopInterface;
 use React\Http\Client\Client as HttpClient;
 use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
-use React\Socket\Connector;
 use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
 
@@ -48,12 +47,8 @@ class Sender
      * @param ConnectorInterface|null $connector
      * @return self
      */
-    public static function createFromLoop(LoopInterface $loop, ConnectorInterface $connector = null)
+    public static function createFromLoop(LoopInterface $loop, ConnectorInterface $connector)
     {
-        if ($connector === null) {
-            $connector = new Connector(array(), $loop);
-        }
-
         return new self(new HttpClient(new ClientConnectionManager($connector, $loop)));
     }
 

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -28,7 +28,9 @@ class SenderTest extends TestCase
 
     public function testCreateFromLoop()
     {
-        $sender = Sender::createFromLoop($this->loop, null);
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $sender = Sender::createFromLoop($this->loop, $connector);
 
         $this->assertInstanceOf('React\Http\Io\Sender', $sender);
     }

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -32,7 +32,7 @@ class StreamingServerTest extends TestCase
     }
 
 
-    private function mockConnection(array $additionalMethods = null)
+    private function mockConnection(array $additionalMethods = array())
     {
         $connection = $this->getMockBuilder('React\Socket\Connection')
             ->disableOriginalConstructor()
@@ -49,7 +49,7 @@ class StreamingServerTest extends TestCase
                     'getLocalAddress',
                     'pipe'
                 ),
-                (is_array($additionalMethods) ? $additionalMethods : array())
+                $additionalMethods
             ))
             ->getMock();
 


### PR DESCRIPTION
This changeset backports #536 from `3.x` to `1.x` to improve PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #536, #508, #410, reactphp/promise#260, https://github.com/reactphp/socket/pull/317, https://github.com/reactphp/stream/pull/179, reactphp/async#87 and reactphp/promise-timer#70