### PR TITLE
Allow use of PSR-7 v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=7.1",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "fig/http-message-util": "^1.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "react/event-loop": "^1.2",
         "react/promise": "^3.2 || ^2.3 || ^1.2.1",
         "react/socket": "^1.16",


### PR DESCRIPTION
PSR-7 v2 just adds types, which should be safe in virtually any circumstances.  It does require PHP 7.2 or higher, but allowing either version should allow Composer to figure it out.

Without this, having React installed makes a project incompatible with any package that depends on PSR-7 v2, which is a non-small number.

(I haven't tried running this locally yet; I am assuming CI will indicate if there's an issue.)