### PR TITLE
[3.x] Improve PHP8.5+ support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -25,7 +25,9 @@ class BrowserTest extends TestCase
         $this->browser = new Browser(null, $this->loop);
 
         $ref = new \ReflectionProperty($this->browser, 'transaction');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->browser, $this->sender);
     }
 
@@ -34,11 +36,15 @@ class BrowserTest extends TestCase
         $browser = new Browser();
 
         $ref = new \ReflectionProperty($browser, 'transaction');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $transaction = $ref->getValue($browser);
 
         $ref = new \ReflectionProperty($transaction, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($transaction);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -51,23 +57,33 @@ class BrowserTest extends TestCase
         $browser = new Browser($connector);
 
         $ref = new \ReflectionProperty($browser, 'transaction');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $transaction = $ref->getValue($browser);
 
         $ref = new \ReflectionProperty($transaction, 'sender');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $sender = $ref->getValue($transaction);
 
         $ref = new \ReflectionProperty($sender, 'http');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $client = $ref->getValue($sender);
 
         $ref = new \ReflectionProperty($client, 'connectionManager');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connectionManager = $ref->getValue($client);
 
         $ref = new \ReflectionProperty($connectionManager, 'connector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ret = $ref->getValue($connectionManager);
 
         $this->assertSame($connector, $ret);
@@ -78,11 +94,15 @@ class BrowserTest extends TestCase
         $browser = new Browser(null, $this->loop);
 
         $ref = new \ReflectionProperty($browser, 'transaction');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $transaction = $ref->getValue($browser);
 
         $ref = new \ReflectionProperty($transaction, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($transaction);
 
         $this->assertSame($this->loop, $loop);

--- a/tests/HttpServerTest.php
+++ b/tests/HttpServerTest.php
@@ -58,15 +58,21 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(function () { });
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $streamingServer = $ref->getValue($http);
 
         $ref = new \ReflectionProperty($streamingServer, 'clock');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $clock = $ref->getValue($streamingServer);
 
         $ref = new \ReflectionProperty($clock, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($clock);
 
         $this->assertInstanceOf(LoopInterface::class, $loop);
@@ -331,7 +337,9 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getConcurrentRequestsLimit');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $value = $ref->invoke($http, $memory_limit, $post_max_size);
 
@@ -343,7 +351,9 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $value = $ref->invoke($http, '1k');
 
@@ -355,7 +365,9 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $value = $ref->invoke($http, '1M');
 
@@ -371,7 +383,9 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(function () { });
 
         $ref = new \ReflectionMethod($http, 'getMaxRequestSize');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $value = $ref->invoke($http);
 
@@ -388,17 +402,23 @@ final class HttpServerTest extends TestCase
         ini_set('memory_limit', $old);
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $streamingServer = $ref->getValue($http);
 
         $ref = new \ReflectionProperty($streamingServer, 'callback');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middlewareRunner = $ref->getValue($streamingServer);
 
         $ref = new \ReflectionProperty($middlewareRunner, 'middleware');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middleware = $ref->getValue($middlewareRunner);
 
@@ -418,17 +438,23 @@ final class HttpServerTest extends TestCase
         ini_set('memory_limit', $old);
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $streamingServer = $ref->getValue($http);
 
         $ref = new \ReflectionProperty($streamingServer, 'callback');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middlewareRunner = $ref->getValue($streamingServer);
 
         $ref = new \ReflectionProperty($middlewareRunner, 'middleware');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middleware = $ref->getValue($middlewareRunner);
 
@@ -441,17 +467,23 @@ final class HttpServerTest extends TestCase
         $http = new HttpServer(new StreamingRequestMiddleware(), function () { });
 
         $ref = new \ReflectionProperty($http, 'streamingServer');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $streamingServer = $ref->getValue($http);
 
         $ref = new \ReflectionProperty($streamingServer, 'callback');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middlewareRunner = $ref->getValue($streamingServer);
 
         $ref = new \ReflectionProperty($middlewareRunner, 'middleware');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $middleware = $ref->getValue($middlewareRunner);
 

--- a/tests/Io/ClockTest.php
+++ b/tests/Io/ClockTest.php
@@ -33,7 +33,9 @@ class ClockTest extends TestCase
         $now = $clock->now();
 
         $ref = new \ReflectionProperty($clock, 'now');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $this->assertEquals($now, $ref->getValue($clock));
 
         $this->assertNotNull($tick);

--- a/tests/Io/MultipartParserTest.php
+++ b/tests/Io/MultipartParserTest.php
@@ -1049,15 +1049,25 @@ final class MultipartParserTest extends TestCase
 
         $reflectecClass = new \ReflectionClass(MultipartParser::class);
         $requestProperty = $reflectecClass->getProperty('request');
-        $requestProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $requestProperty->setAccessible(true);
+        }
         $cursorProperty = $reflectecClass->getProperty('cursor');
-        $cursorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $cursorProperty->setAccessible(true);
+        }
         $multipartBodyPartCountProperty = $reflectecClass->getProperty('multipartBodyPartCount');
-        $multipartBodyPartCountProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $multipartBodyPartCountProperty->setAccessible(true);
+        }
         $maxMultipartBodyPartsProperty = $reflectecClass->getProperty('maxMultipartBodyParts');
-        $maxMultipartBodyPartsProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $maxMultipartBodyPartsProperty->setAccessible(true);
+        }
         $parseBodyMethod = $reflectecClass->getMethod('parseBody');
-        $parseBodyMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $parseBodyMethod->setAccessible(true);
+        }
 
         $this->assertSame(0, $cursorProperty->getValue($parser));
 

--- a/tests/Io/RequestHeaderParserTest.php
+++ b/tests/Io/RequestHeaderParserTest.php
@@ -851,7 +851,9 @@ class RequestHeaderParserTest extends TestCase
         $connection->emit('data', ["GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"]);
 
         $ref = new \ReflectionProperty($parser, 'connectionParams');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->assertCount(1, $ref->getValue($parser));
 

--- a/tests/Io/StreamingServerTest.php
+++ b/tests/Io/StreamingServerTest.php
@@ -2251,11 +2251,15 @@ class StreamingServerTest extends TestCase
         });
 
         $ref = new \ReflectionProperty($server, 'clock');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $clock = $ref->getValue($server);
 
         $ref = new \ReflectionProperty($clock, 'now');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($clock, 1652972091.3958);
 
         $buffer = '';
@@ -3052,7 +3056,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3069,7 +3075,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3092,7 +3100,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3117,7 +3127,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3142,7 +3154,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3167,7 +3181,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3193,7 +3209,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->once())->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);
@@ -3219,7 +3237,9 @@ class StreamingServerTest extends TestCase
         $parser->expects($this->exactly(2))->method('handle');
 
         $ref = new \ReflectionProperty($server, 'parser');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($server, $parser);
 
         $server->listen($this->socket);

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -38,7 +38,9 @@ class TransactionTest extends TestCase
         $this->assertNotSame($transaction, $new);
 
         $ref = new \ReflectionProperty($new, 'followRedirects');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->assertFalse($ref->getValue($new));
     }
@@ -52,7 +54,9 @@ class TransactionTest extends TestCase
         $transaction->withOptions(['followRedirects' => false]);
 
         $ref = new \ReflectionProperty($transaction, 'followRedirects');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->assertTrue($ref->getValue($transaction));
     }
@@ -67,7 +71,9 @@ class TransactionTest extends TestCase
         $transaction = $transaction->withOptions(['followRedirects' => null]);
 
         $ref = new \ReflectionProperty($transaction, 'followRedirects');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
 
         $this->assertTrue($ref->getValue($transaction));
     }


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by porting #547 from `1.x` to `3.x`.

Builds on #536, #543, and many others.