### PR TITLE
[1.x] Update test environment for PHP 7.2 to compatible PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "clue/http-proxy-react": "^1.8",
         "clue/reactphp-ssh-proxy": "^1.4",
         "clue/socks-react": "^1.4",
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
         "react/async": "^4.2 || ^3 || ^2",
         "react/promise-stream": "^1.4",
         "react/promise-timer": "^1.11"


### PR DESCRIPTION
This changes ensures we can continue run PHPUnit on PHP 7.2 by updating PHPUnit to 8.5. This is due to recent improvements in composer as discussed in https://github.com/reactphp/event-loop/pull/284.