### PR TITLE
Allow usage of environment variables in PHP ini settings that contain byte size values

### DIFF
--- a/src/Io/IniUtil.php
+++ b/src/Io/IniUtil.php
@@ -19,6 +19,14 @@ final class IniUtil
             return (int)$size;
         }
 
+        // ini size values might be specified via environment variables, e.g.: memory_limit=${PHP_MEMORY_LIMIT}
+        $matches = [];
+        $envVarUsed = preg_match('#^\$(?|(\w+)|\{(\w+)})$#', $size, $matches);
+        $envVarName = $matches[1] ?? false;
+        if ($envVarUsed && $envVarName && array_key_exists($envVarName, $_ENV)) {
+            $size = (string)$_ENV[$envVarName];
+        }
+
         $suffix = \strtoupper(\substr($size, -1));
         $strippedSize = \substr($size, 0, -1);
 

--- a/tests/Io/IniUtilTest.php
+++ b/tests/Io/IniUtilTest.php
@@ -74,4 +74,48 @@ class IniUtilTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         IniUtil::iniSizeToBytes($input);
     }
+
+    public function testIniSizeViaEnvVariableWorks()
+    {
+        self::assertArrayNotHasKey('INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE', $_ENV);
+        $_ENV['INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE'] = '23M';
+        $this->assertSame(23 * 1024 * 1024, IniUtil::iniSizeToBytes('${INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE}'));
+    }
+
+    public function testIniSizeViaSimpleEnvVariableWorks()
+    {
+        self::assertArrayNotHasKey('INIUTIL_SIMPLE_ENV_VAR_WITH_PHP_SIZE_VALUE', $_ENV);
+        $_ENV['INIUTIL_SIMPLE_ENV_VAR_WITH_PHP_SIZE_VALUE'] = '42M';
+        $this->assertSame(42 * 1024 * 1024, IniUtil::iniSizeToBytes('$INIUTIL_SIMPLE_ENV_VAR_WITH_PHP_SIZE_VALUE'));
+    }
+
+    public function testIniSizeViaEnvVariableFailsForNonSizeValue()
+    {
+        self::assertArrayNotHasKey('INIUTIL_ENV_VAR_WITHOUT_PHP_SIZE_VALUE', $_ENV);
+        $_ENV['INIUTIL_ENV_VAR_WITHOUT_PHP_SIZE_VALUE'] = 'no-size';
+        $this->expectException(\InvalidArgumentException::class);
+        IniUtil::iniSizeToBytes('${INIUTIL_ENV_VAR_WITHOUT_PHP_SIZE_VALUE}');
+    }
+
+    public function testIniSizeViaEnvVariableIgnoresInvalidSizeModifier()
+    {
+        self::assertArrayNotHasKey('INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE_AND_INVALID_MODIFIER', $_ENV);
+        $_ENV['INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE_AND_INVALID_MODIFIER'] = '1337V';
+        $this->assertSame(1337, IniUtil::iniSizeToBytes('${INIUTIL_ENV_VAR_WITH_PHP_SIZE_VALUE_AND_INVALID_MODIFIER}'));
+    }
+
+    public function testIniSizeViaEnvVariableFailsForNonNumericValue()
+    {
+        self::assertArrayNotHasKey('INIUTIL_ENV_VAR_WITH_NON_NUMERIC_PHP_SIZE_VALUE', $_ENV);
+        $_ENV['INIUTIL_ENV_VAR_WITH_NON_NUMERIC_PHP_SIZE_VALUE'] = 'V1337V';
+        $this->expectException(\InvalidArgumentException::class);
+        IniUtil::iniSizeToBytes('${INIUTIL_ENV_VAR_WITH_NON_NUMERIC_PHP_SIZE_VALUE}');
+    }
+
+    public function testIniSizeViaMissingEnvVariableFails()
+    {
+        self::assertArrayNotHasKey('INIUTIL_ENV_VAR_MISSING_WITH_NON_NUMERIC_PHP_SIZE_VALUE', $_ENV);
+        $this->expectException(\InvalidArgumentException::class);
+        IniUtil::iniSizeToBytes('${INIUTIL_ENV_VAR_MISSING_WITH_NON_NUMERIC_PHP_SIZE_VALUE}');
+    }
 }


### PR DESCRIPTION
I ran into a problem where the `IniUtil::iniSizeToBytes` function threw errors due to the usage of environment variables inside PHP ini settings to configure size values.

Example:

```ini
memory_limit=${PHP_MEMORY_LIMIT}
post_max_size=$PHP_POST_MAX_SIZE
```

This might be used e.g. in docker setups where the container gets `post_max_size`, `memory_limit` etc values via environment variables instead of providing different ini files per environments via mounts.

I suggest the changes within this pull request. I didn't add a changelog entry, as I don't know your rules for this. The used regular expression should work w/ PCRE and PCRE2 if I'm not mistaken. I didn't verify performance aspects, but usage of the function seems to be in constructors only. PS: That last string cast is not phpstan level 10 compatible. :dagger: 
