### PR TITLE
Run tests on PHP 8.4 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -24,7 +25,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
Builds on top of #536 and https://github.com/clue/framework-x/pull/267.

In order to avoid segfault with Xdebug 3.4.2 on PHP 8.1+ (https://bugs.xdebug.org/view.php?id=2332), i also updated the test suite to use PCOV instead of Xdebug on PHP 8+ as discussed in https://github.com/reactphp/socket/pull/323.