### PR TITLE
[3.x] Allow underscore character in Uri host

### DIFF
--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -46,7 +46,7 @@ final class Uri implements UriInterface
     public function __construct($uri)
     {
         $parts = \parse_url($uri);
-        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s_%+]#', $parts['host']))) {
+        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s%+]#', $parts['host']))) {
             throw new \InvalidArgumentException('Invalid URI given');
         }
 
@@ -164,7 +164,7 @@ final class Uri implements UriInterface
             return $this;
         }
 
-        if (\preg_match('#[\s_%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
+        if (\preg_match('#[\s%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
             throw new \InvalidArgumentException('Invalid URI host given');
         }
 

--- a/tests/Message/UriTest.php
+++ b/tests/Message/UriTest.php
@@ -120,6 +120,9 @@ class UriTest extends TestCase
         yield [
             'http://user%20name:pass%20word@localhost/path%20name?query%20name#frag%20ment'
         ];
+        yield [
+            'http://docker_container/'
+        ];
     }
 
     /**
@@ -326,6 +329,16 @@ class UriTest extends TestCase
         $new = $uri->withHost('example.com');
         $this->assertNotSame($uri, $new);
         $this->assertEquals('example.com', $new->getHost());
+        $this->assertEquals('localhost', $uri->getHost());
+    }
+
+    public function testWithHostReturnsNewInstanceWhenHostIsChangedWithUnderscore()
+    {
+        $uri = new Uri('http://localhost');
+
+        $new = $uri->withHost('docker_container');
+        $this->assertNotSame($uri, $new);
+        $this->assertEquals('docker_container', $new->getHost());
         $this->assertEquals('localhost', $uri->getHost());
     }
 


### PR DESCRIPTION
This changeset ports #524 from `1.x` to `3.x` to make sure both branches are in line, thanks to @lulhum for the original suggestion.

Builds on top of #524 and #521 with necessary changes from #530.